### PR TITLE
Loading of custom DockerCmdExecFactory

### DIFF
--- a/src/main/java/com/github/dockerjava/core/DockerClientBuilder.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientBuilder.java
@@ -11,13 +11,14 @@ public class DockerClientBuilder {
 	private static ServiceLoader<DockerCmdExecFactory> serviceLoader = ServiceLoader.load(DockerCmdExecFactory.class);
 
 	private DockerClientImpl dockerClient = null;
+	private DockerCmdExecFactory dockerCmdExecFactory = null;
 
 	private DockerClientBuilder(DockerClientImpl dockerClient) {
 		this.dockerClient = dockerClient;
 	}
 
 	public static DockerClientBuilder getInstance() {
-		return new DockerClientBuilder(withDefaultDockerCmdExecFactory(DockerClientImpl.getInstance()));
+		return new DockerClientBuilder(DockerClientImpl.getInstance());
 	}
 	
 	public static DockerClientBuilder getInstance(DockerClientConfigBuilder dockerClientConfigBuilder) {
@@ -25,22 +26,13 @@ public class DockerClientBuilder {
 	}
 
 	public static DockerClientBuilder getInstance(DockerClientConfig dockerClientConfig) {
-		return new DockerClientBuilder(withDefaultDockerCmdExecFactory(DockerClientImpl
-				.getInstance(dockerClientConfig)));
+		return new DockerClientBuilder(DockerClientImpl
+				.getInstance(dockerClientConfig));
 	}
 
 	public static DockerClientBuilder getInstance(String serverUrl) {
-		return new DockerClientBuilder(withDefaultDockerCmdExecFactory(DockerClientImpl
-				.getInstance(serverUrl)));
-	}
-
-	private static DockerClientImpl withDefaultDockerCmdExecFactory(
-			DockerClientImpl dockerClient) {
-		
-		DockerCmdExecFactory dockerCmdExecFactory = getDefaultDockerCmdExecFactory();
-		
-		return dockerClient
-				.withDockerCmdExecFactory(dockerCmdExecFactory);
+		return new DockerClientBuilder(DockerClientImpl
+				.getInstance(serverUrl));
 	}
 
 	public static DockerCmdExecFactory getDefaultDockerCmdExecFactory() {
@@ -53,12 +45,18 @@ public class DockerClientBuilder {
 
 	public DockerClientBuilder withDockerCmdExecFactory(
 			DockerCmdExecFactory dockerCmdExecFactory) {
-		dockerClient = dockerClient
-				.withDockerCmdExecFactory(dockerCmdExecFactory);
+		this.dockerCmdExecFactory = dockerCmdExecFactory;
 		return this;
 	}
 
 	public DockerClient build() {
+	        if(dockerCmdExecFactory != null) {
+	            dockerClient.withDockerCmdExecFactory(dockerCmdExecFactory);
+	        }
+	        else {
+	            dockerClient.withDockerCmdExecFactory(getDefaultDockerCmdExecFactory());
+	        }
+	        
 		return dockerClient;
 	}
 }


### PR DESCRIPTION
The DockerCmdExecFactory is accessed through the Java ServiceLoader. However, there are situations especially in an OSGi environment where the default implementation may not be available due to different classpath architectures.

The DockerClientBuilder does allow for a custom DockerCmdExecFactory to be specified, but only after attempting to load the default. An exception is thrown if the default is not found, otherwise the factory is set and initiated. 

If a custom implementation is specified, initialization occurs twice (once for the default and subsequently for the custom implementation). This PR initiates the DockerCmdExecFactory in the DockerClient once at build time
