### PR TITLE
Support tag in push image command

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/PushImageCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/PushImageCmd.java
@@ -14,12 +14,19 @@ public interface PushImageCmd extends DockerCmd<InputStream>{
 
 	public String getName();
 
+	public String getTag();
+
 	/**
 	 * @param name The name, e.g. "alexec/busybox" or just "busybox" if you want to default. Not null.
 	 */
 	public PushImageCmd withName(String name);
 	
-	public AuthConfig getAuthConfig();
+    /**
+     * @param tag The image's tag. Not null.
+     */
+    public PushImageCmd withTag(String tag);
+
+    public AuthConfig getAuthConfig();
 	
 	public PushImageCmd withAuthConfig(AuthConfig authConfig);
 

--- a/src/main/java/com/github/dockerjava/core/command/PushImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/PushImageCmdImpl.java
@@ -14,16 +14,22 @@ import com.google.common.base.Preconditions;
  */
 public class PushImageCmdImpl extends AbstrAuthCfgDockerCmd<PushImageCmd, InputStream> implements PushImageCmd  {
 
-	private String name;
+    private String name;
+    private String tag;
 
-	public PushImageCmdImpl(PushImageCmd.Exec exec, String name) {
-		super(exec);
-		withName(name);
-	}
+    public PushImageCmdImpl(PushImageCmd.Exec exec, String name) {
+    	super(exec);
+    	withName(name);
+    }
 
     @Override
 	public String getName() {
         return name;
+    }
+
+    @Override
+    public String getTag() {
+        return tag;
     }
 
     /**
@@ -36,6 +42,16 @@ public class PushImageCmdImpl extends AbstrAuthCfgDockerCmd<PushImageCmd, InputS
 		return this;
 	}
 
+    /**
+     * @param tag The image's tag. Can be null or empty.
+     */
+    @Override
+    public PushImageCmd withTag(String tag) {
+        Preconditions.checkNotNull(tag, "tag was not specified");
+        this.tag = tag;
+        return this;
+    }
+
     @Override
     public String toString() {
         return new StringBuilder("push ")
@@ -46,7 +62,7 @@ public class PushImageCmdImpl extends AbstrAuthCfgDockerCmd<PushImageCmd, InputS
     /**
      * @throws NotFoundException No such image
      */
-	@Override
+    @Override
     public InputStream exec() throws NotFoundException {
     	return super.exec();
     }

--- a/src/main/java/com/github/dockerjava/jaxrs/PushImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/PushImageCmdExec.java
@@ -24,7 +24,8 @@ public class PushImageCmdExec extends AbstrDockerCmdExec<PushImageCmd, InputStre
 
 	@Override
 	protected InputStream execute(PushImageCmd command) {
-		WebTarget webResource = getBaseResource().path("/images/" + name(command) + "/push");
+		WebTarget webResource = getBaseResource().path("/images/" + name(command) + "/push")
+		    .queryParam("tag", command.getTag());
 
 		final String registryAuth = registryAuth(command.getAuthConfig());
 		LOGGER.trace("POST: {}", webResource);


### PR DESCRIPTION
Starting from https://docs.docker.com/reference/api/docker_remote_api_v1.11/, push a image to the registry support tag in query parameter. 

It is missing in current implementation. Adding the support for it now.

See issue 108 opened:

https://github.com/docker-java/docker-java/issues/108
