### PR TITLE
support DOCKER_TLS_VERIFY to detect ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ In your application, e.g.
 ##### System Environment
 
     export DOCKER_URL=http://localhost:2376
-    
-Note: we also auto-detect defaults. If you use `DOCKER_HOST` we use that value, and if `DOCKER_CERT_PATH` is set, we switch to SSL.
 
-##### File System  
+Note: we also auto-detect defaults. If you use `DOCKER_HOST` we use that value, and if `DOCKER_CERT_PATH` or `DOCKER_TLS_VERIFY=1` is set, we switch to SSL.
+
+##### File System
 
 In `$HOME/.docker.io.properties`
 

--- a/src/main/java/com/github/dockerjava/core/DockerClientConfig.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientConfig.java
@@ -21,6 +21,7 @@ public class DockerClientConfig implements Serializable {
 	
 	private static final String DOCKER_HOST_PROPERTY = "DOCKER_HOST";
     private static final String DOCKER_CERT_PATH_PROPERTY = "DOCKER_CERT_PATH";
+    private static final String DOCKER_VERIFY_TLS_PROPERTY = "DOCKER_TLS_VERIFY";
     private static final String DOCKER_IO_URL_PROPERTY = "docker.io.url";
     private static final String DOCKER_IO_VERSION_PROPERTY = "docker.io.version";
     private static final String DOCKER_IO_USERNAME_PROPERTY = "docker.io.username";
@@ -142,7 +143,7 @@ public class DockerClientConfig implements Serializable {
 
     private static String protocol(Map<String, String> env) {
         // if this is set, we assume we need SSL
-        return env.containsKey(DOCKER_CERT_PATH_PROPERTY) ? "https" : "http";
+        return env.containsKey(DOCKER_CERT_PATH_PROPERTY) || "1".equals(env.get(DOCKER_VERIFY_TLS_PROPERTY)) ? "https" : "http";
     }
 
     /**

--- a/src/test/java/com/github/dockerjava/core/DockerClientConfigTest.java
+++ b/src/test/java/com/github/dockerjava/core/DockerClientConfigTest.java
@@ -45,7 +45,7 @@ public class DockerClientConfigTest {
     }
 
     @Test
-    public void environmentDockerHostHttpsAutoDetect() throws Exception {
+    public void environmentDockerHostHttpsAutoDetectByCertPath() throws Exception {
 
         // given docker host in env
         Map<String, String> env = new HashMap<String, String>(System.getenv());
@@ -58,6 +58,38 @@ public class DockerClientConfigTest {
 
         // then the URL is that value with "tcp" changed to "https"
         assertEquals(config.getUri(), URI.create("https://bar:8768"));
+    }
+
+    @Test
+    public void environmentDockerHostHttpsAutoDetectByTlsVerify() throws Exception {
+
+        // given docker host in env
+        Map<String, String> env = new HashMap<String, String>(System.getenv());
+        env.put("DOCKER_HOST", "tcp://bar:8768");
+        // and it looks to be SSL enabled
+        env.put("DOCKER_TLS_VERIFY", "1");
+
+        // when you build a config
+        DockerClientConfig config = buildConfig(env, new Properties());
+
+        // then the URL is that value with "tcp" changed to "https"
+        assertEquals(config.getUri(), URI.create("https://bar:8768"));
+    }
+
+    @Test
+    public void environmentDockerHostWithInvalidTlsVerify() throws Exception {
+
+        // given docker host in env
+        Map<String, String> env = new HashMap<String, String>(System.getenv());
+        env.put("DOCKER_HOST", "tcp://bar:8768");
+        // and it looks to be SSL enabled
+        env.put("DOCKER_TLS_VERIFY", "any value different from '1'");
+
+        // when you build a config
+        DockerClientConfig config = buildConfig(env, new Properties());
+
+        // then the URL is that value with "tcp" changed to "https"
+        assertEquals(config.getUri(), URI.create("http://bar:8768"));
     }
 
     @Test


### PR DESCRIPTION
The docker documentation on 'how to run docker with https' recommends the DOCKER_VERIFY_TLS flag to always enable SSL (see: https://docs.docker.com/articles/https/#secure-by-default).
This pull request detects the DOCKER_VERIFY_TLS setting and will enable https automatically.