### PR TITLE
Use project.build.sourceEncoding in compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,6 @@
 					<configuration>
 						<source>${jdk.source}</source>
 						<target>${jdk.target}</target>
-						<encoding>ISO-8859-1</encoding>
 						<debug>${jdk.debug}</debug>
 						<optimize>${jdk.optimize}</optimize>
 					</configuration>


### PR DESCRIPTION
Defining a default encoding of _UTF-8_ in `project.build.sourceEncoding` and
then overriding it in the compiler args with another (presumably wrong)
encoding does not make sense. 
By default, `<encoding>` will use `project.build.sourceEncoding`.
