### PR TITLE
Change VolumesFrom to handle array

### DIFF
--- a/src/main/java/com/github/dockerjava/client/command/CreateContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/CreateContainerCmd.java
@@ -63,17 +63,23 @@ public class CreateContainerCmd extends AbstrDockerCmd<CreateContainerCmd, Conta
 		return this;
 	}
 
-        public CreateContainerCmd withEnv(String... env) {
-                Preconditions.checkNotNull(env, "env was not specified");
-                this.containerCreateConfig.withEnv(env);
-                return this;
-        }
+	public CreateContainerCmd withVolumesFrom(String... volumesFrom) {
+		Preconditions.checkNotNull(volumesFrom, "volumes was not specified");
+		this.containerCreateConfig.withVolumesFrom(volumesFrom);
+		return this;
+	}
+	
+    public CreateContainerCmd withEnv(String... env) {
+            Preconditions.checkNotNull(env, "env was not specified");
+            this.containerCreateConfig.withEnv(env);
+            return this;
+    }
 
-        public CreateContainerCmd withHostName(String hostName) {
-                Preconditions.checkNotNull(hostName, "hostName was not specified");
-                this.containerCreateConfig.withHostName(hostName);
-                return this;
-        }
+    public CreateContainerCmd withHostName(String hostName) {
+            Preconditions.checkNotNull(hostName, "hostName was not specified");
+            this.containerCreateConfig.withHostName(hostName);
+            return this;
+    }
 
 	public CreateContainerCmd withName(String name) {
 		Preconditions.checkNotNull(name, "name was not specified");

--- a/src/main/java/com/github/dockerjava/client/model/ContainerInspectResponse.java
+++ b/src/main/java/com/github/dockerjava/client/model/ContainerInspectResponse.java
@@ -268,7 +268,7 @@ public class ContainerInspectResponse {
         private String dns;
         
         @JsonProperty("VolumesFrom")
-        private String volumesFrom;
+        private String[] volumesFrom;
 
         @JsonProperty("ContainerIDFile")
         private String containerIDFile;
@@ -307,7 +307,7 @@ public class ContainerInspectResponse {
 			return dns;
 		}
 
-		public String getVolumesFrom() {
+		public String[] getVolumesFrom() {
 			return volumesFrom;
 		}
 

--- a/src/main/java/com/github/dockerjava/client/model/CreateContainerConfig.java
+++ b/src/main/java/com/github/dockerjava/client/model/CreateContainerConfig.java
@@ -58,7 +58,7 @@ public class CreateContainerConfig {
     @JsonProperty("Dns")          private String[]  dns;
     @JsonProperty("Image")        private String    image;
     @JsonProperty("Volumes")      private Volumes   volumes = new Volumes();
-    @JsonProperty("VolumesFrom")  private String    volumesFrom = "";
+    @JsonProperty("VolumesFrom")  private String[]    volumesFrom = new String[]{};
     @JsonProperty("WorkingDir")   private String workingDir = "";
     @JsonProperty("DisableNetwork") private boolean disableNetwork = false;
     @JsonProperty("ExposedPorts")   private ExposedPorts exposedPorts = new ExposedPorts();
@@ -237,11 +237,11 @@ public class CreateContainerConfig {
         return this;
     }
 
-    public String getVolumesFrom() {
+    public String[] getVolumesFrom() {
         return volumesFrom;
     }
 
-    public CreateContainerConfig withVolumesFrom(String volumesFrom) {
+    public CreateContainerConfig withVolumesFrom(String[] volumesFrom) {
         this.volumesFrom = volumesFrom;
         return this;
     }


### PR DESCRIPTION
Calling Inspect command on containers created by openshift/geard failed because HostConfig-> VolumesFrom is an array.
`"VolumesFrom": [
            "rockmongo-1-data"
        ]
`
