### PR TITLE
Use RegEx to match ADD command from Dockerfile.

### DIFF
--- a/src/main/java/com/github/dockerjava/client/command/BuildImgCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/BuildImgCmd.java
@@ -126,7 +126,7 @@ public class BuildImgCmd extends AbstrDockerCmd<BuildImgCmd, ClientResponse>  {
 			filesToAdd.add(dockerFile);
 
 			for (String cmd : dockerFileContent) {
-				final Matcher matcher = ADD_PATTERN.matcher(cmd);
+				final Matcher matcher = ADD_PATTERN.matcher(cmd.trim());
 				if (matcher.find()) {
 					if (matcher.groupCount() != 2) {
 						throw new DockerException(String.format("Wrong format on line [%s]", cmd));


### PR DESCRIPTION
Dockerfile spec does not specify the whitespace format between the `ADD` command and the parameters.  The existing implementation assumes a space followed by a tab.  This change uses the whitespace character class to handle any whitespace (space, tab, etc) between the command and the parameters.
