### PR TITLE
Makes Config a public, immutable class with a builder

### DIFF
--- a/src/main/java/com/github/dockerjava/client/Config.java
+++ b/src/main/java/com/github/dockerjava/client/Config.java
@@ -6,31 +6,75 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Properties;
 
-class Config {
-    URI url;
-    String version, username, password, email;
-    Integer readTimeout;
-    boolean enableLoggingFilter;
+public class Config {
+    private final URI uri;
+    private final String version, username, password, email;
+    private final Integer readTimeout;
+    private final boolean loggingFilterEnabled;
 
-    private Config() {
+    private Config(DockerClientConfigBuilder builder) {
+        this.uri = builder.uri;
+        this.version = builder.version;
+        this.username = builder.username;
+        this.password = builder.password;
+        this.email = builder.email;
+        this.readTimeout = builder.readTimeout;
+        this.loggingFilterEnabled = builder.loggingFilterEnabled;
     }
 
-    static Config createConfig() throws DockerException {
-        final Properties p = new Properties();
+    public URI getUri() {
+        return uri;
+    }
 
+    public String getVersion() {
+        return version;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public Integer getReadTimeout() {
+        return readTimeout;
+    }
+
+    public boolean isLoggingFilterEnabled() {
+        return loggingFilterEnabled;
+    }
+
+    public static Properties loadIncludedDockerProperties() {
         try {
+            Properties p = new Properties();
             p.load(Config.class.getResourceAsStream("/docker.io.properties"));
+            return p;
         } catch (IOException e) {
             throw new DockerException(e);
         }
+    }
 
-        final File file = new File(System.getProperty("user.home"), ".docker.io.properties");
+    /**
+     * Creates a new Properties object containing values overridden from ${user.home}/.docker.io.properties
+     * @param p The original set of properties to override
+     * @return A copy of the original Properties with overridden values
+     */
+    public static Properties overrideDockerPropertiesWithSettingsFromUserHome(Properties p) {
+        Properties overriddenProperties = new Properties();
+        overriddenProperties.putAll(p);
 
-	    if (file.isFile()) {
+        final File usersDockerPropertiesFile = new File(System.getProperty("user.home"), ".docker.io.properties");
+        if (usersDockerPropertiesFile.isFile()) {
             try {
-                final FileInputStream in = new FileInputStream(file);
+                final FileInputStream in = new FileInputStream(usersDockerPropertiesFile);
                 try {
-                    p.load(in);
+                    overriddenProperties.load(in);
                 } finally {
                     in.close();
                 }
@@ -38,24 +82,93 @@ class Config {
                 throw new DockerException(e);
             }
         }
+        return overriddenProperties;
+    }
 
-	    for (String s : new String[]{"url", "version", "username", "password", "email"}) {
+    /**
+     * Creates a new Properties object containing values overridden from the System properties
+     * @param p The original set of properties to override
+     * @return A copy of the original Properties with overridden values
+     */
+    public static Properties overrideDockerPropertiesWithSystemProperties(Properties p) {
+        Properties overriddenProperties = new Properties();
+        overriddenProperties.putAll(p);
+
+        // TODO Add all values from system properties that begin with docker.io.*
+        for (String s : new String[]{"url", "version", "username", "password", "email"}) {
 		    final String key = "docker.io." + s;
-		    if (System.getProperties().keySet().contains(key)) {
-			    p.setProperty(key, System.getProperty(key));
+		    if (System.getProperties().containsKey(key)) {
+			    overriddenProperties.setProperty(key, System.getProperty(key));
 		    }
 	    }
+        return overriddenProperties;
+    }
 
-        final Config c = new Config();
+    public static DockerClientConfigBuilder createDefaultConfigBuilder() {
+        Properties properties = loadIncludedDockerProperties();
+        properties = overrideDockerPropertiesWithSettingsFromUserHome(properties);
+        properties = overrideDockerPropertiesWithSystemProperties(properties);
+        return new DockerClientConfigBuilder().withProperties(properties);
+    }
 
-        c.url = URI.create(p.getProperty("docker.io.url"));
-        c.version = p.getProperty("docker.io.version");
-        c.username = p.getProperty("docker.io.username");
-        c.password = p.getProperty("docker.io.password");
-        c.email = p.getProperty("docker.io.email");
-        c.readTimeout = Integer.valueOf(p.getProperty("docker.io.readTimeout", "1000"));
-        c.enableLoggingFilter = Boolean.valueOf(p.getProperty("docker.io.enableLoggingFilter", "true"));
+    public static class DockerClientConfigBuilder {
+        private URI uri;
+        private String version, username, password, email;
+        private Integer readTimeout;
+        private boolean loggingFilterEnabled;
 
-        return c;
+        public DockerClientConfigBuilder() {
+        }
+
+        /**
+         * This will set all fields in the builder to those contained in the Properties object. The Properties object
+         * should contain the following docker.io.* keys: url, version, username, password, and email. If
+         * docker.io.readTimeout or docker.io.enableLoggingFilter are not contained, they will be set to 1000 and true,
+         * respectively.
+         *
+         * @param p
+         * @return
+         */
+        public DockerClientConfigBuilder withProperties(Properties p) {
+            return withUri(p.getProperty("docker.io.url"))
+                    .withVersion(p.getProperty("docker.io.version"))
+                    .withUsername(p.getProperty("docker.io.username"))
+                    .withPassword(p.getProperty("docker.io.password"))
+                    .withEmail(p.getProperty("docker.io.email"))
+                    .withReadTimeout(Integer.valueOf(p.getProperty("docker.io.readTimeout", "1000")))
+                    .withLoggingFilter(Boolean.valueOf(p.getProperty("docker.io.enableLoggingFilter", "true")));
+        }
+
+        public final DockerClientConfigBuilder withUri(String uri) {
+            this.uri = URI.create(uri);
+            return this;
+        }
+        public final DockerClientConfigBuilder withVersion(String version) {
+            this.version = version;
+            return this;
+        }
+        public final DockerClientConfigBuilder withUsername(String username) {
+            this.username = username;
+            return this;
+        }
+        public final DockerClientConfigBuilder withPassword(String password) {
+            this.password = password;
+            return this;
+        }
+        public final DockerClientConfigBuilder withEmail(String email) {
+            this.email = email;
+            return this;
+        }
+        public final DockerClientConfigBuilder withReadTimeout(int readTimeout) {
+            this.readTimeout = readTimeout;
+            return this;
+        }
+        public final DockerClientConfigBuilder withLoggingFilter(boolean loggingFilterEnabled) {
+            this.loggingFilterEnabled = loggingFilterEnabled;
+            return this;
+        }
+        public Config build() {
+            return new Config(this);
+        }
     }
 }


### PR DESCRIPTION
This makes Config a public class, so it can be passed into the
DockerClient constructor from code in different packages. It also
makes Config an immutable object and includes a builder for convenience.

Fixes issue #24.
