### PR TITLE
Bind.parse() fails when access mode is specified

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/Bind.java
+++ b/src/main/java/com/github/dockerjava/api/model/Bind.java
@@ -38,6 +38,7 @@ public class Bind {
 	 * 
 	 * @param serialized the specification, e.g. <code>/host:/container:ro</code>
 	 * @return a {@link Bind} matching the specification
+	 * @throws IllegalArgumentException if the specification cannot be parsed
 	 */
 	public static Bind parse(String serialized) {
 		try {
@@ -52,16 +53,14 @@ public class Bind {
 				else if ("ro".equals(parts[2].toLowerCase()))
 					return new Bind(parts[0], Volume.parse(parts[1]), true);
 				else
-					throw new RuntimeException("Error parsing Bind '"
-							+ serialized + "'");
+					throw new IllegalArgumentException();
 			}
 			default: {
-				throw new RuntimeException("Error parsing Bind '" + serialized
-						+ "'");
+				throw new IllegalArgumentException();
 			}
 			}
 		} catch (Exception e) {
-			throw new RuntimeException("Error parsing Bind '" + serialized
+			throw new IllegalArgumentException("Error parsing Bind '" + serialized
 					+ "'");
 		}
 	}

--- a/src/test/java/com/github/dockerjava/api/model/BindTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/BindTest.java
@@ -30,9 +30,22 @@ public class BindTest {
 		assertEquals(bind.isReadOnly(), true);
 	}
 
-	@Test(expectedExceptions = RuntimeException.class)
+	@Test(expectedExceptions = IllegalArgumentException.class,
+			expectedExceptionsMessageRegExp = "Error parsing Bind.*")
 	public void parseInvalidAccessMode() {
 		Bind.parse("/host:/container:xx");
 	}
-	
+
+	@Test(expectedExceptions = IllegalArgumentException.class, 
+			expectedExceptionsMessageRegExp = "Error parsing Bind 'nonsense'")
+	public void parseInvalidInput() {
+		Bind.parse("nonsense");
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class, 
+			expectedExceptionsMessageRegExp = "Error parsing Bind 'null'")
+	public void parseNull() {
+		Bind.parse(null);
+	}
+
 }


### PR DESCRIPTION
Due to an off-by-one error only input without given access mode (like `/host:/container`) could be parsed, see added test.
Also added support for read-only (`:ro`) specifications.

I would also like to change the thrown exception to `IllegalArgumentException` in `Bind.parse()` and `Volume.parse()`.
Is this OK, should I amend this PR with it?
