### PR TITLE
Set Jersey client CommonProperties.FEATURE_AUTO_DISCOVERY_DISABLE

### DIFF
--- a/src/main/java/com/github/dockerjava/jaxrs/DockerCmdExecFactoryImpl.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/DockerCmdExecFactoryImpl.java
@@ -10,6 +10,7 @@ import javax.ws.rs.client.WebTarget;
 import com.github.dockerjava.api.command.EventsCmd;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.CommonProperties;
 
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.github.dockerjava.api.command.AttachContainerCmd;
@@ -63,6 +64,7 @@ public class DockerCmdExecFactoryImpl implements DockerCmdExecFactory {
 		Preconditions.checkNotNull(dockerClientConfig, "config was not specified");
 
         ClientConfig clientConfig = new ClientConfig();
+        clientConfig.property(CommonProperties.FEATURE_AUTO_DISCOVERY_DISABLE, true);
 
         clientConfig.register(ResponseStatusExceptionFilter.class);
         clientConfig.register(JsonClientFilter.class);


### PR DESCRIPTION
This prevents Jersey SPI autodiscovery of other XML mapping libraries on
your classpath.

We use Moxy for our mapping library with Jersey and were having problems with this conflicting with Jackson mapper used by docker-java plugin. By switching off auto disovery on Jersey client, you can make sure that only the things you have explicitly registered will be used when making Jersey clients.
