### PR TITLE
New enum "InternetProtocol" for supported IP protocols replaces "scheme"

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/InternetProtocol.java
+++ b/src/main/java/com/github/dockerjava/api/model/InternetProtocol.java
@@ -1,0 +1,49 @@
+package com.github.dockerjava.api.model;
+
+
+/**
+ * The IP protocols supported by Docker.
+ * 
+ * @see #TCP
+ * @see #UDP
+ */
+public enum InternetProtocol {
+	/** The <i>Transmission Control Protocol</i> */
+	TCP, 
+
+	/** The <i>User Datagram Protocol</i> */
+	UDP;
+	
+	/**
+	 * The default {@link InternetProtocol}: {@link #TCP}
+	 */
+	public static final InternetProtocol DEFAULT = TCP;
+
+	/**
+	 * Returns a string representation of this {@link InternetProtocol} suitable
+	 * for inclusion in a JSON message.
+	 * The output is the lowercased name of the Protocol, e.g. <code>tcp</code>.
+	 * 
+	 * @return a string representation of this {@link InternetProtocol}
+	 */
+	@Override
+	public String toString() {
+		return super.toString().toLowerCase();
+	}
+
+	/**
+	 * Parses a string to an {@link InternetProtocol}.
+	 * 
+	 * @param serialized the protocol, e.g. <code>tcp</code> or <code>TCP</code>
+	 * @return an {@link InternetProtocol} described by the string
+	 * @throws IllegalArgumentException if the argument cannot be parsed
+	 */
+	public static InternetProtocol parse(String serialized) throws IllegalArgumentException {
+		try {
+			return valueOf(serialized.toUpperCase());
+		} catch (Exception e) {
+			throw new IllegalArgumentException("Error parsing Protocol '" + serialized + "'");
+		}
+	}
+
+}

--- a/src/test/java/com/github/dockerjava/api/model/InternetProtocolTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/InternetProtocolTest.java
@@ -1,0 +1,42 @@
+package com.github.dockerjava.api.model;
+
+import static com.github.dockerjava.api.model.InternetProtocol.*;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+public class InternetProtocolTest {
+
+	@Test
+	public void defaultProtocol() {
+		assertEquals(InternetProtocol.DEFAULT, TCP);
+	}
+
+	@Test
+	public void stringify() {
+		assertEquals(TCP.toString(), "tcp");
+	}
+
+	@Test
+	public void parseUpperCase() {
+		assertEquals(InternetProtocol.parse("TCP"), TCP);
+	}
+
+	@Test
+	public void parseLowerCase() {
+		assertEquals(InternetProtocol.parse("tcp"), TCP);
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class, 
+			expectedExceptionsMessageRegExp = "Error parsing Protocol.*")
+	public void parseInvalidInput() {
+		InternetProtocol.parse("xx");
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class, 
+			expectedExceptionsMessageRegExp = "Error parsing Protocol 'null'")
+	public void parseNull() {
+		InternetProtocol.parse(null);
+	}
+
+}


### PR DESCRIPTION
The legal values for internet protocols (here known as schemes) should be defined as an enum, not as `String`. This gives us type safety and some improvements in parsing and stringification.
See #70, `AccessMode`. 
In addition, _scheme_ is a misleading name. This PR replaces it with `InternetProtocol`.
