### PR TITLE
Improve parsing and serialization of Link

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/Link.java
+++ b/src/main/java/com/github/dockerjava/api/model/Link.java
@@ -90,4 +90,16 @@ public class Link
 		return new HashCodeBuilder().append(name).append(alias).toHashCode();
 	}
 
+	/**
+	 * Returns a string representation of this {@link Link} suitable
+	 * for inclusion in a JSON message.
+	 * The format is <code>name:alias</code>, like the argument in {@link #parse(String)}.
+	 * 
+	 * @return a string representation of this {@link Link}
+	 */
+	@Override
+	public String toString() {
+		return name + ":" + alias;
+	}
+
 }

--- a/src/main/java/com/github/dockerjava/api/model/Links.java
+++ b/src/main/java/com/github/dockerjava/api/model/Links.java
@@ -45,8 +45,7 @@ public class Links
 		{
 			jsonGen.writeStartArray();
 			for (final Link link : links.getLinks()) {
-				final String s = link.getName() + ":" + link.getAlias();
-				jsonGen.writeString(s);
+				jsonGen.writeString(link.toString());
 			}
 			jsonGen.writeEndArray();
 		}

--- a/src/test/java/com/github/dockerjava/api/model/LinkTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/LinkTest.java
@@ -25,4 +25,9 @@ public class LinkTest {
 		Link.parse(null);
 	}
 
+	@Test
+	public void stringify() {
+		assertEquals(Link.parse("name:alias").toString(), "name:alias");
+	}
+
 }


### PR DESCRIPTION
This aims to adjust parsing and serialization of `Link` to the way it is handled in `Bind` and `Volume`.
Added tests and javadoc.
