### PR TITLE
list filtered images as described in the remote api docs

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/ListImagesCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/ListImagesCmd.java
@@ -8,18 +8,18 @@ import com.github.dockerjava.api.model.Image;
  * List images
  *
  * @param showAll - Show all images (by default filter out the intermediate images used to build)
- * @param filter - TODO: undocumented in docker remote api reference
+ * @param filters - a json encoded value of the filters (a map[string][]string) to process on the images list.
  */
 public interface ListImagesCmd extends DockerCmd<List<Image>> {
 
-	public String getFilter();
+	public String getFilters();
 
 	public boolean hasShowAllEnabled();
 
 	public ListImagesCmd withShowAll(boolean showAll);
 
-	public ListImagesCmd withFilter(String filter);
-	
+	public ListImagesCmd withFilters(String filters);
+
 	public static interface Exec extends DockerCmdExec<ListImagesCmd, List<Image>> {
 	}
 

--- a/src/main/java/com/github/dockerjava/core/command/ListImagesCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ListImagesCmdImpl.java
@@ -11,21 +11,21 @@ import com.google.common.base.Preconditions;
  * List images
  *
  * @param showAll - Show all images (by default filter out the intermediate images used to build)
- * @param filter - TODO: undocumented in docker remote api reference
+ * @param filters - a json encoded value of the filters (a map[string][]string) to process on the images list.
  */
 public class ListImagesCmdImpl extends AbstrDockerCmd<ListImagesCmd, List<Image>> implements ListImagesCmd  {
 
-	private String filter;
-	
+	private String filters;
+
 	private boolean showAll = false;
-	
+
 	public ListImagesCmdImpl(ListImagesCmd.Exec exec) {
 		super(exec);
 	}
 
     @Override
-	public String getFilter() {
-        return filter;
+	public String getFilters() {
+        return filters;
     }
 
     @Override
@@ -40,9 +40,9 @@ public class ListImagesCmdImpl extends AbstrDockerCmd<ListImagesCmd, List<Image>
 	}
 
 	@Override
-	public ListImagesCmd withFilter(String filter) {
-		Preconditions.checkNotNull(filter, "filter was not specified");
-		this.filter = filter;
+	public ListImagesCmd withFilters(String filter) {
+		Preconditions.checkNotNull(filter, "filters have not been specified");
+		this.filters = filter;
 		return this;
 	}
 
@@ -50,7 +50,7 @@ public class ListImagesCmdImpl extends AbstrDockerCmd<ListImagesCmd, List<Image>
     public String toString() {
         return new StringBuilder("images ")
             .append(showAll ? "--all=true" : "")
-            .append(filter != null ? "--filter " + filter : "")
+            .append(filters != null ? "--filter " + filters : "")
             .toString();
     }
 }

--- a/src/main/java/com/github/dockerjava/jaxrs/ListImagesCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/ListImagesCmdExec.java
@@ -6,16 +6,19 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 
+import com.google.common.net.UrlEscapers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.dockerjava.api.command.ListImagesCmd;
 import com.github.dockerjava.api.model.Image;
 
+import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
+
 public class ListImagesCmdExec extends AbstrDockerCmdExec<ListImagesCmd, List<Image>> implements ListImagesCmd.Exec {
-	
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(ListImagesCmdExec.class);
-	
+
 	public ListImagesCmdExec(WebTarget baseResource) {
 		super(baseResource);
 	}
@@ -24,15 +27,17 @@ public class ListImagesCmdExec extends AbstrDockerCmdExec<ListImagesCmd, List<Im
 	protected List<Image> execute(ListImagesCmd command) {
 		WebTarget webResource = getBaseResource()
                 .path("/images/json")
-                .queryParam("filter", command.getFilter())
+                .queryParam("filters", urlPathSegmentEscaper().escape(command.getFilters()))
                 .queryParam("all", command.hasShowAllEnabled() ? "1" : "0");
 
 		LOGGER.trace("GET: {}", webResource);
-		
-		List<Image> images = webResource.request().accept(MediaType.APPLICATION_JSON).get(new GenericType<List<Image>>() {
-		});
+
+		List<Image> images = webResource.request()
+				.accept(MediaType.APPLICATION_JSON)
+				.get(new GenericType<List<Image>>() {
+				});
 		LOGGER.trace("Response: {}", images);
-		
+
 		return images;
 	}
 

--- a/src/test/java/com/github/dockerjava/client/AbstractDockerClientTest.java
+++ b/src/test/java/com/github/dockerjava/client/AbstractDockerClientTest.java
@@ -20,7 +20,7 @@ import java.net.DatagramSocket;
 import java.net.ServerSocket;
 
 public abstract class AbstractDockerClientTest extends Assert {
-	
+
 	public static final Logger LOG = LoggerFactory
 			.getLogger(AbstractDockerClientTest.class);
     public static final String DOCKER_JAVA = "dockerjava";
@@ -39,8 +39,8 @@ public abstract class AbstractDockerClientTest extends Assert {
 		LOG.info("Pulling image 'busybox'");
 		// need to block until image is pulled completely
 		asString(dockerClient.pullImageCmd("busybox").withTag("latest").exec());
-		
-		
+
+
 
 		assertNotNull(dockerClient);
 		LOG.info("======================= END OF BEFORETEST =======================\n\n");
@@ -75,7 +75,7 @@ public abstract class AbstractDockerClientTest extends Assert {
 
 		for (String container : dockerCmdExecFactory.getContainerNames()) {
 			LOG.info("Cleaning up temporary container {}", container);
-			
+
 			try {
 				dockerClient.removeContainerCmd(container).withForce().exec();
 			} catch (DockerException ignore) {
@@ -90,17 +90,17 @@ public abstract class AbstractDockerClientTest extends Assert {
 			} catch (DockerException ignore) {
 				ignore.printStackTrace();
 			}
-		}	
-		
+		}
+
 		LOG.info(
 				"################################## END OF {} ##################################\n",
 				result.getName());
 	}
 
 	protected String asString(InputStream response)  {
-	
+
 		StringWriter logwriter = new StringWriter();
-        
+
 		try {
 			LineIterator itr = IOUtils.lineIterator(
 					response, "UTF-8");
@@ -110,7 +110,7 @@ public abstract class AbstractDockerClientTest extends Assert {
 				logwriter.write(line + (itr.hasNext() ? "\n" : ""));
 				//LOG.info("line: "+line);
 			}
-			
+
 			return logwriter.toString();
 		} catch (IOException e) {
 			throw new RuntimeException(e);
@@ -118,12 +118,12 @@ public abstract class AbstractDockerClientTest extends Assert {
 			IOUtils.closeQuietly(response);
 		}
 	}
-	
+
 	// UTIL
 
 	/**
 	 * Checks to see if a specific port is available.
-	 * 
+	 *
 	 * @param port
 	 *            the port to check for availability
 	 */

--- a/src/test/java/com/github/dockerjava/core/command/RemoveImageCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/RemoveImageCmdImplTest.java
@@ -59,11 +59,11 @@ public class RemoveImageCmdImplTest extends AbstractDockerClientTest {
 		LOG.info("Created container: {}", container.toString());
 		assertThat(container.getId(), not(isEmptyString()));
 		dockerClient.startContainerCmd(container.getId()).exec();
-		
-		LOG.info("Commiting container {}", container.toString());
+
+		LOG.info("Committing container {}", container.toString());
 		String imageId = dockerClient
 				.commitCmd(container.getId()).exec();
-	
+
 		dockerClient.stopContainerCmd(container.getId()).exec();
 		dockerClient.killContainerCmd(container.getId()).exec();
 		dockerClient.removeContainerCmd(container.getId()).exec();
@@ -72,7 +72,7 @@ public class RemoveImageCmdImplTest extends AbstractDockerClientTest {
 		dockerClient.removeImageCmd(imageId).exec();
 
 		List<Container> containers = dockerClient.listContainersCmd().withShowAll(true).exec();
-		
+
 		Matcher matcher = not(hasItem(hasField("id", startsWith(imageId))));
 		assertThat(containers, matcher);
 	}


### PR DESCRIPTION
This makes the `--filter` parameter work for the list images command. See https://docs.docker.com/reference/api/docker_remote_api_v1.15/#list-images for details.

The significant change is the renaming from `filter` to `filters`. A user has to provide the desired filters as json object, the encoding is performed transparently by the docker-java library. The `listDanglingImages` test should be a good example.

Attention: this is an api change!
