### PR TITLE
Allow multiple port bindings per ExposedPort

### DIFF
--- a/src/test/java/com/github/dockerjava/api/model/PortsTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/PortsTest.java
@@ -11,23 +11,27 @@ import com.github.dockerjava.api.model.Ports.Binding;
 
 public class PortsTest {
 	private final ObjectMapper objectMapper = new ObjectMapper();
+	private final String jsonWithDoubleBindingForOnePort = 
+			"{\"80/tcp\":[{\"HostIp\":\"10.0.0.1\",\"HostPort\":\"80\"},{\"HostIp\":\"10.0.0.2\",\"HostPort\":\"80\"}]}";
 
 	@Test
-	public void deserializingPortWithMultipleBindingsReturnsFirstBinding() throws Exception {
-		String json = "{\"80/tcp\":[{\"HostIp\":\"10.0.0.1\",\"HostPort\":\"80\"},{\"HostIp\":\"10.0.0.2\",\"HostPort\":\"80\"}]}";
-		Ports ports = objectMapper.readValue(json, Ports.class);
-		Map<ExposedPort, Binding> bindings = ports.getBindings();
-		assertEquals(bindings.size(), 1);
+	public void deserializingPortWithMultipleBindings() throws Exception {
+		Ports ports = objectMapper.readValue(jsonWithDoubleBindingForOnePort, Ports.class);
+		Map<ExposedPort, Binding[]> map = ports.getBindings();
+		assertEquals(map.size(), 1);
 
-		Binding binding = bindings.get(ExposedPort.tcp(80));
-		assertEquals(binding, new Binding("10.0.0.1", 80));
+		Binding[] bindings = map.get(ExposedPort.tcp(80));
+		assertEquals(bindings.length, 2);
+		assertEquals(bindings[0], new Binding("10.0.0.1", 80));
+		assertEquals(bindings[1], new Binding("10.0.0.2", 80));
 	}
 	
 	@Test
-	public void serializePort() throws Exception {
-		Ports ports = new Ports(ExposedPort.tcp(80), new Binding("10.0.0.1", 80));
-		String expectedJson = "{\"80/tcp\":[{\"HostIp\":\"10.0.0.1\",\"HostPort\":\"80\"}]}";
-		assertEquals(objectMapper.writeValueAsString(ports), expectedJson);
+	public void serializingPortWithMultipleBindings() throws Exception {
+		Ports ports = new Ports();
+		ports.bind(ExposedPort.tcp(80), new Binding("10.0.0.1", 80));
+		ports.bind(ExposedPort.tcp(80), new Binding("10.0.0.2", 80));
+		assertEquals(objectMapper.writeValueAsString(ports), jsonWithDoubleBindingForOnePort);
 	}
 	
 }

--- a/src/test/java/com/github/dockerjava/core/command/StartContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/StartContainerCmdImplTest.java
@@ -163,6 +163,7 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
 		Ports portBindings = new Ports();
 		portBindings.bind(tcp22, Ports.Binding(11022));
 		portBindings.bind(tcp23, Ports.Binding(11023));
+		portBindings.bind(tcp23, Ports.Binding(11024));
 
 		dockerClient.startContainerCmd(container.getId()).withPortBindings(portBindings).exec();
 
@@ -172,11 +173,14 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
 		assertThat(Arrays.asList(inspectContainerResponse.getConfig().getExposedPorts()),
 				contains(tcp22, tcp23));
 
-		assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp22),
+		assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp22)[0],
 				is(equalTo(Ports.Binding(11022))));
 
-		assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23),
+		assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23)[0],
 				is(equalTo(Ports.Binding(11023))));
+
+		assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23)[1],
+				is(equalTo(Ports.Binding(11024))));
 
 	}
 


### PR DESCRIPTION
docker-java currently maps the Docker API elements _.HostConfig.PortBindings_ and _.NetworkSettings.Ports_ to a `Map<ExposedPort, Binding>`. This is incorrect. There may be multiple Bindings per ExposedPort. The API element is an array.

To illustrate, create a container with `docker run -d -p 80:80 -p 81:80 eboraas/apache:latest`. Docker remote API will report

> "PortBindings":{"80/tcp":**[**{"HostIp":"","HostPort":"80"}**,**{"HostIp":"","HostPort":"81"}**]**}
> "Ports":{"443/tcp":null,"80/tcp":**[**{"HostIp":"0.0.0.0"**,**"HostPort":"80"},{"HostIp":"0.0.0.0","HostPort":"81"}**]**}}

docker-java will only give you access to the first Binding, as shown by the test contributed in d1f31cdfb0716c976eff6051f00fc8896cfc75c8. There is no way to create multiple port bindings per ExposedPort with the current state of docker-java.

This PR changes the type used for storing port bindings to `Map<ExposedPort, Binding[]>`, solving both problems.
