### PR TITLE
explicitly use the latest image version

### DIFF
--- a/src/test/resources/netcat/Dockerfile
+++ b/src/test/resources/netcat/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               0.3
 
-FROM ubuntu
+FROM ubuntu:latest
 
 #install netcat
 RUN apt-get install -y netcat

--- a/src/test/resources/nginx/Dockerfile
+++ b/src/test/resources/nginx/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               0.0.1
 
-FROM      ubuntu
+FROM      ubuntu:latest
 MAINTAINER Guillaume J. Charmes "guillaume@dotcloud.com"
 
 # make sure the package repository is up to date

--- a/src/test/resources/testAddFile/Dockerfile
+++ b/src/test/resources/testAddFile/Dockerfile
@@ -1,4 +1,4 @@
-FROM      ubuntu
+FROM      ubuntu:latest
 
 # Copy testrun.sh files into the container
 

--- a/src/test/resources/testAddFileInSubfolder/Dockerfile
+++ b/src/test/resources/testAddFileInSubfolder/Dockerfile
@@ -1,4 +1,4 @@
-FROM      ubuntu
+FROM      ubuntu:latest
 
 # Copy testrun.sh files into the container
 

--- a/src/test/resources/testAddFolder/Dockerfile
+++ b/src/test/resources/testAddFolder/Dockerfile
@@ -1,4 +1,4 @@
-FROM      ubuntu
+FROM      ubuntu:latest
 
 # Copy testrun.sh files into the container
 

--- a/src/test/resources/testAddUrl/Dockerfile
+++ b/src/test/resources/testAddUrl/Dockerfile
@@ -1,4 +1,4 @@
-FROM      ubuntu
+FROM      ubuntu:latest
 
 # Copy testrun.sh files into the container
 

--- a/src/test/resources/testENVSubstitution/Dockerfile
+++ b/src/test/resources/testENVSubstitution/Dockerfile
@@ -1,4 +1,4 @@
-FROM      ubuntu
+FROM      ubuntu:latest
 
 # Copy testrun.sh files into the container
 

--- a/src/test/resources/testReadFile/Dockerfile
+++ b/src/test/resources/testReadFile/Dockerfile
@@ -1,4 +1,4 @@
-FROM      ubuntu
+FROM      ubuntu:latest
 
 # Copy testrun.sh files into the container
 


### PR DESCRIPTION
though this change shouldn't change any behaviour, it might help recognizing which image is pulled during the tests. I normally only use the ubuntu:14.04 image, so the ubuntu:latest isn't locally available, which makes the tests run a bit slower for the first run.
