### PR TITLE
Allow user to check where volume is binded on host

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
+++ b/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
@@ -116,13 +116,9 @@ public class InspectContainerResponse {
     }
 
     @JsonIgnore
-    public Bind[] getBinds() {
+    public VolumeBind[] getVolumes() {
         return volumes.getBinds();
     }
-
-    @JsonIgnore
-    public Volume[] getVolumes() { return volumes.getVolumes(); }
-
 
     @JsonIgnore
     public Volume[] getVolumesRW() {

--- a/src/main/java/com/github/dockerjava/api/model/VolumeBind.java
+++ b/src/main/java/com/github/dockerjava/api/model/VolumeBind.java
@@ -1,0 +1,19 @@
+package com.github.dockerjava.api.model;
+
+public class VolumeBind {
+    private final String hostPath;
+    private final String containerPath;
+
+    public VolumeBind(String hostPath, String containerPath){
+        this.hostPath = hostPath;
+        this.containerPath = containerPath;
+    }
+
+    public String getContainerPath() {
+        return containerPath;
+    }
+
+    public String getHostPath() {
+        return hostPath;
+    }
+}

--- a/src/test/java/com/github/dockerjava/api/model/VolumeBindsTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/VolumeBindsTest.java
@@ -1,0 +1,33 @@
+package com.github.dockerjava.api.model;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jdk.nashorn.internal.parser.JSONParser;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.testng.Assert.*;
+
+public class VolumeBindsTest {
+    @Test
+    public void t() throws IOException {
+        String s = "{\"/data\":\"/some/path\"}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        VolumeBinds volumeBinds = objectMapper.readValue(s, VolumeBinds.class);
+        VolumeBind[] binds = volumeBinds.getBinds();
+        assertEquals(binds.length,1);
+        assertEquals(binds[0].getHostPath(),"/some/path");
+        assertEquals(binds[0].getContainerPath(), "/data");
+    }
+
+    @Test(expectedExceptions = JsonMappingException.class)
+    public void t1() throws IOException {
+        String s = "{\"/data\": {} }";
+        ObjectMapper objectMapper = new ObjectMapper();
+        VolumeBinds volumeBinds = objectMapper.readValue(s, VolumeBinds.class);
+    }
+
+
+}

--- a/src/test/java/com/github/dockerjava/core/command/StartContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/StartContainerCmdImplTest.java
@@ -10,16 +10,12 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
+import java.util.*;
 
 import com.github.dockerjava.api.DockerException;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
-import com.github.dockerjava.api.model.Bind;
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.Link;
-import com.github.dockerjava.api.model.Ports;
-import com.github.dockerjava.api.model.Volume;
+import com.github.dockerjava.api.model.*;
 
 import org.testng.ITestResult;
 import org.testng.annotations.AfterMethod;
@@ -82,9 +78,12 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
 		inspectContainerResponse = dockerClient.inspectContainerCmd(container
 				.getId()).exec();
 
-
-		assertThat(Arrays.asList(inspectContainerResponse.getVolumes()),
-				contains(volume1, volume2));
+        VolumeBind[] volumeBinds = inspectContainerResponse.getVolumes();
+        List<String> volumes = new ArrayList<String>();
+        for(VolumeBind bind :volumeBinds){
+            volumes.add(bind.getContainerPath());
+        }
+        assertThat(volumes,	contains(volume1.getPath(), volume2.getPath()));
 
 		assertThat(Arrays.asList(inspectContainerResponse.getVolumesRW()),
 				contains(volume1, volume2));


### PR DESCRIPTION
Inspect container returns the physical location in host where container's volumes are binded. This information was not accessible using docker-java. This merge adds possibility to check this information.

It is used something like:

```
InspectContainerResponse container = docker.inspectContainerCmd(appid).exec();
    for (VolumeBind bind : container.getVolumes()) {
        System.out.println(bind.getHostPath()+":"+bind.getContainerPath());
    }
```
