### PR TITLE
Port to Jersey/JAX-RS 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,13 +50,14 @@
 
 		<version.slf4j>1.6.1</version.slf4j>
 
-		<jersey.version>1.18</jersey.version>
+		<jersey.version>2.11</jersey.version>
 		<jersey-apache-client4.version>1.9</jersey-apache-client4.version>
 
 		<jackson-jaxrs.version>2.3.3</jackson-jaxrs.version>
 
 		<httpclient.version>4.2.5</httpclient.version>
 		<commons-compress.version>1.5</commons-compress.version>
+        <commons-codec.version>1.8</commons-codec.version>
 		<commons-io.version>2.3</commons-io.version>
 		<commons-lang.version>2.6</commons-lang.version>
 		<slf4j-api.version>1.7.5</slf4j-api.version>
@@ -87,31 +88,9 @@
 			<version>${jackson-jaxrs.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.sun.jersey</groupId>
-			<artifactId>jersey-core</artifactId>
+			<groupId>org.glassfish.jersey.connectors</groupId>
+			<artifactId>jersey-jetty-connector</artifactId>
 			<version>${jersey.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.jersey</groupId>
-			<artifactId>jersey-client</artifactId>
-			<version>${jersey.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.sun.jersey.contribs</groupId>
-			<artifactId>jersey-multipart</artifactId>
-			<version>${jersey.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.jersey.contribs</groupId>
-			<artifactId>jersey-apache-client4</artifactId>
-			<version>${jersey-apache-client4.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>${httpclient.version}</version>
 		</dependency>
 
 		<dependency>
@@ -119,6 +98,11 @@
 			<artifactId>commons-compress</artifactId>
 			<version>${commons-compress.version}</version>
 		</dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
+        </dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>

--- a/src/main/java/com/github/dockerjava/client/command/AbstrAuthCfgDockerCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/AbstrAuthCfgDockerCmd.java
@@ -2,12 +2,11 @@ package com.github.dockerjava.client.command;
 
 import java.io.IOException;
 
-import org.apache.commons.codec.binary.Base64;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.client.DockerException;
 import com.github.dockerjava.client.model.AuthConfig;
 import com.google.common.base.Preconditions;
+import org.apache.commons.codec.binary.Base64;
 
 public abstract class AbstrAuthCfgDockerCmd<T extends AbstrDockerCmd<T, RES_T>, RES_T> extends
 		AbstrDockerCmd<T, RES_T> {

--- a/src/main/java/com/github/dockerjava/client/command/AbstrDockerCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/AbstrDockerCmd.java
@@ -4,16 +4,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.WebResource;
+
+import javax.ws.rs.client.WebTarget;
 
 public abstract class AbstrDockerCmd<T extends AbstrDockerCmd<T, RES_T>, RES_T> implements DockerCmd<RES_T> {
     
     private final static Logger LOGGER = LoggerFactory.getLogger(AbstrDockerCmd.class);
 
-	protected WebResource baseResource;
+	protected WebTarget baseResource;
 
 	@SuppressWarnings("unchecked")
-	public T withBaseResource(WebResource baseResource) {
+	public T withBaseResource(WebTarget baseResource) {
 		this.baseResource = baseResource;
 		return (T)this;
 	}

--- a/src/main/java/com/github/dockerjava/client/command/AuthCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/AuthCmd.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.client.command;
 
+import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
@@ -7,8 +8,9 @@ import org.slf4j.LoggerFactory;
 
 import com.github.dockerjava.client.DockerException;
 import com.github.dockerjava.client.model.AuthConfig;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
+import javax.ws.rs.client.WebTarget;
+
+import static javax.ws.rs.client.Entity.entity;
 
 /**
  * 
@@ -25,12 +27,11 @@ public class AuthCmd extends AbstrAuthCfgDockerCmd<AuthCmd, Void> {
 	
 	protected Void impl() throws DockerException {
 		try {
-			WebResource webResource = baseResource.path("/auth");
+			WebTarget webResource = baseResource.path("/auth");
 			LOGGER.trace("POST: {}", webResource);
-			webResource.header("Content-Type", MediaType.APPLICATION_JSON)
-					.accept(MediaType.APPLICATION_JSON).post(authConfig);
+			webResource.request().accept(MediaType.APPLICATION_JSON).post(entity(authConfig, MediaType.APPLICATION_JSON));
 			return null;
-		} catch (UniformInterfaceException e) {
+		} catch (ClientErrorException e) {
 			throw new DockerException(e);
 		}
 	}

--- a/src/main/java/com/github/dockerjava/client/command/ContainerDiffCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/ContainerDiffCmd.java
@@ -2,6 +2,9 @@ package com.github.dockerjava.client.command;
 
 import java.util.List;
 
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
@@ -11,9 +14,6 @@ import com.github.dockerjava.client.DockerException;
 import com.github.dockerjava.client.NotFoundException;
 import com.github.dockerjava.client.model.ChangeLog;
 import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.GenericType;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
 
 /**
  * Inspect changes on a container's filesystem
@@ -49,13 +49,13 @@ public class ContainerDiffCmd extends AbstrDockerCmd<ContainerDiffCmd, List<Chan
     }
 
     protected List<ChangeLog> impl() throws DockerException {
-		WebResource webResource = baseResource.path(String.format("/containers/%s/changes", containerId));
+		WebTarget webResource = baseResource.path("/containers/{id}/changes").resolveTemplate("id", containerId);
 
 		try {
 			LOGGER.trace("GET: {}", webResource);
-			return webResource.accept(MediaType.APPLICATION_JSON).get(new GenericType<List<ChangeLog>>() {
-			});
-		} catch (UniformInterfaceException exception) {
+			return webResource.request().accept(MediaType.APPLICATION_JSON).get(new GenericType<List<ChangeLog>>() {
+            });
+		} catch (ClientErrorException exception) {
 			if (exception.getResponse().getStatus() == 404) {
 				throw new NotFoundException(String.format("No such container %s", containerId));
 			} else if (exception.getResponse().getStatus() == 500) {

--- a/src/main/java/com/github/dockerjava/client/command/InfoCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/InfoCmd.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.client.command;
 
+import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
@@ -7,8 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import com.github.dockerjava.client.DockerException;
 import com.github.dockerjava.client.model.Info;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
+import javax.ws.rs.client.WebTarget;
 
 
 /**
@@ -24,12 +24,12 @@ public class InfoCmd extends AbstrDockerCmd<InfoCmd, Info>  {
     }
 
 	protected Info impl() throws DockerException {
-		WebResource webResource = baseResource.path("/info");
+		WebTarget webResource = baseResource.path("/info");
 
 		try {
 			LOGGER.trace("GET: {}", webResource);
-			return webResource.accept(MediaType.APPLICATION_JSON).get(Info.class);
-		} catch (UniformInterfaceException exception) {
+			return webResource.request().accept(MediaType.APPLICATION_JSON).get(Info.class);
+		} catch (ClientErrorException exception) {
 			if (exception.getResponse().getStatus() == 500) {
 				throw new DockerException("Server error.", exception);
 			} else {

--- a/src/main/java/com/github/dockerjava/client/command/InspectContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/InspectContainerCmd.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.client.command;
 
+import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
@@ -8,8 +9,7 @@ import org.slf4j.LoggerFactory;
 import com.github.dockerjava.client.DockerException;
 import com.github.dockerjava.client.NotFoundException;
 import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
+import javax.ws.rs.client.WebTarget;
 
 /**
  * Inspect the details of a container.
@@ -40,12 +40,12 @@ public class InspectContainerCmd extends AbstrDockerCmd<InspectContainerCmd, Ins
     }
 
 	protected InspectContainerResponse impl() throws DockerException {
-		WebResource webResource = baseResource.path(String.format("/containers/%s/json", containerId));
+		WebTarget webResource = baseResource.path("/containers/{id}/json").resolveTemplate("id", containerId);
 
 		try {
 			LOGGER.trace("GET: {}", webResource);
-			return webResource.accept(MediaType.APPLICATION_JSON).get(InspectContainerResponse.class);
-		} catch (UniformInterfaceException exception) {
+			return webResource.request().accept(MediaType.APPLICATION_JSON).get(InspectContainerResponse.class);
+		} catch (ClientErrorException exception) {
 			if (exception.getResponse().getStatus() == 404) {
 				throw new NotFoundException(String.format("No such container %s", containerId));
 			} else if (exception.getResponse().getStatus() == 500) {

--- a/src/main/java/com/github/dockerjava/client/command/InspectImageCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/InspectImageCmd.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.client.command;
 
+import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
@@ -8,8 +9,7 @@ import org.slf4j.LoggerFactory;
 import com.github.dockerjava.client.DockerException;
 import com.github.dockerjava.client.NotFoundException;
 import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
+import javax.ws.rs.client.WebTarget;
 
 
 /**
@@ -41,12 +41,12 @@ public class InspectImageCmd extends AbstrDockerCmd<InspectImageCmd, InspectImag
     }
 
 	protected InspectImageResponse impl() {
-		WebResource webResource = baseResource.path(String.format("/images/%s/json", imageId));
+		WebTarget webResource = baseResource.path("/images/{id}/json").resolveTemplate("id", imageId);
 
 		try {
 			LOGGER.trace("GET: {}", webResource);
-			return webResource.accept(MediaType.APPLICATION_JSON).get(InspectImageResponse.class);
-		} catch (UniformInterfaceException exception) {
+			return webResource.request().accept(MediaType.APPLICATION_JSON).get(InspectImageResponse.class);
+		} catch (ClientErrorException exception) {
 			if (exception.getResponse().getStatus() == 404) {
 				throw new NotFoundException(String.format("No such image %s", imageId));
 			} else if (exception.getResponse().getStatus() == 500) {

--- a/src/main/java/com/github/dockerjava/client/command/KillContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/KillContainerCmd.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.client.command;
 
+import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
@@ -7,8 +8,9 @@ import org.slf4j.LoggerFactory;
 
 import com.github.dockerjava.client.DockerException;
 import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
+import javax.ws.rs.client.WebTarget;
+
+import static javax.ws.rs.client.Entity.entity;
 
 /**
  * Kill a running container.
@@ -49,7 +51,7 @@ public class KillContainerCmd extends AbstrDockerCmd<KillContainerCmd, Void> {
     }
 
 	protected Void impl() throws DockerException {
-		WebResource webResource = baseResource.path(String.format("/containers/%s/kill", containerId));
+		WebTarget webResource = baseResource.path("/containers/{id}/kill").resolveTemplate("id", containerId);
 
 		if(signal != null) {
 			webResource = webResource.queryParam("signal", signal);
@@ -57,8 +59,8 @@ public class KillContainerCmd extends AbstrDockerCmd<KillContainerCmd, Void> {
 
 		try {
 			LOGGER.trace("POST: {}", webResource);
-			webResource.accept(MediaType.APPLICATION_JSON).type(MediaType.APPLICATION_JSON).post();
-		} catch (UniformInterfaceException exception) {
+			webResource.request().accept(MediaType.APPLICATION_JSON).post(entity(null, MediaType.APPLICATION_JSON));
+		} catch (ClientErrorException exception) {
 			if (exception.getResponse().getStatus() == 404) {
 				LOGGER.warn("No such container {}", containerId);
 			} else if (exception.getResponse().getStatus() == 204) {

--- a/src/main/java/com/github/dockerjava/client/command/ListContainersCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/ListContainersCmd.java
@@ -2,6 +2,7 @@ package com.github.dockerjava.client.command;
 
 import java.util.List;
 
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -10,9 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import com.github.dockerjava.client.model.Container;
 import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.GenericType;
-import com.sun.jersey.api.client.WebResource;
-import com.sun.jersey.core.util.MultivaluedMapImpl;
+import javax.ws.rs.client.WebTarget;
 
 
 /**
@@ -93,19 +92,19 @@ public class ListContainersCmd extends AbstrDockerCmd<ListContainersCmd, List<Co
     }
 
 	protected List<Container> impl() {
-		MultivaluedMap<String, String> params = new MultivaluedMapImpl();
-		if(limit >= 0) {
-			params.add("limit", String.valueOf(limit));
-		}
-		params.add("all", showAll ? "1" : "0");
-		params.add("since", sinceId);
-		params.add("before", beforeId);
-		params.add("size", showSize ? "1" : "0");
+		WebTarget webResource = baseResource.path("/containers/json")
+                .queryParam("all", showAll ? "1" : "0")
+                .queryParam("since", sinceId)
+                .queryParam("before", beforeId)
+                .queryParam("size", showSize ? "1" : "0");
 
-		WebResource webResource = baseResource.path("/containers/json").queryParams(params);
+        if (limit >= 0) {
+            webResource = webResource.queryParam("limit", String.valueOf(limit));
+        }
+
 		LOGGER.trace("GET: {}", webResource);
-		List<Container> containers = webResource.accept(MediaType.APPLICATION_JSON).get(new GenericType<List<Container>>() {
-		});
+		List<Container> containers = webResource.request().accept(MediaType.APPLICATION_JSON).get(new GenericType<List<Container>>() {
+        });
 		LOGGER.trace("Response: {}", containers);
 
 		return containers;

--- a/src/main/java/com/github/dockerjava/client/command/PauseContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/PauseContainerCmd.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.client.command;
 
+import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
@@ -7,9 +8,10 @@ import org.slf4j.LoggerFactory;
 
 import com.github.dockerjava.client.DockerException;
 import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.client.Entity.entity;
 
 /**
  * Pause a container.
@@ -45,14 +47,14 @@ public class PauseContainerCmd extends AbstrDockerCmd<PauseContainerCmd, Integer
     }
 
 	protected Integer impl() throws DockerException {
-		WebResource webResource = baseResource.path(String.format("/containers/%s/pause", containerId));
+		WebTarget webResource = baseResource.path("/containers/{id}/pause").resolveTemplate("id", containerId);
 
-		ClientResponse response = null;
+		Response response = null;
 
 		try {
 			LOGGER.trace("POST: {}", webResource);
-			response = webResource.accept(MediaType.APPLICATION_JSON).type(MediaType.APPLICATION_JSON).post(ClientResponse.class);
-		} catch (UniformInterfaceException exception) {
+			response = webResource.request().accept(MediaType.APPLICATION_JSON).post(entity(null, MediaType.APPLICATION_JSON), Response.class);
+		} catch (ClientErrorException exception) {
 			if (exception.getResponse().getStatus() == 404) {
 				LOGGER.warn("No such container {}", containerId);
 			} else if (exception.getResponse().getStatus() == 204) {

--- a/src/main/java/com/github/dockerjava/client/command/PingCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/PingCmd.java
@@ -3,9 +3,9 @@ package com.github.dockerjava.client.command;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 
 /**
  * Ping the Docker server
@@ -16,13 +16,13 @@ public class PingCmd extends AbstrDockerCmd<PingCmd, Integer> {
     private static final Logger LOGGER = LoggerFactory.getLogger(PingCmd.class);
     
     protected Integer impl() {
-        WebResource webResource = baseResource.path("/_ping");
+        WebTarget webResource = baseResource.path("/_ping");
 
         try {
             LOGGER.trace("GET: {}", webResource);
-            ClientResponse resp = webResource.get(ClientResponse.class);
+            Response resp = webResource.request().get(Response.class);
             return resp.getStatus();
-        } catch (UniformInterfaceException exception) {
+        } catch (ClientErrorException exception) {
             return exception.getResponse().getStatus();
         }
     }

--- a/src/main/java/com/github/dockerjava/client/command/PullImageCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/PullImageCmd.java
@@ -1,34 +1,30 @@
 package com.github.dockerjava.client.command;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-
-import org.apache.commons.lang.StringUtils;
+import com.github.dockerjava.client.DockerException;
+import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.client.DockerException;
-import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
-import com.sun.jersey.core.util.MultivaluedMapImpl;
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.client.Entity.entity;
 
 
 /**
- *
  * Pull image from repository.
- *
  */
-public class PullImageCmd extends AbstrDockerCmd<PullImageCmd, ClientResponse>  {
+public class PullImageCmd extends AbstrDockerCmd<PullImageCmd, Response> {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(PullImageCmd.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PullImageCmd.class);
 
-	private String repository, tag, registry;
+    private String repository, tag, registry;
 
-	public PullImageCmd(String repository) {
-		withRepository(repository);
-	}
+    public PullImageCmd(String repository) {
+        withRepository(repository);
+    }
 
     public String getRepository() {
         return repository;
@@ -43,50 +39,49 @@ public class PullImageCmd extends AbstrDockerCmd<PullImageCmd, ClientResponse>  
     }
 
     public PullImageCmd withRepository(String repository) {
-		Preconditions.checkNotNull(repository, "repository was not specified");
-		this.repository = repository;
-		return this;
-	}
+        Preconditions.checkNotNull(repository, "repository was not specified");
+        this.repository = repository;
+        return this;
+    }
 
-	public PullImageCmd withTag(String tag) {
-		Preconditions.checkNotNull(tag, "tag was not specified");
-		this.tag = tag;
-		return this;
-	}
+    public PullImageCmd withTag(String tag) {
+        Preconditions.checkNotNull(tag, "tag was not specified");
+        this.tag = tag;
+        return this;
+    }
 
-	public PullImageCmd withRegistry(String registry) {
-		Preconditions.checkNotNull(registry, "registry was not specified");
-		this.registry = registry;
-		return this;
-	}
+    public PullImageCmd withRegistry(String registry) {
+        Preconditions.checkNotNull(registry, "registry was not specified");
+        this.registry = registry;
+        return this;
+    }
 
     @Override
     public String toString() {
         return new StringBuilder("pull ")
-            .append(repository)
-            .append(tag != null ? ":" + tag : "")
-            .toString();
+                .append(repository)
+                .append(tag != null ? ":" + tag : "")
+                .toString();
     }
 
-	protected ClientResponse impl() {
-		Preconditions.checkNotNull(repository, "Repository was not specified");
+    protected Response impl() {
+        Preconditions.checkNotNull(repository, "Repository was not specified");
 
-		MultivaluedMap<String, String> params = new MultivaluedMapImpl();
-		params.add("tag", tag);
-		params.add("fromImage", repository);
-		params.add("registry", registry);
+        WebTarget webResource = baseResource
+                .path("/images/create")
+                .queryParam("tag", tag)
+                .queryParam("fromImage", repository)
+                .queryParam("registry", registry);
 
-		WebResource webResource = baseResource.path("/images/create").queryParams(params);
-
-		try {
-			LOGGER.trace("POST: {}", webResource);
-			return webResource.accept(MediaType.APPLICATION_OCTET_STREAM_TYPE).post(ClientResponse.class);
-		} catch (UniformInterfaceException exception) {
-			if (exception.getResponse().getStatus() == 500) {
-				throw new DockerException("Server error.", exception);
-			} else {
-				throw new DockerException(exception);
-			}
-		}
-	}
+        try {
+            LOGGER.trace("POST: {}", webResource);
+            return webResource.request().accept(MediaType.APPLICATION_OCTET_STREAM_TYPE).post(entity(Response.class, MediaType.APPLICATION_JSON));
+        } catch (ClientErrorException exception) {
+            if (exception.getResponse().getStatus() == 500) {
+                throw new DockerException("Server error.", exception);
+            } else {
+                throw new DockerException(exception);
+            }
+        }
+    }
 }

--- a/src/main/java/com/github/dockerjava/client/command/PushImageCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/PushImageCmd.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.client.command;
 
+import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
@@ -7,9 +8,10 @@ import org.slf4j.LoggerFactory;
 
 import com.github.dockerjava.client.DockerException;
 import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.client.Entity.entity;
 
 
 /**
@@ -17,7 +19,7 @@ import com.sun.jersey.api.client.WebResource;
  *
  * @param name The name, e.g. "alexec/busybox" or just "busybox" if you want to default. Not null.
  */
-public class PushImageCmd extends AbstrAuthCfgDockerCmd<PushImageCmd, ClientResponse>  {
+public class PushImageCmd extends AbstrAuthCfgDockerCmd<PushImageCmd, Response>  {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(PushImageCmd.class);
 
@@ -47,16 +49,17 @@ public class PushImageCmd extends AbstrAuthCfgDockerCmd<PushImageCmd, ClientResp
             .toString();
     }
 
-	protected ClientResponse impl() {
-		WebResource webResource = baseResource.path("/images/" + name(name) + "/push");
+	protected Response impl() {
+		WebTarget webResource = baseResource.path("/images/" + name(name) + "/push");
 		try {
 			final String registryAuth = registryAuth();
 			LOGGER.trace("POST: {}", webResource);
 			return webResource
+                    .request()
 					.header("X-Registry-Auth", registryAuth)
 					.accept(MediaType.APPLICATION_JSON)
-					.post(ClientResponse.class);
-		} catch (UniformInterfaceException e) {
+					.post(entity(Response.class, MediaType.APPLICATION_JSON));
+		} catch (ClientErrorException e) {
 			throw new DockerException(e);
 		}
 	}

--- a/src/main/java/com/github/dockerjava/client/command/RemoveContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/RemoveContainerCmd.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.client.command;
 
+import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.lang.StringUtils;
@@ -8,8 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import com.github.dockerjava.client.DockerException;
 import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
+import javax.ws.rs.client.WebTarget;
 
 /**
  * Remove a container.
@@ -73,13 +73,13 @@ public class RemoveContainerCmd extends AbstrDockerCmd<RemoveContainerCmd, Void>
 	protected Void impl() throws DockerException {
 		Preconditions.checkState(!StringUtils.isEmpty(containerId), "Container ID can't be empty");
 
-		WebResource webResource = baseResource.path("/containers/" + containerId).queryParam("v", removeVolumes ? "1" : "0").queryParam("force", force ? "1" : "0");
+		WebTarget webResource = baseResource.path("/containers/" + containerId).queryParam("v", removeVolumes ? "1" : "0").queryParam("force", force ? "1" : "0");
 
 		try {
 			LOGGER.trace("DELETE: {}", webResource);
-			String response = webResource.accept(MediaType.APPLICATION_JSON).delete(String.class);
+			String response = webResource.request().accept(MediaType.APPLICATION_JSON).delete(String.class);
 			LOGGER.trace("Response: {}", response);
-		} catch (UniformInterfaceException exception) {
+		} catch (ClientErrorException exception) {
 			if (exception.getResponse().getStatus() == 204) {
 				//no error
 				LOGGER.trace("Successfully removed container " + containerId);

--- a/src/main/java/com/github/dockerjava/client/command/RemoveImageCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/RemoveImageCmd.java
@@ -6,9 +6,10 @@ import org.slf4j.LoggerFactory;
 
 import com.github.dockerjava.client.DockerException;
 import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
+
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 
 /**
  *
@@ -72,14 +73,14 @@ public class RemoveImageCmd extends AbstrDockerCmd<RemoveImageCmd, Void> {
 		Preconditions.checkState(!StringUtils.isEmpty(imageId), "Image ID can't be empty");
 
 		try {
-			WebResource webResource = baseResource.path("/images/" + imageId)
+			WebTarget webResource = baseResource.path("/images/" + imageId)
 					.queryParam("force", force ? "1" : "0").queryParam("noprune", noPrune ? "1" : "0");
 
 			LOGGER.trace("DELETE: {}", webResource);
-			webResource.delete(ClientResponse.class);
+			webResource.request().delete(Response.class);
 
 
-		} catch (UniformInterfaceException exception) {
+		} catch (ClientErrorException exception) {
 			if (exception.getResponse().getStatus() == 204) {
 				//no error
 				LOGGER.trace("Successfully removed image " + imageId);

--- a/src/main/java/com/github/dockerjava/client/command/RestartContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/RestartContainerCmd.java
@@ -1,5 +1,7 @@
 package com.github.dockerjava.client.command;
 
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
@@ -8,8 +10,9 @@ import org.slf4j.LoggerFactory;
 import com.github.dockerjava.client.DockerException;
 import com.github.dockerjava.client.NotFoundException;
 import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
+import javax.ws.rs.client.WebTarget;
+
+import static javax.ws.rs.client.Entity.entity;
 
 /**
  * Restart a running container.
@@ -58,13 +61,13 @@ public class RestartContainerCmd extends AbstrDockerCmd<RestartContainerCmd, Voi
     }
 
 	protected Void impl() throws DockerException {
-		WebResource webResource = baseResource.path(String.format("/containers/%s/restart", containerId))
-				.queryParam("t", String.valueOf(timeout));;
+		WebTarget webResource = baseResource.path("/containers/{id}/restart").resolveTemplate("id", containerId)
+				.queryParam("t", String.valueOf(timeout));
 
 		try {
 			LOGGER.trace("POST: {}", webResource);
-			webResource.accept(MediaType.APPLICATION_JSON).type(MediaType.APPLICATION_JSON).post();
-		} catch (UniformInterfaceException exception) {
+			webResource.request().accept(MediaType.APPLICATION_JSON).post(entity(null, MediaType.APPLICATION_JSON_TYPE));
+		} catch (ClientErrorException exception) {
 			if (exception.getResponse().getStatus() == 404) {
 				throw new NotFoundException(String.format("No such container %s", containerId));
 			} else if (exception.getResponse().getStatus() == 204) {

--- a/src/main/java/com/github/dockerjava/client/command/SearchImagesCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/SearchImagesCmd.java
@@ -2,6 +2,8 @@ package com.github.dockerjava.client.command;
 
 import java.util.List;
 
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
@@ -10,9 +12,7 @@ import org.slf4j.LoggerFactory;
 import com.github.dockerjava.client.DockerException;
 import com.github.dockerjava.client.model.SearchItem;
 import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.GenericType;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
+import javax.ws.rs.client.WebTarget;
 
 
 /**
@@ -48,12 +48,12 @@ public class SearchImagesCmd extends AbstrDockerCmd<SearchImagesCmd, List<Search
     }
 
 	protected List<SearchItem> impl() {
-		WebResource webResource = baseResource.path("/images/search").queryParam("term", term);
+		WebTarget webResource = baseResource.path("/images/search").queryParam("term", term);
 		try {
 			LOGGER.trace("GET: {}", webResource);
-			return webResource.accept(MediaType.APPLICATION_JSON).get(new GenericType<List<SearchItem>>() {
-			});
-		} catch (UniformInterfaceException exception) {
+			return webResource.request().accept(MediaType.APPLICATION_JSON).get(new GenericType<List<SearchItem>>() {
+            });
+		} catch (ClientErrorException exception) {
 			if (exception.getResponse().getStatus() == 500) {
 				throw new DockerException("Server error.", exception);
 			} else {

--- a/src/main/java/com/github/dockerjava/client/command/StopContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/StopContainerCmd.java
@@ -1,5 +1,7 @@
 package com.github.dockerjava.client.command;
 
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
@@ -7,8 +9,9 @@ import org.slf4j.LoggerFactory;
 
 import com.github.dockerjava.client.DockerException;
 import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
+import javax.ws.rs.client.WebTarget;
+
+import static javax.ws.rs.client.Entity.entity;
 
 /**
  * Stop a running container.
@@ -58,13 +61,13 @@ public class StopContainerCmd extends AbstrDockerCmd<StopContainerCmd, Void> {
     }
 
 	protected Void impl() throws DockerException {
-		WebResource webResource = baseResource.path(String.format("/containers/%s/stop", containerId))
+		WebTarget webResource = baseResource.path("/containers/{id}/stop").resolveTemplate("id", containerId)
 				.queryParam("t", String.valueOf(timeout));
 
 		try {
 			LOGGER.trace("POST: {}", webResource);
-			webResource.accept(MediaType.APPLICATION_JSON).type(MediaType.APPLICATION_JSON).post();
-		} catch (UniformInterfaceException exception) {
+			webResource.request().accept(MediaType.APPLICATION_JSON).post(entity(null, MediaType.APPLICATION_JSON));
+		} catch (ClientErrorException exception) {
 			if (exception.getResponse().getStatus() == 404) {
 				LOGGER.warn("No such container {}", containerId);
 			} else if(exception.getResponse().getStatus() == 304) {

--- a/src/main/java/com/github/dockerjava/client/command/TagImageCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/TagImageCmd.java
@@ -1,5 +1,7 @@
 package com.github.dockerjava.client.command;
 
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 
 import org.slf4j.Logger;
@@ -7,10 +9,10 @@ import org.slf4j.LoggerFactory;
 
 import com.github.dockerjava.client.DockerException;
 import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
-import com.sun.jersey.core.util.MultivaluedMapImpl;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.client.Entity.entity;
 
 
 /**
@@ -92,20 +94,16 @@ public class TagImageCmd extends AbstrDockerCmd<TagImageCmd, Integer>  {
     }
 
 	protected Integer impl() {
-
-		MultivaluedMap<String, String> params = new MultivaluedMapImpl();
-		params.add("repo", repository);
-		params.add("tag", tag);
-		params.add("force", force ? "1" : "0");
-
-		WebResource webResource = baseResource.path("/images/" + imageId + "/tag").queryParams(
-				params);
+		WebTarget webResource = baseResource.path("/images/" + imageId + "/tag")
+                .queryParam("repo", repository)
+                .queryParam("tag", tag)
+                .queryParam("force", force ? "1" : "0");
 
 		try {
 			LOGGER.trace("POST: {}", webResource);
-			ClientResponse resp = webResource.post(ClientResponse.class);
+			Response resp = webResource.request().post(entity(null, MediaType.APPLICATION_JSON), Response.class);
 			return resp.getStatus();
-		} catch (UniformInterfaceException exception) {
+		} catch (ClientErrorException exception) {
 			throw new DockerException(exception);
 		}
 	}

--- a/src/main/java/com/github/dockerjava/client/command/TopContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/TopContainerCmd.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.client.command;
 
+import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.lang.StringUtils;
@@ -9,8 +10,7 @@ import org.slf4j.LoggerFactory;
 import com.github.dockerjava.client.DockerException;
 import com.github.dockerjava.client.NotFoundException;
 import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
+import javax.ws.rs.client.WebTarget;
 
 /**
  *
@@ -59,15 +59,15 @@ public class TopContainerCmd extends AbstrDockerCmd<TopContainerCmd, TopContaine
     }
 
 	protected TopContainerResponse impl() throws DockerException {
-		WebResource webResource = baseResource.path(String.format("/containers/%s/top", containerId));
+		WebTarget webResource = baseResource.path("/containers/{id}/top").resolveTemplate("id", containerId);
 
 		if(!StringUtils.isEmpty(psArgs))
 			webResource = webResource.queryParam("ps_args", psArgs);
 
 		try {
 			LOGGER.trace("GET: {}", webResource);
-			return webResource.accept(MediaType.APPLICATION_JSON).get(TopContainerResponse.class);
-		} catch (UniformInterfaceException exception) {
+			return webResource.request().accept(MediaType.APPLICATION_JSON).get(TopContainerResponse.class);
+		} catch (ClientErrorException exception) {
 			if (exception.getResponse().getStatus() == 404) {
 				throw new NotFoundException(String.format("No such container %s", containerId));
 			} else if (exception.getResponse().getStatus() == 500) {

--- a/src/main/java/com/github/dockerjava/client/command/UnpauseContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/UnpauseContainerCmd.java
@@ -1,5 +1,7 @@
 package com.github.dockerjava.client.command;
 
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
@@ -7,9 +9,8 @@ import org.slf4j.LoggerFactory;
 
 import com.github.dockerjava.client.DockerException;
 import com.google.common.base.Preconditions;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 
 /**
  * Unpause a container.
@@ -45,14 +46,14 @@ public class UnpauseContainerCmd extends AbstrDockerCmd<UnpauseContainerCmd, Int
     }
 
 	protected Integer impl() throws DockerException {
-		WebResource webResource = baseResource.path(String.format("/containers/%s/unpause", containerId));
+		WebTarget webResource = baseResource.path("/containers/{id}/unpause").resolveTemplate("id", containerId);
 
-		ClientResponse response = null;
+		Response response = null;
 
 		try {
 			LOGGER.trace("POST: {}", webResource);
-			response = webResource.accept(MediaType.APPLICATION_JSON).type(MediaType.APPLICATION_JSON).post(ClientResponse.class);
-		} catch (UniformInterfaceException exception) {
+			response = webResource.request().accept(MediaType.APPLICATION_JSON).post(Entity.entity(Response.class, MediaType.APPLICATION_JSON));
+		} catch (ClientErrorException exception) {
 			if (exception.getResponse().getStatus() == 404) {
 				LOGGER.warn("No such container {}", containerId);
 			} else if (exception.getResponse().getStatus() == 204) {

--- a/src/main/java/com/github/dockerjava/client/command/VersionCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/VersionCmd.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.client.command;
 
+import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.MediaType;
 
 import org.slf4j.Logger;
@@ -7,8 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import com.github.dockerjava.client.DockerException;
 import com.github.dockerjava.client.model.Version;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
+import javax.ws.rs.client.WebTarget;
 
 
 /**
@@ -25,12 +25,12 @@ public class VersionCmd extends AbstrDockerCmd<VersionCmd, Version>  {
     }   
 
 	protected Version impl() throws DockerException {
-		WebResource webResource = baseResource.path("/version");
+		WebTarget webResource = baseResource.path("/version");
 
 		try {
 			LOGGER.trace("GET: {}", webResource);
-			return webResource.accept(MediaType.APPLICATION_JSON).get(Version.class);
-		} catch (UniformInterfaceException exception) {
+			return webResource.request().accept(MediaType.APPLICATION_JSON).get(Version.class);
+		} catch (ClientErrorException exception) {
 			if (exception.getResponse().getStatus() == 500) {
 				throw new DockerException("Server error.", exception);
 			} else {

--- a/src/main/java/com/github/dockerjava/client/utils/JsonClientFilter.java
+++ b/src/main/java/com/github/dockerjava/client/utils/JsonClientFilter.java
@@ -1,26 +1,25 @@
 package com.github.dockerjava.client.utils;
 
 
-import com.sun.jersey.api.client.ClientRequest;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.filter.ClientFilter;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
 
 /**
  *
  * @author Konstantin Pelykh (kpelykh@gmail.com)
  *
  */
-public class JsonClientFilter extends ClientFilter {
+public class JsonClientFilter implements ClientResponseFilter {
 
-    public ClientResponse handle(ClientRequest cr) {
-        // Call the next filter
-        ClientResponse resp = getNext().handle(cr);
-        String respContentType = resp.getHeaders().getFirst("Content-Type");
-        if (respContentType != null && respContentType.startsWith("text/plain")) {
-            String newContentType = "application/json" + respContentType.substring(10);
-            resp.getHeaders().putSingle("Content-Type", newContentType);
+
+    @Override
+    public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
+        if (responseContext.getMediaType() != null && responseContext.getMediaType().isCompatible(MediaType.TEXT_PLAIN_TYPE)) {
+            String newContentType = "application/json" + responseContext.getMediaType().toString().substring(10);
+            responseContext.getHeaders().putSingle("Content-Type", newContentType);
         }
-        return resp;
     }
-
 }

--- a/src/test/java/com/github/dockerjava/client/AbstractDockerClientTest.java
+++ b/src/test/java/com/github/dockerjava/client/AbstractDockerClientTest.java
@@ -2,13 +2,13 @@ package com.github.dockerjava.client;
 
 import com.github.dockerjava.client.DockerClient;
 import com.github.dockerjava.client.DockerException;
-import com.sun.jersey.api.client.ClientResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.ITestResult;
 
+import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.DatagramSocket;
@@ -82,7 +82,7 @@ public abstract class AbstractDockerClientTest extends Assert {
 				result.getName());
 	}
 
-	protected String logResponseStream(ClientResponse response)  {
+	protected String logResponseStream(Response response)  {
 		String responseString;
 		try {
 			responseString = DockerClient.asString(response);

--- a/src/test/java/com/github/dockerjava/client/command/AuthCmdTest.java
+++ b/src/test/java/com/github/dockerjava/client/command/AuthCmdTest.java
@@ -3,12 +3,12 @@ package com.github.dockerjava.client.command;
 import com.github.dockerjava.client.AbstractDockerClientTest;
 import com.github.dockerjava.client.DockerClient;
 import com.github.dockerjava.client.DockerException;
-import com.sun.jersey.api.client.UniformInterfaceException;
 
 import org.hamcrest.Matchers;
 import org.testng.ITestResult;
 import org.testng.annotations.*;
 
+import javax.ws.rs.ClientErrorException;
 import java.lang.reflect.Method;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -46,8 +46,8 @@ public class AuthCmdTest extends AbstractDockerClientTest {
 			new DockerClient().authCmd().exec();
             fail("Expected a DockerException caused by a bad password.");
 		} catch (DockerException e) {
-			assertThat(e.getCause(), Matchers.instanceOf(UniformInterfaceException.class));
-			assertEquals(((UniformInterfaceException) e.getCause()).getResponse().getStatus(), 401);
+			assertThat(e.getCause(), Matchers.instanceOf(ClientErrorException.class));
+			assertEquals(((ClientErrorException) e.getCause()).getResponse().getStatus(), 401);
 		}
 	}
 }

--- a/src/test/java/com/github/dockerjava/client/command/BuildImageCmdTest.java
+++ b/src/test/java/com/github/dockerjava/client/command/BuildImageCmdTest.java
@@ -10,12 +10,14 @@ import static org.hamcrest.Matchers.nullValue;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringWriter;
 import java.lang.reflect.Method;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
 import org.apache.commons.lang.StringUtils;
+import org.glassfish.jersey.client.ClientResponse;
 import org.testng.ITestResult;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterTest;
@@ -25,7 +27,8 @@ import org.testng.annotations.Test;
 
 import com.github.dockerjava.client.AbstractDockerClientTest;
 import com.github.dockerjava.client.DockerException;
-import com.sun.jersey.api.client.ClientResponse;
+
+import javax.ws.rs.core.Response;
 
 public class BuildImageCmdTest extends AbstractDockerClientTest {
 
@@ -55,20 +58,21 @@ public class BuildImageCmdTest extends AbstractDockerClientTest {
 		File baseDir = new File(Thread.currentThread().getContextClassLoader()
 				.getResource("nginx").getFile());
 
-		ClientResponse response = dockerClient.buildImageCmd(baseDir).exec();
+		Response response = dockerClient.buildImageCmd(baseDir).exec();
 
 		StringWriter logwriter = new StringWriter();
 
+        InputStream is = response.readEntity(InputStream.class);
 		try {
-			LineIterator itr = IOUtils.lineIterator(
-					response.getEntityInputStream(), "UTF-8");
+            LineIterator itr = IOUtils.lineIterator(
+                    is, "UTF-8");
 			while (itr.hasNext()) {
 				String line = itr.next();
 				logwriter.write(line + "\n");
 				LOG.info(line);
 			}
 		} finally {
-			IOUtils.closeQuietly(response.getEntityInputStream());
+			IOUtils.closeQuietly(is);
 		}
 
 		String fullLog = logwriter.toString();
@@ -115,20 +119,21 @@ public class BuildImageCmdTest extends AbstractDockerClientTest {
 			throws DockerException, IOException {
 
 		// Build image
-		ClientResponse response = dockerClient.buildImageCmd(baseDir).exec();
+		Response response = dockerClient.buildImageCmd(baseDir).exec();
 
 		StringWriter logwriter = new StringWriter();
 
+        InputStream is = response.readEntity(InputStream.class);
 		try {
-			LineIterator itr = IOUtils.lineIterator(
-					response.getEntityInputStream(), "UTF-8");
+            LineIterator itr = IOUtils.lineIterator(
+                    is, "UTF-8");
 			while (itr.hasNext()) {
 				String line = itr.next();
 				logwriter.write(line + "\n");
 				LOG.info(line);
 			}
 		} finally {
-			IOUtils.closeQuietly(response.getEntityInputStream());
+			IOUtils.closeQuietly(is);
 		}
 
 		String fullLog = logwriter.toString();
@@ -150,7 +155,7 @@ public class BuildImageCmdTest extends AbstractDockerClientTest {
 		tmpContainers.add(container.getId());
 
 		// Log container
-		ClientResponse logResponse = logContainer(container
+		Response logResponse = logContainer(container
 				.getId());
 
 		assertThat(logResponseStream(logResponse), containsString(expectedText));
@@ -159,7 +164,7 @@ public class BuildImageCmdTest extends AbstractDockerClientTest {
 	}
 
 
-	private ClientResponse logContainer(String containerId) {
+	private Response logContainer(String containerId) {
 		return dockerClient.logContainerCmd(containerId).withStdErr().withStdOut().exec();
 	}
 
@@ -169,20 +174,21 @@ public class BuildImageCmdTest extends AbstractDockerClientTest {
 		File baseDir = new File(Thread.currentThread().getContextClassLoader()
 				.getResource("netcat").getFile());
 
-		ClientResponse response = dockerClient.buildImageCmd(baseDir).withNoCache().exec();
+		Response response = dockerClient.buildImageCmd(baseDir).withNoCache().exec();
 
 		StringWriter logwriter = new StringWriter();
 
+        InputStream is = response.readEntity(InputStream.class);
 		try {
-			LineIterator itr = IOUtils.lineIterator(
-					response.getEntityInputStream(), "UTF-8");
+            LineIterator itr = IOUtils.lineIterator(
+                    is, "UTF-8");
 			while (itr.hasNext()) {
 				String line = itr.next();
 				logwriter.write(line + "\n");
 				LOG.info(line);
 			}
 		} finally {
-			IOUtils.closeQuietly(response.getEntityInputStream());
+			IOUtils.closeQuietly(is);
 		}
 
 		String fullLog = logwriter.toString();

--- a/src/test/java/com/github/dockerjava/client/command/CopyFileFromContainerCmdTest.java
+++ b/src/test/java/com/github/dockerjava/client/command/CopyFileFromContainerCmdTest.java
@@ -1,10 +1,10 @@
 package com.github.dockerjava.client.command;
 
 import com.github.dockerjava.client.AbstractDockerClientTest;
-import com.sun.jersey.api.client.ClientResponse;
 import org.testng.ITestResult;
 import org.testng.annotations.*;
 
+import javax.ws.rs.core.Response;
 import java.lang.reflect.Method;
 
 import static org.hamcrest.Matchers.*;
@@ -46,7 +46,7 @@ public class CopyFileFromContainerCmdTest extends AbstractDockerClientTest {
         dockerClient.startContainerCmd(container.getId()).exec();
         tmpContainers.add(container.getId());
 
-        ClientResponse response = dockerClient.copyFileFromContainerCmd(container.getId(), "/test").exec();
+        Response response = dockerClient.copyFileFromContainerCmd(container.getId(), "/test").exec();
         assertTrue(response.getStatus() == 200 && response.hasEntity(), "The file was not copied from the container.");
     }
 }

--- a/src/test/java/com/github/dockerjava/client/command/LogContainerCmdTest.java
+++ b/src/test/java/com/github/dockerjava/client/command/LogContainerCmdTest.java
@@ -18,7 +18,8 @@ import org.testng.annotations.Test;
 
 import com.github.dockerjava.client.AbstractDockerClientTest;
 import com.github.dockerjava.client.DockerException;
-import com.sun.jersey.api.client.ClientResponse;
+
+import javax.ws.rs.core.Response;
 
 public class LogContainerCmdTest extends AbstractDockerClientTest {
 
@@ -60,7 +61,7 @@ public class LogContainerCmdTest extends AbstractDockerClientTest {
 
 		assertThat(exitCode, equalTo(0));
 
-		ClientResponse response = dockerClient.logContainerCmd(container.getId()).withStdErr().withStdOut().exec();
+		Response response = dockerClient.logContainerCmd(container.getId()).withStdErr().withStdOut().exec();
 
 		assertThat(logResponseStream(response), endsWith(snippet));
 	}

--- a/src/test/java/com/github/dockerjava/client/command/PullImageCmdTest.java
+++ b/src/test/java/com/github/dockerjava/client/command/PullImageCmdTest.java
@@ -18,7 +18,8 @@ import org.testng.annotations.Test;
 import com.github.dockerjava.client.AbstractDockerClientTest;
 import com.github.dockerjava.client.DockerException;
 import com.github.dockerjava.client.model.Info;
-import com.sun.jersey.api.client.ClientResponse;
+
+import javax.ws.rs.core.Response;
 
 public class PullImageCmdTest extends AbstractDockerClientTest {
 
@@ -70,7 +71,7 @@ public class PullImageCmdTest extends AbstractDockerClientTest {
 		LOG.info("Pulling image: {}", testImage);
 
 		tmpImgs.add(testImage);
-		ClientResponse response = dockerClient.pullImageCmd(testImage).exec();
+		Response response = dockerClient.pullImageCmd(testImage).exec();
 
 		assertThat(logResponseStream(response),
 				containsString("Download complete"));


### PR DESCRIPTION
I want to use this library in an environment where there are other libraries that depend on Jersey 2. Since Jersey 2 has better performance and a nicer API compared to Jersey 1, I thought I would just port this library to Jersey 2.

All the tests pass so I assume that this port is complete.
