### PR TITLE
Downgraded jackson-jaxrs dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 		<jersey.version>2.11</jersey.version>
 		<jersey-apache-client4.version>1.9</jersey-apache-client4.version>
 
-		<jackson-jaxrs.version>2.3.3</jackson-jaxrs.version>
+		<jackson-jaxrs.version>2.1.2</jackson-jaxrs.version>
 
 		<httpclient.version>4.2.5</httpclient.version>
 		<commons-compress.version>1.5</commons-compress.version>


### PR DESCRIPTION
For better compatibility in jar-conflict szenarios I'd like to suggest to use jackson 2.1.2 as it seems that no 2.3.3 methods are in use yet.
