### PR TITLE
Allow unauthorized pullImageCmd

### DIFF
--- a/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
@@ -125,7 +125,7 @@ public class DockerClientImpl implements Closeable, DockerClient {
 	@Override
 	public PullImageCmd pullImageCmd(String repository) {
 		return new PullImageCmdImpl(getDockerCmdExecFactory()
-				.createPullImageCmdExec(), repository).withAuthConfig(dockerClientConfig.effectiveAuthConfig(repository));
+				.createPullImageCmdExec(), dockerClientConfig.effectiveAuthConfig(repository), repository);
 	}
 
 	@Override

--- a/src/main/java/com/github/dockerjava/core/command/AbstrAuthCfgDockerCmd.java
+++ b/src/main/java/com/github/dockerjava/core/command/AbstrAuthCfgDockerCmd.java
@@ -15,6 +15,11 @@ import org.apache.commons.codec.binary.Base64;
 public abstract class AbstrAuthCfgDockerCmd<T extends DockerCmd<RES_T>, RES_T> extends
 		AbstrDockerCmd<T, RES_T> {
 
+	public AbstrAuthCfgDockerCmd(DockerCmdExec<T, RES_T> execution, AuthConfig authConfig) {
+		super(execution);
+		withOptionalAuthConfig(authConfig);
+	}
+
 	public AbstrAuthCfgDockerCmd(DockerCmdExec<T, RES_T> execution) {
 		super(execution);
 	}
@@ -25,9 +30,13 @@ public abstract class AbstrAuthCfgDockerCmd<T extends DockerCmd<RES_T>, RES_T> e
 		return authConfig;
 	}
 
-	@SuppressWarnings("unchecked")
 	public T withAuthConfig(AuthConfig authConfig) {
 		Preconditions.checkNotNull(authConfig, "authConfig was not specified");
+		return withOptionalAuthConfig(authConfig);
+	}
+
+	@SuppressWarnings("unchecked")
+	private T withOptionalAuthConfig(AuthConfig authConfig) {
 		this.authConfig = authConfig;
 		return (T)this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/PullImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/PullImageCmdImpl.java
@@ -1,6 +1,7 @@
 package com.github.dockerjava.core.command;
 
 import com.github.dockerjava.api.command.PullImageCmd;
+import com.github.dockerjava.api.model.AuthConfig;
 import com.google.common.base.Preconditions;
 
 import java.io.InputStream;
@@ -14,8 +15,8 @@ public class PullImageCmdImpl extends AbstrAuthCfgDockerCmd<PullImageCmd, InputS
 
     private String repository, tag, registry;
 
-	public PullImageCmdImpl(PullImageCmd.Exec exec, String repository) {
-		super(exec);
+	public PullImageCmdImpl(PullImageCmd.Exec exec, AuthConfig authConfig, String repository) {
+		super(exec, authConfig);
 		withRepository(repository);
 	}
 


### PR DESCRIPTION
In some scenarios it may be desired to omit `X-Registry-Auth` from the image pull request. `PullImageCmdExec` handles null `authConfig` well, but currently it is impossible to create such cmd.

This pull request allows to have `null` in the default `AuthConfig` while still doing null checks in the `withAuthConfig` method if called explicitly.