### PR TITLE
Adding support for networkMode

### DIFF
--- a/src/main/java/com/github/dockerjava/client/command/StartContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/client/command/StartContainerCmd.java
@@ -5,6 +5,7 @@ import javax.ws.rs.core.MediaType;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.dockerjava.client.model.*;
+
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +51,10 @@ public class StartContainerCmd extends AbstrDockerCmd<StartContainerCmd, Void> {
 	@JsonProperty("VolumesFrom")
 	private String volumesFrom;
 	
+    @JsonProperty("NetworkMode")          
+    private String  networkMode = "bridge";
+
+	
 	public StartContainerCmd(String containerId) {
 		withContainerId(containerId);
 	}
@@ -88,10 +93,13 @@ public class StartContainerCmd extends AbstrDockerCmd<StartContainerCmd, Void> {
 		return volumesFrom;
 	}
 
-	
 	public String getContainerId() {
 		return containerId;
 	}
+	   
+    public String getNetworkMode() {        
+        return networkMode;
+    }
 
 	@JsonIgnore
 	public StartContainerCmd withBinds(Bind... binds) {
@@ -148,7 +156,13 @@ public class StartContainerCmd extends AbstrDockerCmd<StartContainerCmd, Void> {
 				.checkNotNull(containerId, "containerId was not specified");
 		this.containerId = containerId;
 		return this;
-	}
+    }
+
+    public StartContainerCmd withNetworkMode(String networkMode) {
+        Preconditions.checkNotNull(networkMode, "networkMode was not specified");
+        this.networkMode = networkMode;
+        return this;
+    }
 
 	@Override
 	public String toString() {

--- a/src/test/java/com/github/dockerjava/client/command/StartContainerCmdTest.java
+++ b/src/test/java/com/github/dockerjava/client/command/StartContainerCmdTest.java
@@ -214,5 +214,29 @@ public class StartContainerCmdTest extends AbstractDockerClientTest {
 
 	}
 
+	@Test
+    public void startContainerWithNetworkMode() throws DockerException {
+
+        CreateContainerResponse container = dockerClient
+                .createContainerCmd("busybox")
+                .withCmd("true").exec();
+
+        LOG.info("Created container {}", container.toString());
+
+        assertThat(container.getId(), not(isEmptyString()));
+
+        InspectContainerResponse inspectContainerResponse = dockerClient
+                .inspectContainerCmd(container.getId()).exec();
+
+        dockerClient.startContainerCmd(container.getId()).withNetworkMode("host").exec();
+
+        inspectContainerResponse = dockerClient.inspectContainerCmd(container
+                .getId()).exec();
+
+        assertThat(inspectContainerResponse.getHostConfig().getNetworkMode(),
+                is(equalTo("host")));
+
+        tmpContainers.add(container.getId());
+    }
 
 }


### PR DESCRIPTION
Adding support for networkMode in startContainerCmd. Default is 'bridge' mode. Also added the test case. 
This adds support for --net option for the docker run command:
--net="bridge"         Set the Network mode for the container
                               'bridge': creates a new network stack for the container on the docker bridge
                               'none': no networking for this container
                               'container:<name|id>': reuses another container network stack
                               'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
