### PR TITLE
Allow SSL configuration from pre-existing keystore to be used

### DIFF
--- a/src/main/java/com/github/dockerjava/core/KeystoreSSLConfig.java
+++ b/src/main/java/com/github/dockerjava/core/KeystoreSSLConfig.java
@@ -1,0 +1,133 @@
+package com.github.dockerjava.core;
+
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * An SSL Config that is based on an pre-existing or pre-loaded KeyStore.
+ */
+public class KeystoreSSLConfig implements SSLConfig, Serializable {
+
+  private final KeyStore keystore;
+  private final String keystorePassword;
+
+  /**
+   * @param keystore a KeyStore
+   * @param keystorePassword key password
+   */
+  public KeystoreSSLConfig(KeyStore keystore, String keystorePassword) {
+    this.keystorePassword = keystorePassword;
+    Preconditions.checkNotNull(keystore);
+    this.keystore = keystore;
+  }
+
+  /**
+   *
+   * @param pfxFile a PKCS12 file
+   * @param password Password for the keystore
+   * @throws KeyStoreException
+   * @throws IOException
+   * @throws CertificateException
+   * @throws NoSuchAlgorithmException
+   */
+  public KeystoreSSLConfig(File pfxFile, String password)
+      throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
+    Preconditions.checkNotNull(pfxFile);
+    Preconditions.checkNotNull(password);
+    keystore = KeyStore.getInstance("pkcs12");
+    keystore.load(new FileInputStream(pfxFile), password.toCharArray());
+    keystorePassword = password;
+  }
+
+
+  /**
+   * Get the SSL Context out of the keystore.
+   * @return java SSLContext
+   * @throws KeyManagementException
+   * @throws UnrecoverableKeyException
+   * @throws NoSuchAlgorithmException
+   * @throws KeyStoreException
+   */
+  @Override
+  public SSLContext getSSLContext()
+      throws KeyManagementException, UnrecoverableKeyException, NoSuchAlgorithmException,
+             KeyStoreException {
+
+    final SSLContext context = SSLContext.getInstance("TLS");
+
+    String httpProtocols = System.getProperty("https.protocols");
+    System.setProperty("https.protocols", "TLSv1");
+
+    if (httpProtocols != null)
+      System.setProperty("https.protocols", httpProtocols);
+
+    final KeyManagerFactory
+        keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+    keyManagerFactory.init(keystore, keystorePassword.toCharArray());
+    context.init(keyManagerFactory.getKeyManagers(), new TrustManager[]{
+        new X509TrustManager() {
+          @Override
+          public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[]{};
+          }
+
+          @Override
+          public void checkClientTrusted(final X509Certificate[] arg0, final String arg1) {
+
+          }
+
+          @Override
+          public void checkServerTrusted(final X509Certificate[] arg0, final String arg1) {
+
+          }
+        }
+    }, new SecureRandom());
+
+    return context;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    KeystoreSSLConfig that = (KeystoreSSLConfig) o;
+
+    return keystore.equals(that.keystore);
+
+  }
+
+  @Override
+  public int hashCode() {
+    return keystore.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("keystore", keystore)
+        .toString();
+  }
+}

--- a/src/main/java/com/github/dockerjava/core/LocalDirectorySSLConfig.java
+++ b/src/main/java/com/github/dockerjava/core/LocalDirectorySSLConfig.java
@@ -1,0 +1,101 @@
+package com.github.dockerjava.core;
+
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+
+import com.github.dockerjava.api.DockerClientException;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.glassfish.jersey.SslConfigurator;
+
+import java.io.Serializable;
+import java.security.KeyStore;
+import java.security.Security;
+
+import javax.net.ssl.SSLContext;
+
+/**
+ * SSL Config from local files.
+ */
+public class LocalDirectorySSLConfig implements SSLConfig, Serializable {
+
+  private final String dockerCertPath;
+
+  public LocalDirectorySSLConfig(String dockerCertPath) {
+    Preconditions.checkNotNull(dockerCertPath);
+    this.dockerCertPath = dockerCertPath;
+  }
+
+  public String getDockerCertPath() {
+    return dockerCertPath;
+  }
+
+  @Override
+  public SSLContext getSSLContext() {
+
+    boolean certificatesExist = CertificateUtils.verifyCertificatesExist(dockerCertPath);
+
+    if (certificatesExist) {
+
+      try {
+
+        Security.addProvider(new BouncyCastleProvider());
+
+        KeyStore keyStore = CertificateUtils.createKeyStore(dockerCertPath);
+        KeyStore trustStore = CertificateUtils.createTrustStore(dockerCertPath);
+
+        // properties acrobatics not needed for java > 1.6
+        String httpProtocols = System.getProperty("https.protocols");
+        System.setProperty("https.protocols", "TLSv1");
+        SslConfigurator sslConfig = SslConfigurator.newInstance(true);
+        if (httpProtocols != null) {
+          System.setProperty("https.protocols", httpProtocols);
+        }
+
+        sslConfig.keyStore(keyStore);
+        sslConfig.keyStorePassword("docker");
+        sslConfig.trustStore(trustStore);
+
+        return sslConfig.createSSLContext();
+
+
+      } catch (Exception e) {
+        throw new DockerClientException(e.getMessage(), e);
+      }
+
+    }
+
+    return null;
+
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    LocalDirectorySSLConfig that = (LocalDirectorySSLConfig) o;
+
+    if (!dockerCertPath.equals(that.dockerCertPath)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return dockerCertPath.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("dockerCertPath", dockerCertPath)
+        .toString();
+  }
+}

--- a/src/main/java/com/github/dockerjava/core/SSLConfig.java
+++ b/src/main/java/com/github/dockerjava/core/SSLConfig.java
@@ -1,0 +1,22 @@
+package com.github.dockerjava.core;
+
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+
+import javax.net.ssl.SSLContext;
+
+/**
+ * Get an SSL Config. Allows for various different implementations.
+ */
+public interface SSLConfig {
+
+  /**
+   * Get the SSL Context, from wherever it comes (file, keystore).
+   * @return an SSL context.
+   */
+  SSLContext getSSLContext()
+      throws KeyManagementException, UnrecoverableKeyException, NoSuchAlgorithmException,
+             KeyStoreException;
+}

--- a/src/test/java/com/github/dockerjava/core/DockerClientConfigTest.java
+++ b/src/test/java/com/github/dockerjava/core/DockerClientConfigTest.java
@@ -16,12 +16,12 @@ public class DockerClientConfigTest {
     public static final DockerClientConfig EXAMPLE_CONFIG = newExampleConfig();
 
     private static DockerClientConfig newExampleConfig() {
-        return new DockerClientConfig(URI.create("http://foo"), "bar", "baz", "qux", "blam", "wham", "flim", "flam", 877, false);
+        return new DockerClientConfig(URI.create("http://foo"), "bar", "baz", "qux", "blam", "wham", "flam", 877, false, new LocalDirectorySSLConfig("flim"));
     }
 
     @Test
     public void string() throws Exception {
-        assertEquals("DockerClientConfig{uri=http://foo, version='bar', username='baz', password='qux', email='blam', serverAddress='wham', dockerCertPath='flim', dockerCfgPath='flam', readTimeout=877, loggingFilterEnabled=false}",
+        assertEquals("DockerClientConfig{uri=http://foo, version='bar', username='baz', password='qux', email='blam', serverAddress='wham', dockerCfgPath='flam', sslConfig='LocalDirectorySSLConfig{dockerCertPath=flim}', readTimeout=877, loggingFilterEnabled=false}",
                 EXAMPLE_CONFIG.toString());
     }
 
@@ -104,8 +104,8 @@ public class DockerClientConfigTest {
         assertEquals(config.getServerAddress(), AuthConfig.DEFAULT_SERVER_ADDRESS);
         assertEquals(config.getVersion(), null);
         assertEquals(config.isLoggingFilterEnabled(), true);
-        assertEquals(config.getDockerCertPath(), "someHomeDir/.docker");
         assertEquals(config.getDockerCfgPath(), "someHomeDir/.dockercfg");
+        assertEquals( ((LocalDirectorySSLConfig)config.getSslConfig()).getDockerCertPath(), "someHomeDir/.docker");
     }
 
     @Test

--- a/src/test/java/com/github/dockerjava/core/DockerClientImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/DockerClientImplTest.java
@@ -10,7 +10,7 @@ public class DockerClientImplTest {
     @Test
     public void configuredInstanceAuthConfig() throws Exception {
         // given a config with null serverAddress
-        DockerClientConfig dockerClientConfig = new DockerClientConfig(null, null, "", "", "", null, null, null, 0, false);
+        DockerClientConfig dockerClientConfig = new DockerClientConfig(null, null, "", "", "", null, null,  0, false, null);
         DockerClientImpl dockerClient = DockerClientImpl.getInstance(dockerClientConfig);
 
         // when we get the auth config


### PR DESCRIPTION
Rather than assuming that the relevant keys are present in the local filesystem.
