### PR TITLE
Use canonical form of Docker folder when building TAR files

### DIFF
--- a/src/main/java/com/github/dockerjava/core/CompressArchiveUtil.java
+++ b/src/main/java/com/github/dockerjava/core/CompressArchiveUtil.java
@@ -15,7 +15,7 @@ public class CompressArchiveUtil {
             tos.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
             for (File file : files) {
                 TarArchiveEntry tarEntry = new TarArchiveEntry(file);
-                tarEntry.setName(relativize(base, file));
+                tarEntry.setName(relativize(base.getCanonicalFile(), file.getCanonicalFile()));
 
                 if (!file.isDirectory()) {
                     if (file.canExecute()) {


### PR DESCRIPTION
In `BuildImageCmdImpl#buildDockerFolderTar` a canonical form of the source files referenced in the Dockerfile is used. But the Docker folder is passed in the given form to the `CompressArchiveUtil`.

`CompressArchiveUtil#relativize` creates absolute TAR archive entries if the canonical form of the source files differs from the given form of the Docker folder. As a result, the Docker deamon can not find the files during the build. This can happen in case-insensitive file systems such as Windows, for example.

As a solution, the canonical form of the Docker folder must be used.
