### PR TITLE
Add travis-ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+jdk:
+  - openjdk7
+  - oraclejdk7


### PR DESCRIPTION
This makes the DockerClientBuilder compile again (see #90 ). I also added a commit to configure travis-ci, so that in future pull requests basic correctness will be checked automatically (see #91). You still need to enable travis-ci to watch your repository, though.
