### PR TITLE
Remove Google Guava as dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
 		<slf4j-api.version>1.7.5</slf4j-api.version>
 		<jsr305.version>1.3.9</jsr305.version>
 		<jnr.unixsocket.version>0.3</jnr.unixsocket.version>
-		<guava.version>18.0</guava.version>
 		<bouncycastle.version>1.51</bouncycastle.version>
 		<unix-socket-factory.version>2014-11-16T14-41-27</unix-socket-factory.version>
 
@@ -148,12 +147,6 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>jul-to-slf4j</artifactId>
 			<version>${slf4j-api.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/github/dockerjava/Preconditions.java
+++ b/src/main/java/com/github/dockerjava/Preconditions.java
@@ -1,0 +1,145 @@
+/* Copyright (C) 2008 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.dockerjava;
+
+
+public final class Preconditions {
+    private Preconditions() {}
+
+    /**
+     * Ensures the truth of an expression involving one or more parameters to the calling method.
+     *
+     * @param expression a boolean expression
+     * @param errorMessageTemplate a template for the exception message should the check fail. The
+     *     message is formed by replacing each {@code %s} placeholder in the template with an
+     *     argument. These are matched by position - the first {@code %s} gets {@code
+     *     errorMessageArgs[0]}, etc.  Unmatched arguments will be appended to the formatted message
+     *     in square braces. Unmatched placeholders will be left as-is.
+     * @param errorMessageArgs the arguments to be substituted into the message template. Arguments
+     *     are converted to strings using {@link String#valueOf(Object)}.
+     * @throws IllegalArgumentException if {@code expression} is false
+     * @throws NullPointerException if the check fails and either {@code errorMessageTemplate} or
+     *     {@code errorMessageArgs} is null (don't let this happen)
+     */
+    public static void checkArgument(boolean expression,
+        String errorMessageTemplate,
+        Object... errorMessageArgs) {
+      if (!expression) {
+        throw new IllegalArgumentException(Preconditions.format(errorMessageTemplate, errorMessageArgs));
+      }
+    }
+
+    /**
+     * Ensures that an object reference passed as a parameter to the calling method is not null.
+     *
+     * @param reference an object reference
+     * @param errorMessage the exception message to use if the check fails; will be converted to a
+     *     string using {@link String#valueOf(Object)}
+     * @return the non-null reference that was validated
+     * @throws NullPointerException if {@code reference} is null
+     */
+    public static <T> T checkNotNull(T reference, Object errorMessage) {
+      if (reference == null) {
+        throw new NullPointerException(String.valueOf(errorMessage));
+      }
+      return reference;
+    }
+
+    /**
+     * Ensures the truth of an expression involving one or more parameters to the calling method.
+     *
+     * @param expression a boolean expression
+     * @param errorMessage the exception message to use if the check fails; will be converted to a
+     *     string using {@link String#valueOf(Object)}
+     * @throws IllegalArgumentException if {@code expression} is false
+     */
+    public static void checkArgument(boolean expression, Object errorMessage) {
+      if (!expression) {
+        throw new IllegalArgumentException(String.valueOf(errorMessage));
+      }
+    }
+
+    /**
+     * Ensures that an object reference passed as a parameter to the calling method is not null.
+     *
+     * @param reference an object reference
+     * @return the non-null reference that was validated
+     * @throws NullPointerException if {@code reference} is null
+     */
+    public static <T> T checkNotNull(T reference) {
+      if (reference == null) {
+        throw new NullPointerException();
+      }
+      return reference;
+    }
+
+    /**
+     * Ensures the truth of an expression involving the state of the calling instance, but not
+     * involving any parameters to the calling method.
+     *
+     * @param expression a boolean expression
+     * @param errorMessage the exception message to use if the check fails; will be converted to a
+     *     string using {@link String#valueOf(Object)}
+     * @throws IllegalStateException if {@code expression} is false
+     */
+    public static void checkState(boolean expression, Object errorMessage) {
+      if (!expression) {
+        throw new IllegalStateException(String.valueOf(errorMessage));
+      }
+    }
+
+    /**
+     * Substitutes each {@code %s} in {@code template} with an argument. These are matched by
+     * position: the first {@code %s} gets {@code args[0]}, etc.  If there are more arguments than
+     * placeholders, the unmatched arguments will be appended to the end of the formatted message in
+     * square braces.
+     *
+     * @param template a non-null string containing 0 or more {@code %s} placeholders.
+     * @param args the arguments to be substituted into the message template. Arguments are converted
+     *     to strings using {@link String#valueOf(Object)}. Arguments can be null.
+     */
+    // Note that this is somewhat-improperly used from Verify.java as well.
+    public static String format(String template, Object... args) {
+      template = String.valueOf(template); // null -> "null"
+
+      // start substituting the arguments into the '%s' placeholders
+      StringBuilder builder = new StringBuilder(template.length() + 16 * args.length);
+      int templateStart = 0;
+      int i = 0;
+      while (i < args.length) {
+        int placeholderStart = template.indexOf("%s", templateStart);
+        if (placeholderStart == -1) {
+          break;
+        }
+        builder.append(template.substring(templateStart, placeholderStart));
+        builder.append(args[i++]);
+        templateStart = placeholderStart + 2;
+      }
+      builder.append(template.substring(templateStart));
+
+      // if we run out of placeholders, append the extra args in square braces
+      if (i < args.length) {
+        builder.append(" [");
+        builder.append(args[i++]);
+        while (i < args.length) {
+          builder.append(", ");
+          builder.append(args[i++]);
+        }
+        builder.append(']');
+      }
+
+      return builder.toString();
+    }
+}

--- a/src/main/java/com/github/dockerjava/api/command/TopContainerResponse.java
+++ b/src/main/java/com/github/dockerjava/api/command/TopContainerResponse.java
@@ -1,8 +1,9 @@
 package com.github.dockerjava.api.command;
 
+import static com.github.dockerjava.jaxrs.util.guava.Guava.join;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Joiner;
 
 /**
  *
@@ -28,17 +29,15 @@ public class TopContainerResponse {
 
 	@Override
     public String toString() {
-		Joiner joiner = Joiner.on("; ").skipNulls();
-
 		StringBuffer buffer = new StringBuffer();
 		buffer.append("[");
 		for(String[] fields: processes) {
-			buffer.append("[" + joiner.join(fields) + "]");
+			buffer.append("[" + join(fields, "; ", true) + "]");
 		}
 		buffer.append("]");
 
         return "TopContainerResponse{" +
-                "titles=" + joiner.join(titles) +
+                "titles=" + join(titles, "; ", true) +
                 ", processes=" + buffer.toString() +
                 '}';
     }

--- a/src/main/java/com/github/dockerjava/api/model/Device.java
+++ b/src/main/java/com/github/dockerjava/api/model/Device.java
@@ -1,10 +1,11 @@
 package com.github.dockerjava.api.model;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Preconditions;
 
 public class Device {
 
@@ -22,10 +23,10 @@ public class Device {
 
 	public Device(String cGroupPermissions, String pathInContainer,
 			String pathOnHost) {
-		Preconditions.checkNotNull(cGroupPermissions,
+		checkNotNull(cGroupPermissions,
 				"cGroupPermissions is null");
-		Preconditions.checkNotNull(pathInContainer, "pathInContainer is null");
-		Preconditions.checkNotNull(pathOnHost, "pathOnHost is null");
+		checkNotNull(pathInContainer, "pathInContainer is null");
+		checkNotNull(pathOnHost, "pathOnHost is null");
 		this.cGroupPermissions = cGroupPermissions;
 		this.pathInContainer = pathInContainer;
 		this.pathOnHost = pathOnHost;

--- a/src/main/java/com/github/dockerjava/api/model/RestartPolicy.java
+++ b/src/main/java/com/github/dockerjava/api/model/RestartPolicy.java
@@ -1,10 +1,11 @@
 package com.github.dockerjava.api.model;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Preconditions;
 
 /**
  * Container restart policy
@@ -36,7 +37,7 @@ public class RestartPolicy {
 	}
 
 	private RestartPolicy(int maximumRetryCount, String name) {
-		Preconditions.checkNotNull(name, "name is null");
+		checkNotNull(name, "name is null");
 		this.maximumRetryCount = maximumRetryCount;
 		this.name = name;
 	}

--- a/src/main/java/com/github/dockerjava/core/DockerClientConfig.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientConfig.java
@@ -1,19 +1,21 @@
 package com.github.dockerjava.core;
 
-import com.github.dockerjava.api.DockerClientException;
-import com.github.dockerjava.api.model.AuthConfig;
-import com.github.dockerjava.core.NameParser.HostnameReposName;
-import com.github.dockerjava.core.NameParser.ReposTag;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
+import static com.github.dockerjava.Preconditions.checkNotNull;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+
+import com.github.dockerjava.api.DockerClientException;
+import com.github.dockerjava.api.model.AuthConfig;
+import com.github.dockerjava.core.NameParser.HostnameReposName;
+import com.github.dockerjava.core.NameParser.ReposTag;
 
 public class DockerClientConfig implements Serializable {
 
@@ -39,18 +41,23 @@ public class DockerClientConfig implements Serializable {
     /**
      * A map from the environment name to the interval name.
      */
-    private static final Map<String, String> ENV_NAME_TO_IO_NAME = ImmutableMap.<String, String>builder()
-            .put("DOCKER_URL", DOCKER_IO_URL_PROPERTY)
-            .put("DOCKER_VERSION", DOCKER_IO_VERSION_PROPERTY)
-            .put("DOCKER_USERNAME", DOCKER_IO_USERNAME_PROPERTY)
-            .put("DOCKER_PASSWORD", DOCKER_IO_PASSWORD_PROPERTY)
-            .put("DOCKER_EMAIL", DOCKER_IO_EMAIL_PROPERTY)
-            .put("DOCKER_SERVER_ADDRESS", DOCKER_IO_SERVER_ADDRESS_PROPERTY)
-            .put("DOCKER_READ_TIMEOUT", DOCKER_IO_READ_TIMEOUT_PROPERTY)
-            .put("DOCKER_LOGGING_FILTER_ENABLED", DOCKER_IO_ENABLE_LOGGING_FILTER_PROPERTY)
-            .put(DOCKER_CERT_PATH_PROPERTY, DOCKER_IO_DOCKER_CERT_PATH_PROPERTY)
-            .put("DOCKER_CFG_PATH", DOCKER_IO_DOCKER_CFG_PATH_PROPERTY)
-            .build();
+    // Immutable ish
+    private static final Map<String, String> ENV_NAME_TO_IO_NAME;
+    static {
+        Map<String, String> m = new HashMap<String, String>();
+        m.put("DOCKER_URL", DOCKER_IO_URL_PROPERTY);
+        m.put("DOCKER_VERSION", DOCKER_IO_VERSION_PROPERTY);
+        m.put("DOCKER_USERNAME", DOCKER_IO_USERNAME_PROPERTY);
+        m.put("DOCKER_PASSWORD", DOCKER_IO_PASSWORD_PROPERTY);
+        m.put("DOCKER_EMAIL", DOCKER_IO_EMAIL_PROPERTY);
+        m.put("DOCKER_SERVER_ADDRESS", DOCKER_IO_SERVER_ADDRESS_PROPERTY);
+        m.put("DOCKER_READ_TIMEOUT", DOCKER_IO_READ_TIMEOUT_PROPERTY);
+        m.put("DOCKER_LOGGING_FILTER_ENABLED", DOCKER_IO_ENABLE_LOGGING_FILTER_PROPERTY);
+        m.put(DOCKER_CERT_PATH_PROPERTY, DOCKER_IO_DOCKER_CERT_PATH_PROPERTY);
+        m.put("DOCKER_CFG_PATH", DOCKER_IO_DOCKER_CFG_PATH_PROPERTY);
+        ENV_NAME_TO_IO_NAME = Collections.unmodifiableMap(m);
+    }
+
     private static final String DOCKER_IO_PROPERTIES_PROPERTY = "docker.io.properties";
     private URI uri;
     private final String version, username, password, email, serverAddress, dockerCfgPath;
@@ -370,7 +377,7 @@ public class DockerClientConfig implements Serializable {
         }
 
         public final DockerClientConfigBuilder withUri(String uri) {
-            Preconditions.checkNotNull(uri, "uri was not specified");
+            checkNotNull(uri, "uri was not specified");
             this.uri = URI.create(uri);
             return this;
         }

--- a/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.github.dockerjava.Preconditions.checkNotNull;
 
 import java.io.Closeable;
 import java.io.File;
@@ -8,10 +8,75 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.command.*;
+import com.github.dockerjava.api.command.AttachContainerCmd;
+import com.github.dockerjava.api.command.AuthCmd;
+import com.github.dockerjava.api.command.BuildImageCmd;
+import com.github.dockerjava.api.command.CommitCmd;
+import com.github.dockerjava.api.command.ContainerDiffCmd;
+import com.github.dockerjava.api.command.CopyFileFromContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.CreateImageCmd;
+import com.github.dockerjava.api.command.DockerCmdExecFactory;
+import com.github.dockerjava.api.command.EventCallback;
+import com.github.dockerjava.api.command.EventsCmd;
+import com.github.dockerjava.api.command.ExecCreateCmd;
+import com.github.dockerjava.api.command.ExecStartCmd;
+import com.github.dockerjava.api.command.InfoCmd;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectImageCmd;
+import com.github.dockerjava.api.command.KillContainerCmd;
+import com.github.dockerjava.api.command.ListContainersCmd;
+import com.github.dockerjava.api.command.ListImagesCmd;
+import com.github.dockerjava.api.command.LogContainerCmd;
+import com.github.dockerjava.api.command.PauseContainerCmd;
+import com.github.dockerjava.api.command.PingCmd;
+import com.github.dockerjava.api.command.PullImageCmd;
+import com.github.dockerjava.api.command.PushImageCmd;
+import com.github.dockerjava.api.command.RemoveContainerCmd;
+import com.github.dockerjava.api.command.RemoveImageCmd;
+import com.github.dockerjava.api.command.RestartContainerCmd;
+import com.github.dockerjava.api.command.SearchImagesCmd;
+import com.github.dockerjava.api.command.StartContainerCmd;
+import com.github.dockerjava.api.command.StopContainerCmd;
+import com.github.dockerjava.api.command.TagImageCmd;
+import com.github.dockerjava.api.command.TopContainerCmd;
+import com.github.dockerjava.api.command.UnpauseContainerCmd;
+import com.github.dockerjava.api.command.VersionCmd;
+import com.github.dockerjava.api.command.WaitContainerCmd;
 import com.github.dockerjava.api.model.AuthConfig;
-import com.github.dockerjava.core.command.*;
-import com.google.common.base.Preconditions;
+import com.github.dockerjava.core.command.AttachContainerCmdImpl;
+import com.github.dockerjava.core.command.AuthCmdImpl;
+import com.github.dockerjava.core.command.BuildImageCmdImpl;
+import com.github.dockerjava.core.command.CommitCmdImpl;
+import com.github.dockerjava.core.command.ContainerDiffCmdImpl;
+import com.github.dockerjava.core.command.CopyFileFromContainerCmdImpl;
+import com.github.dockerjava.core.command.CreateContainerCmdImpl;
+import com.github.dockerjava.core.command.CreateImageCmdImpl;
+import com.github.dockerjava.core.command.EventsCmdImpl;
+import com.github.dockerjava.core.command.ExecCreateCmdImpl;
+import com.github.dockerjava.core.command.ExecStartCmdImpl;
+import com.github.dockerjava.core.command.InfoCmdImpl;
+import com.github.dockerjava.core.command.InspectContainerCmdImpl;
+import com.github.dockerjava.core.command.InspectImageCmdImpl;
+import com.github.dockerjava.core.command.KillContainerCmdImpl;
+import com.github.dockerjava.core.command.ListContainersCmdImpl;
+import com.github.dockerjava.core.command.ListImagesCmdImpl;
+import com.github.dockerjava.core.command.LogContainerCmdImpl;
+import com.github.dockerjava.core.command.PauseContainerCmdImpl;
+import com.github.dockerjava.core.command.PingCmdImpl;
+import com.github.dockerjava.core.command.PullImageCmdImpl;
+import com.github.dockerjava.core.command.PushImageCmdImpl;
+import com.github.dockerjava.core.command.RemoveContainerCmdImpl;
+import com.github.dockerjava.core.command.RemoveImageCmdImpl;
+import com.github.dockerjava.core.command.RestartContainerCmdImpl;
+import com.github.dockerjava.core.command.SearchImagesCmdImpl;
+import com.github.dockerjava.core.command.StartContainerCmdImpl;
+import com.github.dockerjava.core.command.StopContainerCmdImpl;
+import com.github.dockerjava.core.command.TagImageCmdImpl;
+import com.github.dockerjava.core.command.TopContainerCmdImpl;
+import com.github.dockerjava.core.command.UnpauseContainerCmdImpl;
+import com.github.dockerjava.core.command.VersionCmdImpl;
+import com.github.dockerjava.core.command.WaitContainerCmdImpl;
 
 /**
  * @author Konstantin Pelykh (kpelykh@gmail.com)
@@ -33,7 +98,7 @@ public class DockerClientImpl implements Closeable, DockerClient {
 	}
 
 	private DockerClientImpl(DockerClientConfig dockerClientConfig) {
-		Preconditions.checkNotNull(dockerClientConfig,
+		checkNotNull(dockerClientConfig,
 				"config was not specified");
 		this.dockerClientConfig = dockerClientConfig;
 	}
@@ -58,7 +123,7 @@ public class DockerClientImpl implements Closeable, DockerClient {
 
 	public DockerClientImpl withDockerCmdExecFactory(
 			DockerCmdExecFactory dockerCmdExecFactory) {
-		Preconditions.checkNotNull(dockerCmdExecFactory,
+		checkNotNull(dockerCmdExecFactory,
 				"dockerCmdExecFactory was not specified");
 		this.dockerCmdExecFactory = dockerCmdExecFactory;
 		this.dockerCmdExecFactory.init(dockerClientConfig);
@@ -66,7 +131,7 @@ public class DockerClientImpl implements Closeable, DockerClient {
 	}
 
 	private DockerCmdExecFactory getDockerCmdExecFactory() {
-		Preconditions.checkNotNull(dockerCmdExecFactory,
+		checkNotNull(dockerCmdExecFactory,
 				"dockerCmdExecFactory was not specified");
 		return dockerCmdExecFactory;
 	}

--- a/src/main/java/com/github/dockerjava/core/KeystoreSSLConfig.java
+++ b/src/main/java/com/github/dockerjava/core/KeystoreSSLConfig.java
@@ -1,7 +1,6 @@
 package com.github.dockerjava.core;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
+import static com.github.dockerjava.Preconditions.checkNotNull;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -35,7 +34,7 @@ public class KeystoreSSLConfig implements SSLConfig, Serializable {
    */
   public KeystoreSSLConfig(KeyStore keystore, String keystorePassword) {
     this.keystorePassword = keystorePassword;
-    Preconditions.checkNotNull(keystore);
+    checkNotNull(keystore);
     this.keystore = keystore;
   }
 
@@ -50,8 +49,8 @@ public class KeystoreSSLConfig implements SSLConfig, Serializable {
    */
   public KeystoreSSLConfig(File pfxFile, String password)
       throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
-    Preconditions.checkNotNull(pfxFile);
-    Preconditions.checkNotNull(password);
+    checkNotNull(pfxFile);
+    checkNotNull(password);
     keystore = KeyStore.getInstance("pkcs12");
     keystore.load(new FileInputStream(pfxFile), password.toCharArray());
     keystorePassword = password;
@@ -126,8 +125,10 @@ public class KeystoreSSLConfig implements SSLConfig, Serializable {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("keystore", keystore)
+    return new StringBuilder()
+        .append(this.getClass().getSimpleName()).append("{")
+            .append("keystore=").append(keystore)
+        .append("}")
         .toString();
   }
 }

--- a/src/main/java/com/github/dockerjava/core/LocalDirectorySSLConfig.java
+++ b/src/main/java/com/github/dockerjava/core/LocalDirectorySSLConfig.java
@@ -1,15 +1,17 @@
 package com.github.dockerjava.core;
 
-import com.github.dockerjava.api.DockerClientException;
-import com.google.common.base.Objects;
-import com.google.common.base.Preconditions;
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
+import java.io.Serializable;
+import java.security.Security;
+
+import javax.net.ssl.SSLContext;
+
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.glassfish.jersey.SslConfigurator;
 
-import javax.net.ssl.SSLContext;
-import java.io.Serializable;
-import java.security.KeyStore;
-import java.security.Security;
+import com.github.dockerjava.api.DockerClientException;
+
 
 /**
  * SSL Config from local files.
@@ -19,7 +21,7 @@ public class LocalDirectorySSLConfig implements SSLConfig, Serializable {
   private final String dockerCertPath;
 
   public LocalDirectorySSLConfig(String dockerCertPath) {
-    Preconditions.checkNotNull(dockerCertPath);
+    checkNotNull(dockerCertPath);
     this.dockerCertPath = dockerCertPath;
   }
 
@@ -88,8 +90,10 @@ public class LocalDirectorySSLConfig implements SSLConfig, Serializable {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
-        .add("dockerCertPath", dockerCertPath)
+    return new StringBuilder()
+        .append(this.getClass().getSimpleName()).append("{")
+            .append("dockerCertPath=").append(dockerCertPath)
+        .append("}")
         .toString();
   }
 }

--- a/src/main/java/com/github/dockerjava/core/command/AbstrAuthCfgDockerCmd.java
+++ b/src/main/java/com/github/dockerjava/core/command/AbstrAuthCfgDockerCmd.java
@@ -1,16 +1,15 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import java.io.IOException;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.codec.binary.Base64;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.command.DockerCmd;
 import com.github.dockerjava.api.command.DockerCmdExec;
 import com.github.dockerjava.api.model.AuthConfig;
-
-import com.google.common.base.Preconditions;
-
-import org.apache.commons.codec.binary.Base64;
 
 public abstract class AbstrAuthCfgDockerCmd<T extends DockerCmd<RES_T>, RES_T> extends
 		AbstrDockerCmd<T, RES_T> {
@@ -31,7 +30,7 @@ public abstract class AbstrAuthCfgDockerCmd<T extends DockerCmd<RES_T>, RES_T> e
 	}
 
 	public T withAuthConfig(AuthConfig authConfig) {
-		Preconditions.checkNotNull(authConfig, "authConfig was not specified");
+		checkNotNull(authConfig, "authConfig was not specified");
 		return withOptionalAuthConfig(authConfig);
 	}
 

--- a/src/main/java/com/github/dockerjava/core/command/AbstrDockerCmd.java
+++ b/src/main/java/com/github/dockerjava/core/command/AbstrDockerCmd.java
@@ -1,5 +1,7 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import java.io.IOException;
 
 import org.slf4j.Logger;
@@ -8,7 +10,6 @@ import org.slf4j.LoggerFactory;
 import com.github.dockerjava.api.DockerException;
 import com.github.dockerjava.api.command.DockerCmd;
 import com.github.dockerjava.api.command.DockerCmdExec;
-import com.google.common.base.Preconditions;
 
 public abstract class AbstrDockerCmd<CMD_T extends DockerCmd<RES_T>, RES_T> implements DockerCmd<RES_T> {
     
@@ -17,7 +18,7 @@ public abstract class AbstrDockerCmd<CMD_T extends DockerCmd<RES_T>, RES_T> impl
 	protected DockerCmdExec<CMD_T, RES_T> execution;
 	
 	public AbstrDockerCmd(DockerCmdExec<CMD_T, RES_T> execution) {
-		Preconditions.checkNotNull(execution, "execution was not specified");
+		checkNotNull(execution, "execution was not specified");
 		this.execution = execution;
 	}
 

--- a/src/main/java/com/github/dockerjava/core/command/AttachContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/AttachContainerCmdImpl.java
@@ -1,11 +1,11 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import java.io.InputStream;
 
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.AttachContainerCmd;
-
-import com.google.common.base.Preconditions;
 
 /**
  * Attach to container
@@ -66,7 +66,7 @@ public class AttachContainerCmdImpl extends	AbstrDockerCmd<AttachContainerCmd, I
 
 	@Override
 	public AttachContainerCmd withContainerId(String containerId) {
-		Preconditions.checkNotNull(containerId, "containerId was not specified");
+		checkNotNull(containerId, "containerId was not specified");
 		this.containerId = containerId;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
@@ -1,5 +1,9 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkArgument;
+import static com.github.dockerjava.Preconditions.checkNotNull;
+import static com.github.dockerjava.Preconditions.checkState;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,7 +28,6 @@ import com.github.dockerjava.core.CompressArchiveUtil;
 import com.github.dockerjava.core.GoLangFileMatch;
 import com.github.dockerjava.core.GoLangFileMatchException;
 import com.github.dockerjava.core.GoLangMatchFileFilter;
-import com.google.common.base.Preconditions;
 
 /**
  * 
@@ -49,7 +52,7 @@ public class BuildImageCmdImpl extends
 
 	public BuildImageCmdImpl(BuildImageCmd.Exec exec, File dockerFolder) {
 		super(exec);
-		Preconditions.checkNotNull(dockerFolder, "dockerFolder is null");
+		checkNotNull(dockerFolder, "dockerFolder is null");
 		tarFile = buildDockerFolderTar(dockerFolder);
 		try {
 			withTarInputStream(FileUtils.openInputStream(tarFile));
@@ -61,7 +64,7 @@ public class BuildImageCmdImpl extends
 
 	public BuildImageCmdImpl(BuildImageCmd.Exec exec, InputStream tarInputStream) {
 		super(exec);
-		Preconditions.checkNotNull(tarInputStream, "tarInputStream is null");
+		checkNotNull(tarInputStream, "tarInputStream is null");
 		withTarInputStream(tarInputStream);
 	}
 
@@ -72,14 +75,14 @@ public class BuildImageCmdImpl extends
 
 	@Override
 	public BuildImageCmdImpl withTarInputStream(InputStream tarInputStream) {
-		Preconditions.checkNotNull(tarInputStream, "tarInputStream is null");
+		checkNotNull(tarInputStream, "tarInputStream is null");
 		this.tarInputStream = tarInputStream;
 		return this;
 	}
 
 	@Override
 	public BuildImageCmdImpl withTag(String tag) {
-		Preconditions.checkNotNull(tag, "Tag is null");
+		checkNotNull(tag, "Tag is null");
 		this.tag = tag;
 		return this;
 	}
@@ -157,11 +160,11 @@ public class BuildImageCmdImpl extends
 	}
 
 	protected File buildDockerFolderTar(File dockerFolder) {
-		Preconditions.checkArgument(dockerFolder.exists(),
+		checkArgument(dockerFolder.exists(),
 				"Path %s doesn't exist", dockerFolder);
-		Preconditions.checkArgument(dockerFolder.isDirectory(),
+		checkArgument(dockerFolder.isDirectory(),
 				"Folder %s doesn't exist", dockerFolder);
-		Preconditions.checkState(new File(dockerFolder, "Dockerfile").exists(),
+		checkState(new File(dockerFolder, "Dockerfile").exists(),
 				"Dockerfile doesn't exist in " + dockerFolder);
 
 		// ARCHIVE TAR

--- a/src/main/java/com/github/dockerjava/core/command/CommitCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CommitCmdImpl.java
@@ -1,15 +1,15 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.CommitCmd;
 import com.github.dockerjava.api.model.ExposedPorts;
 import com.github.dockerjava.api.model.Volumes;
 
-import com.google.common.base.Preconditions;
 
 /**
  *
@@ -86,7 +86,7 @@ public class CommitCmdImpl extends AbstrDockerCmd<CommitCmd, String> implements 
 
     @Override
 	public CommitCmdImpl withContainerId(String containerId) {
-    	Preconditions.checkNotNull(containerId, "containerId was not specified");
+        checkNotNull(containerId, "containerId was not specified");
 		this.containerId = containerId;
 		return this;
 	}
@@ -152,7 +152,7 @@ public class CommitCmdImpl extends AbstrDockerCmd<CommitCmd, String> implements 
 
 	@Override
 	public CommitCmdImpl withCmd(String... cmd) {
-		Preconditions.checkNotNull(cmd, "cmd was not specified");
+        checkNotNull(cmd, "cmd was not specified");
 		this.cmd = cmd;
 		return this;
 	}
@@ -165,28 +165,28 @@ public class CommitCmdImpl extends AbstrDockerCmd<CommitCmd, String> implements 
 
 	@Override
 	public CommitCmdImpl withAuthor(String author) {
-		Preconditions.checkNotNull(author, "author was not specified");
+        checkNotNull(author, "author was not specified");
 		this.author = author;
 		return this;
 	}
 
 	@Override
 	public CommitCmdImpl withMessage(String message) {
-		Preconditions.checkNotNull(message, "message was not specified");
+        checkNotNull(message, "message was not specified");
 		this.message = message;
 		return this;
 	}
 
 	@Override
 	public CommitCmdImpl withTag(String tag) {
-		Preconditions.checkNotNull(tag, "tag was not specified");
+        checkNotNull(tag, "tag was not specified");
 		this.tag = tag;
 		return this;
 	}
 
 	@Override
 	public CommitCmdImpl withRepository(String repository) {
-		Preconditions.checkNotNull(repository, "repository was not specified");
+        checkNotNull(repository, "repository was not specified");
 		this.repository = repository;
 		return this;
 	}
@@ -204,7 +204,7 @@ public class CommitCmdImpl extends AbstrDockerCmd<CommitCmd, String> implements 
 
     @Override
 	public CommitCmdImpl withEnv(String... env) {
-    	Preconditions.checkNotNull(env, "env was not specified");
+        checkNotNull(env, "env was not specified");
         this.env = env;
         return this;
     }
@@ -216,7 +216,7 @@ public class CommitCmdImpl extends AbstrDockerCmd<CommitCmd, String> implements 
 
     @Override
 	public CommitCmdImpl withExposedPorts(ExposedPorts exposedPorts) {
-    	Preconditions.checkNotNull(exposedPorts, "exposedPorts was not specified");
+        checkNotNull(exposedPorts, "exposedPorts was not specified");
         this.exposedPorts = exposedPorts;
         return this;
     }
@@ -228,7 +228,7 @@ public class CommitCmdImpl extends AbstrDockerCmd<CommitCmd, String> implements 
 
     @Override
 	public CommitCmdImpl withHostname(String hostname) {
-    	Preconditions.checkNotNull(hostname, "hostname was not specified");
+        checkNotNull(hostname, "hostname was not specified");
         this.hostname = hostname;
         return this;
     }
@@ -240,7 +240,7 @@ public class CommitCmdImpl extends AbstrDockerCmd<CommitCmd, String> implements 
 
     @Override
 	public CommitCmdImpl withMemory(Integer memory) {
-    	Preconditions.checkNotNull(memory, "memory was not specified");
+        checkNotNull(memory, "memory was not specified");
         this.memory = memory;
         return this;
     }
@@ -252,7 +252,7 @@ public class CommitCmdImpl extends AbstrDockerCmd<CommitCmd, String> implements 
 
     @Override
 	public CommitCmdImpl withMemorySwap(Integer memorySwap) {
-    	Preconditions.checkNotNull(memorySwap, "memorySwap was not specified");
+        checkNotNull(memorySwap, "memorySwap was not specified");
         this.memorySwap = memorySwap;
         return this;
     }
@@ -264,7 +264,7 @@ public class CommitCmdImpl extends AbstrDockerCmd<CommitCmd, String> implements 
 
     @Override
 	public CommitCmdImpl withOpenStdin(boolean openStdin) {
-    	Preconditions.checkNotNull(openStdin, "openStdin was not specified");
+    	checkNotNull(openStdin, "openStdin was not specified");
         this.openStdin = openStdin;
         return this;
     }
@@ -276,7 +276,7 @@ public class CommitCmdImpl extends AbstrDockerCmd<CommitCmd, String> implements 
 
     @Override
 	public CommitCmdImpl withPortSpecs(String... portSpecs) {
-    	Preconditions.checkNotNull(portSpecs, "portSpecs was not specified");
+    	checkNotNull(portSpecs, "portSpecs was not specified");
         this.portSpecs = portSpecs;
         return this;
     }
@@ -320,7 +320,7 @@ public class CommitCmdImpl extends AbstrDockerCmd<CommitCmd, String> implements 
 
     @Override
 	public CommitCmdImpl withUser(String user) {
-    	Preconditions.checkNotNull(user, "user was not specified");
+    	checkNotNull(user, "user was not specified");
         this.user = user;
         return this;
     }
@@ -332,7 +332,7 @@ public class CommitCmdImpl extends AbstrDockerCmd<CommitCmd, String> implements 
 
     @Override
 	public CommitCmdImpl withVolumes(Volumes volumes) {
-    	Preconditions.checkNotNull(volumes, "volumes was not specified");
+    	checkNotNull(volumes, "volumes was not specified");
         this.volumes = volumes;
         return this;
     }
@@ -344,7 +344,7 @@ public class CommitCmdImpl extends AbstrDockerCmd<CommitCmd, String> implements 
 
     @Override
 	public CommitCmdImpl withWorkingDir(String workingDir) {
-    	Preconditions.checkNotNull(workingDir, "workingDir was not specified");
+    	checkNotNull(workingDir, "workingDir was not specified");
         this.workingDir = workingDir;
         return this;
     }

--- a/src/main/java/com/github/dockerjava/core/command/ContainerDiffCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ContainerDiffCmdImpl.java
@@ -1,5 +1,7 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import java.util.List;
 
 import com.github.dockerjava.api.DockerException;
@@ -7,8 +9,6 @@ import com.github.dockerjava.api.InternalServerErrorException;
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.ContainerDiffCmd;
 import com.github.dockerjava.api.model.ChangeLog;
-
-import com.google.common.base.Preconditions;
 
 /**
  * Inspect changes on a container's filesystem
@@ -32,7 +32,7 @@ public class ContainerDiffCmdImpl extends AbstrDockerCmd<ContainerDiffCmd, List<
 
     @Override
 	public ContainerDiffCmdImpl withContainerId(String containerId) {
-		Preconditions.checkNotNull(containerId, "containerId was not specified");
+		checkNotNull(containerId, "containerId was not specified");
 		this.containerId = containerId;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/CopyFileFromContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CopyFileFromContainerCmdImpl.java
@@ -1,15 +1,15 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import java.io.InputStream;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.CopyFileFromContainerCmd;
 
-import com.google.common.base.Preconditions;
 
 /**
  *
@@ -44,14 +44,14 @@ public class CopyFileFromContainerCmdImpl extends AbstrDockerCmd<CopyFileFromCon
 
     @Override
 	public CopyFileFromContainerCmdImpl withContainerId(String containerId) {
-		Preconditions.checkNotNull(containerId, "containerId was not specified");
+		checkNotNull(containerId, "containerId was not specified");
 		this.containerId = containerId;
 		return this;
 	}
 
 	@Override
 	public CopyFileFromContainerCmdImpl withResource(String resource) {
-		Preconditions.checkNotNull(resource, "resource was not specified");
+		checkNotNull(resource, "resource was not specified");
 		this.resource = resource;
 		return this;
 	}
@@ -63,7 +63,7 @@ public class CopyFileFromContainerCmdImpl extends AbstrDockerCmd<CopyFileFromCon
 	
 	@Override
 	public CopyFileFromContainerCmdImpl withHostPath(String hostPath) {
-		Preconditions.checkNotNull(hostPath, "hostPath was not specified");
+		checkNotNull(hostPath, "hostPath was not specified");
 		this.hostPath = hostPath;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
@@ -1,5 +1,7 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -14,7 +16,7 @@ import com.github.dockerjava.api.model.ExposedPorts;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.api.model.Volumes;
-import com.google.common.base.Preconditions;
+
 
 /**
  *
@@ -49,13 +51,13 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
 	
 	public CreateContainerCmdImpl(CreateContainerCmd.Exec exec, String image) {
 		super(exec);
-		Preconditions.checkNotNull(image, "image was not specified");
+		checkNotNull(image, "image was not specified");
 		withImage(image);
 	}
 
 	@Override
 	public CreateContainerCmdImpl withName(String name) {
-		Preconditions.checkNotNull(name, "name was not specified");
+		checkNotNull(name, "name was not specified");
         this.name = name;
         return this;
     }
@@ -318,7 +320,7 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     
     @Override
     public CreateContainerCmd withHostConfig(HostConfig hostConfig) {
-    	Preconditions.checkNotNull(hostConfig, "no host config was specified");
+    	checkNotNull(hostConfig, "no host config was specified");
     	this.hostConfig = hostConfig;
     	return this;
     }

--- a/src/main/java/com/github/dockerjava/core/command/CreateImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CreateImageCmdImpl.java
@@ -1,13 +1,13 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import java.io.InputStream;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 import com.github.dockerjava.api.command.CreateImageCmd;
 import com.github.dockerjava.api.command.CreateImageResponse;
-
-import com.google.common.base.Preconditions;
 
 /**
  * Create an image by importing the given stream of a tar file.
@@ -48,7 +48,7 @@ public class CreateImageCmdImpl extends	AbstrDockerCmd<CreateImageCmd, CreateIma
 	 */
 	@Override
 	public CreateImageCmdImpl withRepository(String repository) {
-		Preconditions.checkNotNull(repository, "repository was not specified");
+		checkNotNull(repository, "repository was not specified");
 		this.repository = repository;
 		return this;
 	}
@@ -58,8 +58,7 @@ public class CreateImageCmdImpl extends	AbstrDockerCmd<CreateImageCmd, CreateIma
 	 */
 	@Override
 	public CreateImageCmdImpl withImageStream(InputStream imageStream) {
-		Preconditions
-				.checkNotNull(imageStream, "imageStream was not specified");
+		checkNotNull(imageStream, "imageStream was not specified");
 		this.imageStream = imageStream;
 		return this;
 	}
@@ -69,7 +68,7 @@ public class CreateImageCmdImpl extends	AbstrDockerCmd<CreateImageCmd, CreateIma
 	 */
 	@Override
 	public CreateImageCmdImpl withTag(String tag) {
-		Preconditions.checkNotNull(tag, "tag was not specified");
+		checkNotNull(tag, "tag was not specified");
 		this.tag = tag;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/ExecCreateCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ExecCreateCmdImpl.java
@@ -1,10 +1,11 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.ExecCreateCmd;
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
-import com.google.common.base.Preconditions;
 
 public class ExecCreateCmdImpl extends AbstrDockerCmd<ExecCreateCmd, ExecCreateCmdResponse> implements ExecCreateCmd {
 
@@ -31,7 +32,7 @@ public class ExecCreateCmdImpl extends AbstrDockerCmd<ExecCreateCmd, ExecCreateC
     }
     
     public ExecCreateCmd withContainerId(String containerId) {
-    	Preconditions.checkNotNull(containerId, "containerId was not specified");
+    	checkNotNull(containerId, "containerId was not specified");
         this.containerId = containerId;
         return this;
     }

--- a/src/main/java/com/github/dockerjava/core/command/ExecStartCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ExecStartCmdImpl.java
@@ -1,10 +1,11 @@
 package com.github.dockerjava.core.command;
 
-import com.github.dockerjava.api.NotFoundException;
-import com.github.dockerjava.api.command.ExecStartCmd;
-import com.google.common.base.Preconditions;
+import static com.github.dockerjava.Preconditions.checkNotNull;
 
 import java.io.InputStream;
+
+import com.github.dockerjava.api.NotFoundException;
+import com.github.dockerjava.api.command.ExecStartCmd;
 
 public class ExecStartCmdImpl extends AbstrDockerCmd<ExecStartCmd, InputStream> implements ExecStartCmd {
 
@@ -24,7 +25,7 @@ public class ExecStartCmdImpl extends AbstrDockerCmd<ExecStartCmd, InputStream> 
     
     @Override
 	public ExecStartCmd withExecId(String execId) {
-    	Preconditions.checkNotNull(execId, "execId was not specified");
+    	checkNotNull(execId, "execId was not specified");
 		this.execId = execId;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/InspectContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/InspectContainerCmdImpl.java
@@ -1,10 +1,10 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.InspectContainerCmd;
 import com.github.dockerjava.api.command.InspectContainerResponse;
-
-import com.google.common.base.Preconditions;
 
 /**
  * Inspect the details of a container.
@@ -25,7 +25,7 @@ public class InspectContainerCmdImpl extends AbstrDockerCmd<InspectContainerCmd,
 
     @Override
 	public InspectContainerCmd withContainerId(String containerId) {
-		Preconditions.checkNotNull(containerId, "containerId was not specified");
+		checkNotNull(containerId, "containerId was not specified");
 		this.containerId = containerId;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/InspectImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/InspectImageCmdImpl.java
@@ -1,10 +1,11 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.InspectImageCmd;
 import com.github.dockerjava.api.command.InspectImageResponse;
 
-import com.google.common.base.Preconditions;
 
 /**
  * Inspect the details of an image.
@@ -25,7 +26,7 @@ public class InspectImageCmdImpl extends AbstrDockerCmd<InspectImageCmd, Inspect
 
     @Override
 	public InspectImageCmd withImageId(String imageId) {
-		Preconditions.checkNotNull(imageId, "imageId was not specified");
+		checkNotNull(imageId, "imageId was not specified");
 		this.imageId = imageId;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/KillContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/KillContainerCmdImpl.java
@@ -1,9 +1,10 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.KillContainerCmd;
 
-import com.google.common.base.Preconditions;
 
 /**
  * Kill a running container.
@@ -29,14 +30,14 @@ public class KillContainerCmdImpl extends AbstrDockerCmd<KillContainerCmd, Void>
 
     @Override
 	public KillContainerCmd withContainerId(String containerId) {
-		Preconditions.checkNotNull(containerId, "containerId was not specified");
+		checkNotNull(containerId, "containerId was not specified");
 		this.containerId = containerId;
 		return this;
 	}
 
 	@Override
 	public KillContainerCmd withSignal(String signal) {
-		Preconditions.checkNotNull(signal, "signal was not specified");
+		checkNotNull(signal, "signal was not specified");
 		this.signal = signal;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/ListContainersCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ListContainersCmdImpl.java
@@ -1,11 +1,13 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkArgument;
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import java.util.List;
 
 import com.github.dockerjava.api.command.ListContainersCmd;
 import com.github.dockerjava.api.model.Container;
 
-import com.google.common.base.Preconditions;
 
 /**
  * List containers
@@ -68,21 +70,21 @@ public class ListContainersCmdImpl extends AbstrDockerCmd<ListContainersCmd, Lis
 
 	@Override
 	public ListContainersCmd withLimit(int limit) {
-		Preconditions.checkArgument(limit > 0, "limit must be greater 0");
+		checkArgument(limit > 0, "limit must be greater 0");
 		this.limit = limit;
 		return this;
 	}
 
 	@Override
 	public ListContainersCmd withSince(String since) {
-		Preconditions.checkNotNull(since, "since was not specified");
+		checkNotNull(since, "since was not specified");
 		this.sinceId = since;
 		return this;
 	}
 
 	@Override
 	public ListContainersCmd withBefore(String before) {
-		Preconditions.checkNotNull(before, "before was not specified");
+		checkNotNull(before, "before was not specified");
 		this.beforeId = before;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/ListImagesCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ListImagesCmdImpl.java
@@ -1,11 +1,11 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import java.util.List;
 
 import com.github.dockerjava.api.command.ListImagesCmd;
 import com.github.dockerjava.api.model.Image;
-
-import com.google.common.base.Preconditions;
 
 /**
  * List images
@@ -41,7 +41,7 @@ public class ListImagesCmdImpl extends AbstrDockerCmd<ListImagesCmd, List<Image>
 
 	@Override
 	public ListImagesCmd withFilters(String filter) {
-		Preconditions.checkNotNull(filter, "filters have not been specified");
+		checkNotNull(filter, "filters have not been specified");
 		this.filters = filter;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/LogContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/LogContainerCmdImpl.java
@@ -1,11 +1,11 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import java.io.InputStream;
 
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.LogContainerCmd;
-
-import com.google.common.base.Preconditions;
 
 /**
  * Get container logs
@@ -67,7 +67,7 @@ public class LogContainerCmdImpl extends AbstrDockerCmd<LogContainerCmd, InputSt
 
     @Override
 	public LogContainerCmd withContainerId(String containerId) {
-		Preconditions.checkNotNull(containerId, "containerId was not specified");
+		checkNotNull(containerId, "containerId was not specified");
 		this.containerId = containerId;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/PauseContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/PauseContainerCmdImpl.java
@@ -1,9 +1,9 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.PauseContainerCmd;
-
-import com.google.common.base.Preconditions;
 
 /**
  * Pause a container.
@@ -27,7 +27,7 @@ public class PauseContainerCmdImpl extends AbstrDockerCmd<PauseContainerCmd, Voi
 
     @Override
 	public PauseContainerCmd withContainerId(String containerId) {
-		Preconditions.checkNotNull(containerId, "containerId was not specified");
+		checkNotNull(containerId, "containerId was not specified");
 		this.containerId = containerId;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/PullImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/PullImageCmdImpl.java
@@ -1,10 +1,11 @@
 package com.github.dockerjava.core.command;
 
-import com.github.dockerjava.api.command.PullImageCmd;
-import com.github.dockerjava.api.model.AuthConfig;
-import com.google.common.base.Preconditions;
+import static com.github.dockerjava.Preconditions.checkNotNull;
 
 import java.io.InputStream;
+
+import com.github.dockerjava.api.command.PullImageCmd;
+import com.github.dockerjava.api.model.AuthConfig;
 
 /**
  *
@@ -37,21 +38,21 @@ public class PullImageCmdImpl extends AbstrAuthCfgDockerCmd<PullImageCmd, InputS
 
     @Override
 	public PullImageCmd withRepository(String repository) {
-		Preconditions.checkNotNull(repository, "repository was not specified");
+		checkNotNull(repository, "repository was not specified");
 		this.repository = repository;
 		return this;
 	}
 
 	@Override
 	public PullImageCmd withTag(String tag) {
-		Preconditions.checkNotNull(tag, "tag was not specified");
+		checkNotNull(tag, "tag was not specified");
 		this.tag = tag;
 		return this;
 	}
 
 	@Override
 	public PullImageCmd withRegistry(String registry) {
-		Preconditions.checkNotNull(registry, "registry was not specified");
+		checkNotNull(registry, "registry was not specified");
 		this.registry = registry;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/PushImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/PushImageCmdImpl.java
@@ -1,11 +1,11 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import java.io.InputStream;
 
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.PushImageCmd;
-
-import com.google.common.base.Preconditions;
 
 /**
  * Push the latest image to the repository.
@@ -37,7 +37,7 @@ public class PushImageCmdImpl extends AbstrAuthCfgDockerCmd<PushImageCmd, InputS
 	 */
 	@Override
 	public PushImageCmd withName(String name) {
-		Preconditions.checkNotNull(name, "name was not specified");
+		checkNotNull(name, "name was not specified");
 		this.name = name;
 		return this;
 	}
@@ -47,7 +47,7 @@ public class PushImageCmdImpl extends AbstrAuthCfgDockerCmd<PushImageCmd, InputS
      */
     @Override
     public PushImageCmd withTag(String tag) {
-        Preconditions.checkNotNull(tag, "tag was not specified");
+        checkNotNull(tag, "tag was not specified");
         this.tag = tag;
         return this;
     }

--- a/src/main/java/com/github/dockerjava/core/command/RemoveContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/RemoveContainerCmdImpl.java
@@ -1,9 +1,9 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.RemoveContainerCmd;
-
-import com.google.common.base.Preconditions;
 
 /**
  * Remove a container.
@@ -39,7 +39,7 @@ public class RemoveContainerCmdImpl extends	AbstrDockerCmd<RemoveContainerCmd, V
 
 	@Override
 	public RemoveContainerCmd withContainerId(String containerId) {
-		Preconditions.checkNotNull(containerId, "containerId was not specified");
+		checkNotNull(containerId, "containerId was not specified");
 		this.containerId = containerId;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/RemoveImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/RemoveImageCmdImpl.java
@@ -1,9 +1,9 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.RemoveImageCmd;
-
-import com.google.common.base.Preconditions;
 
 /**
  *
@@ -38,7 +38,7 @@ public class RemoveImageCmdImpl extends AbstrDockerCmd<RemoveImageCmd, Void> imp
 
     @Override
 	public RemoveImageCmd withImageId(String imageId) {
-		Preconditions.checkNotNull(imageId, "imageId was not specified");
+		checkNotNull(imageId, "imageId was not specified");
 		this.imageId = imageId;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/RestartContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/RestartContainerCmdImpl.java
@@ -1,9 +1,10 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkArgument;
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.RestartContainerCmd;
-
-import com.google.common.base.Preconditions;
 
 /**
  * Restart a running container.
@@ -34,14 +35,14 @@ public class RestartContainerCmdImpl extends AbstrDockerCmd<RestartContainerCmd,
 
     @Override
 	public RestartContainerCmd withContainerId(String containerId) {
-		Preconditions.checkNotNull(containerId, "containerId was not specified");
+		checkNotNull(containerId, "containerId was not specified");
 		this.containerId = containerId;
 		return this;
 	}
 
 	@Override
 	public RestartContainerCmd withtTimeout(int timeout) {
-		Preconditions.checkArgument(timeout >= 0, "timeout must be greater or equal 0");
+		checkArgument(timeout >= 0, "timeout must be greater or equal 0");
 		this.timeout = timeout;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/SearchImagesCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/SearchImagesCmdImpl.java
@@ -1,11 +1,11 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import java.util.List;
 
 import com.github.dockerjava.api.command.SearchImagesCmd;
 import com.github.dockerjava.api.model.SearchItem;
-
-import com.google.common.base.Preconditions;
 
 /**
  * Search images
@@ -29,7 +29,7 @@ public class SearchImagesCmdImpl extends AbstrDockerCmd<SearchImagesCmd, List<Se
 
     @Override
 	public SearchImagesCmd withTerm(String term) {
-		Preconditions.checkNotNull(term, "term was not specified");
+		checkNotNull(term, "term was not specified");
 		this.term = term;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/StartContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/StartContainerCmdImpl.java
@@ -1,6 +1,7 @@
 package com.github.dockerjava.core.command;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+import static com.github.dockerjava.Preconditions.checkNotNull;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 
@@ -20,7 +21,7 @@ import com.github.dockerjava.api.model.LxcConf;
 import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.RestartPolicy;
-import com.google.common.base.Preconditions;
+
 
 /**
  * Start a container
@@ -158,7 +159,7 @@ public class StartContainerCmdImpl extends AbstrDockerCmd<StartContainerCmd, Voi
 	@Override
 	@JsonIgnore
 	public StartContainerCmd withBinds(Bind... binds) {
-		Preconditions.checkNotNull(binds, "binds was not specified");
+		checkNotNull(binds, "binds was not specified");
 		this.binds = new Binds(binds);
 		return this;
 	}
@@ -166,21 +167,21 @@ public class StartContainerCmdImpl extends AbstrDockerCmd<StartContainerCmd, Voi
 	@Override
 	@JsonIgnore
 	public StartContainerCmd withLinks(Link... links) {
-		Preconditions.checkNotNull(links, "links was not specified");
+		checkNotNull(links, "links was not specified");
 		this.links = new Links(links);
 		return this;
 	}
 
 	@Override
 	public StartContainerCmd withLxcConf(LxcConf... lxcConf) {
-		Preconditions.checkNotNull(lxcConf, "lxcConf was not specified");
+		checkNotNull(lxcConf, "lxcConf was not specified");
 		this.lxcConf = lxcConf;
 		return this;
 	}
 
 	@Override
 	public StartContainerCmd withPortBindings(Ports portBindings) {
-		Preconditions.checkNotNull(portBindings,
+		checkNotNull(portBindings,
 				"portBindings was not specified");
 		this.portBindings = portBindings;
 		return this;
@@ -188,7 +189,7 @@ public class StartContainerCmdImpl extends AbstrDockerCmd<StartContainerCmd, Voi
 
 	@Override
 	public StartContainerCmd withPortBindings(PortBinding... portBindings) {
-		Preconditions.checkNotNull(portBindings, "portBindings was not specified");
+		checkNotNull(portBindings, "portBindings was not specified");
 		if (this.portBindings == null) {
 			this.portBindings = new Ports();
 		}
@@ -210,65 +211,63 @@ public class StartContainerCmdImpl extends AbstrDockerCmd<StartContainerCmd, Voi
 
 	@Override
 	public StartContainerCmd withDns(String... dns) {
-		Preconditions.checkNotNull(dns, "dns was not specified");
+		checkNotNull(dns, "dns was not specified");
 		this.dns = dns;
 		return this;
 	}
 	
 	@Override
 	public StartContainerCmd withDnsSearch(String... dnsSearch) {
-		Preconditions.checkNotNull(dnsSearch, "dnsSearch was not specified");
+		checkNotNull(dnsSearch, "dnsSearch was not specified");
 		this.dnsSearch = dnsSearch;
 		return this;
 	}
 
 	@Override
 	public StartContainerCmd withVolumesFrom(String volumesFrom) {
-		Preconditions
-				.checkNotNull(volumesFrom, "volumesFrom was not specified");
+		checkNotNull(volumesFrom, "volumesFrom was not specified");
 		this.volumesFrom = volumesFrom;
 		return this;
 	}
 
 	@Override
 	public StartContainerCmd withContainerId(String containerId) {
-		Preconditions
-				.checkNotNull(containerId, "containerId was not specified");
+	    checkNotNull(containerId, "containerId was not specified");
 		this.containerId = containerId;
 		return this;
     }
 
     @Override
 	public StartContainerCmd withNetworkMode(String networkMode) {
-        Preconditions.checkNotNull(networkMode, "networkMode was not specified");
+        checkNotNull(networkMode, "networkMode was not specified");
         this.networkMode = networkMode;
         return this;
     }
     
     @Override
 	public StartContainerCmd withDevices(Device... devices) {
-		Preconditions.checkNotNull(devices, "devices was not specified");
+		checkNotNull(devices, "devices was not specified");
 		this.devices = devices;
 		return this;
 	}
     
     @Override
    	public StartContainerCmd withRestartPolicy(RestartPolicy restartPolicy) {
-   		Preconditions.checkNotNull(restartPolicy, "restartPolicy was not specified");
+   		checkNotNull(restartPolicy, "restartPolicy was not specified");
    		this.restartPolicy = restartPolicy;
    		return this;
    	}
     
     @Override
 	public StartContainerCmd withCapAdd(Capability... capAdd) {
-		Preconditions.checkNotNull(capAdd, "capAdd was not specified");
+		checkNotNull(capAdd, "capAdd was not specified");
 		this.capAdd = capAdd;
 		return this;
 	}
     
     @Override
 	public StartContainerCmd withCapDrop(Capability... capDrop) {
-		Preconditions.checkNotNull(capDrop, "capDrop was not specified");
+		checkNotNull(capDrop, "capDrop was not specified");
 		this.capDrop = capDrop;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/StopContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/StopContainerCmdImpl.java
@@ -1,10 +1,11 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkArgument;
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.NotModifiedException;
 import com.github.dockerjava.api.command.StopContainerCmd;
-
-import com.google.common.base.Preconditions;
 
 /**
  * Stop a running container.
@@ -36,14 +37,14 @@ public class StopContainerCmdImpl extends AbstrDockerCmd<StopContainerCmd, Void>
 
     @Override
 	public StopContainerCmd withContainerId(String containerId) {
-		Preconditions.checkNotNull(containerId, "containerId was not specified");
+		checkNotNull(containerId, "containerId was not specified");
 		this.containerId = containerId;
 		return this;
 	}
 
 	@Override
 	public StopContainerCmd withTimeout(int timeout) {
-		Preconditions.checkArgument(timeout >= 0, "timeout must be greater or equal 0");
+		checkArgument(timeout >= 0, "timeout must be greater or equal 0");
 		this.timeout = timeout;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/TagImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/TagImageCmdImpl.java
@@ -1,8 +1,9 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import com.github.dockerjava.api.command.TagImageCmd;
 
-import com.google.common.base.Preconditions;
 
 /**
  * Tag an image into a repository
@@ -47,21 +48,21 @@ public class TagImageCmdImpl extends AbstrDockerCmd<TagImageCmd, Void> implement
 
     @Override
 	public TagImageCmd withImageId(String imageId) {
-		Preconditions.checkNotNull(imageId, "imageId was not specified");
+		checkNotNull(imageId, "imageId was not specified");
 		this.imageId = imageId;
 		return this;
 	}
 
 	@Override
 	public TagImageCmd withRepository(String repository) {
-		Preconditions.checkNotNull(repository, "repository was not specified");
+		checkNotNull(repository, "repository was not specified");
 		this.repository = repository;
 		return this;
 	}
 
 	@Override
 	public TagImageCmd withTag(String tag) {
-		Preconditions.checkNotNull(tag, "tag was not specified");
+		checkNotNull(tag, "tag was not specified");
 		this.tag = tag;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/TopContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/TopContainerCmdImpl.java
@@ -1,10 +1,10 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.TopContainerCmd;
 import com.github.dockerjava.api.command.TopContainerResponse;
-
-import com.google.common.base.Preconditions;
 
 /**
  * List processes running inside a container
@@ -32,7 +32,7 @@ public class TopContainerCmdImpl extends AbstrDockerCmd<TopContainerCmd, TopCont
 
     @Override
 	public TopContainerCmd withContainerId(String containerId) {
-		Preconditions.checkNotNull(containerId, "containerId was not specified");
+		checkNotNull(containerId, "containerId was not specified");
 		this.containerId = containerId;
 		return this;
 	}
@@ -40,7 +40,7 @@ public class TopContainerCmdImpl extends AbstrDockerCmd<TopContainerCmd, TopCont
 
 	@Override
 	public TopContainerCmd withPsArgs(String psArgs) {
-		Preconditions.checkNotNull(psArgs, "psArgs was not specified");
+		checkNotNull(psArgs, "psArgs was not specified");
 		this.psArgs = psArgs;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/UnpauseContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/UnpauseContainerCmdImpl.java
@@ -1,9 +1,9 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.UnpauseContainerCmd;
-
-import com.google.common.base.Preconditions;
 
 /**
  * Unpause a container.
@@ -27,7 +27,7 @@ public class UnpauseContainerCmdImpl extends AbstrDockerCmd<UnpauseContainerCmd,
 
     @Override
 	public UnpauseContainerCmd withContainerId(String containerId) {
-		Preconditions.checkNotNull(containerId, "containerId was not specified");
+		checkNotNull(containerId, "containerId was not specified");
 		this.containerId = containerId;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/core/command/WaitContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/WaitContainerCmdImpl.java
@@ -1,7 +1,8 @@
 package com.github.dockerjava.core.command;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import com.github.dockerjava.api.command.WaitContainerCmd;
-import com.google.common.base.Preconditions;
 
 /**
  * Wait a container
@@ -24,7 +25,7 @@ public class WaitContainerCmdImpl extends AbstrDockerCmd<WaitContainerCmd, Integ
 
     @Override
 	public WaitContainerCmd withContainerId(String containerId) {
-		Preconditions.checkNotNull(containerId, "containerId was not specified");
+		checkNotNull(containerId, "containerId was not specified");
 		this.containerId = containerId;
 		return this;
 	}

--- a/src/main/java/com/github/dockerjava/jaxrs/AbstrDockerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/AbstrDockerCmdExec.java
@@ -1,5 +1,7 @@
 package com.github.dockerjava.jaxrs;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import java.io.IOException;
 
 import javax.ws.rs.ProcessingException;
@@ -8,13 +10,10 @@ import javax.ws.rs.client.WebTarget;
 import org.apache.commons.codec.binary.Base64;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import com.github.dockerjava.api.DockerException;
 import com.github.dockerjava.api.command.DockerCmd;
 import com.github.dockerjava.api.command.DockerCmdExec;
 import com.github.dockerjava.api.model.AuthConfig;
-
-import com.google.common.base.Preconditions;
 
 public abstract class AbstrDockerCmdExec<CMD_T extends DockerCmd<RES_T>, RES_T>
 		implements DockerCmdExec<CMD_T, RES_T> {
@@ -22,7 +21,7 @@ public abstract class AbstrDockerCmdExec<CMD_T extends DockerCmd<RES_T>, RES_T>
 	private WebTarget baseResource;
 
 	public AbstrDockerCmdExec(WebTarget baseResource) {
-		Preconditions.checkNotNull(baseResource,
+		checkNotNull(baseResource,
 				"baseResource was not specified");
 		this.baseResource = baseResource;
 	}

--- a/src/main/java/com/github/dockerjava/jaxrs/ApacheUnixSocket.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/ApacheUnixSocket.java
@@ -22,10 +22,6 @@ package com.github.dockerjava.jaxrs;
 
 
 
-import com.google.common.collect.Queues;
-
-import org.newsclub.net.unix.AFUNIXSocket;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -34,7 +30,10 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.nio.channels.SocketChannel;
+import java.util.ArrayDeque;
 import java.util.Queue;
+
+import org.newsclub.net.unix.AFUNIXSocket;
 
 /**
  * Provides a socket that wraps an org.newsclub.net.unix.AFUNIXSocket and delays setting options
@@ -50,7 +49,7 @@ public class ApacheUnixSocket extends Socket {
 
   private final AFUNIXSocket inner;
 
-  private final Queue<SocketOptionSetter> optionsToSet = Queues.newArrayDeque();
+  private final Queue<SocketOptionSetter> optionsToSet = new ArrayDeque<SocketOptionSetter>();
 
   public ApacheUnixSocket() throws IOException {
     this.inner = AFUNIXSocket.newInstance();

--- a/src/main/java/com/github/dockerjava/jaxrs/DockerCmdExecFactoryImpl.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/DockerCmdExecFactoryImpl.java
@@ -1,13 +1,16 @@
 package com.github.dockerjava.jaxrs;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
-import com.github.dockerjava.api.DockerClientException;
-import com.github.dockerjava.api.command.*;
-import com.github.dockerjava.core.DockerClientConfig;
-import com.github.dockerjava.jaxrs.util.JsonClientFilter;
-import com.github.dockerjava.jaxrs.util.ResponseStatusExceptionFilter;
-import com.github.dockerjava.jaxrs.util.SelectiveLoggingFilter;
-import com.google.common.base.Preconditions;
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.logging.Logger;
+
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
@@ -19,13 +22,46 @@ import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 
-import javax.net.ssl.SSLContext;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.WebTarget;
-import java.io.IOException;
-import java.net.URI;
-import java.util.logging.Logger;
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.github.dockerjava.api.DockerClientException;
+import com.github.dockerjava.api.command.AttachContainerCmd;
+import com.github.dockerjava.api.command.AuthCmd;
+import com.github.dockerjava.api.command.BuildImageCmd;
+import com.github.dockerjava.api.command.CommitCmd;
+import com.github.dockerjava.api.command.ContainerDiffCmd;
+import com.github.dockerjava.api.command.CopyFileFromContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.CreateImageCmd;
+import com.github.dockerjava.api.command.DockerCmdExecFactory;
+import com.github.dockerjava.api.command.EventsCmd;
+import com.github.dockerjava.api.command.ExecCreateCmd;
+import com.github.dockerjava.api.command.ExecStartCmd;
+import com.github.dockerjava.api.command.InfoCmd;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectImageCmd;
+import com.github.dockerjava.api.command.KillContainerCmd;
+import com.github.dockerjava.api.command.ListContainersCmd;
+import com.github.dockerjava.api.command.ListImagesCmd;
+import com.github.dockerjava.api.command.LogContainerCmd;
+import com.github.dockerjava.api.command.PauseContainerCmd;
+import com.github.dockerjava.api.command.PingCmd;
+import com.github.dockerjava.api.command.PullImageCmd;
+import com.github.dockerjava.api.command.PushImageCmd;
+import com.github.dockerjava.api.command.RemoveContainerCmd;
+import com.github.dockerjava.api.command.RemoveImageCmd;
+import com.github.dockerjava.api.command.RestartContainerCmd;
+import com.github.dockerjava.api.command.SearchImagesCmd;
+import com.github.dockerjava.api.command.StartContainerCmd;
+import com.github.dockerjava.api.command.StopContainerCmd;
+import com.github.dockerjava.api.command.TagImageCmd;
+import com.github.dockerjava.api.command.TopContainerCmd;
+import com.github.dockerjava.api.command.UnpauseContainerCmd;
+import com.github.dockerjava.api.command.VersionCmd;
+import com.github.dockerjava.api.command.WaitContainerCmd;
+import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.jaxrs.util.JsonClientFilter;
+import com.github.dockerjava.jaxrs.util.ResponseStatusExceptionFilter;
+import com.github.dockerjava.jaxrs.util.SelectiveLoggingFilter;
 
 public class DockerCmdExecFactoryImpl implements DockerCmdExecFactory {
 
@@ -35,7 +71,7 @@ public class DockerCmdExecFactoryImpl implements DockerCmdExecFactory {
 
     @Override
     public void init(DockerClientConfig dockerClientConfig) {
-        Preconditions.checkNotNull(dockerClientConfig, "config was not specified");
+        checkNotNull(dockerClientConfig, "config was not specified");
 
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.connectorProvider(new ApacheConnectorProvider());
@@ -99,7 +135,7 @@ public class DockerCmdExecFactoryImpl implements DockerCmdExecFactory {
       }
 
     protected WebTarget getBaseResource() {
-        Preconditions.checkNotNull(baseResource, "Factory not initialized. You probably forgot to call init()!");
+        checkNotNull(baseResource, "Factory not initialized. You probably forgot to call init()!");
         return baseResource;
     }
 
@@ -270,7 +306,7 @@ public class DockerCmdExecFactoryImpl implements DockerCmdExecFactory {
 
     @Override
     public void close() throws IOException {
-        Preconditions.checkNotNull(client, "Factory not initialized. You probably forgot to call init()!");
+        checkNotNull(client, "Factory not initialized. You probably forgot to call init()!");
         client.close();
     }
 

--- a/src/main/java/com/github/dockerjava/jaxrs/EventsCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/EventsCmdExec.java
@@ -1,9 +1,17 @@
 package com.github.dockerjava.jaxrs;
 
+import static com.github.dockerjava.Preconditions.checkNotNull;
+
 import java.io.InputStream;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
@@ -12,13 +20,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.command.EventCallback;
 import com.github.dockerjava.api.command.EventsCmd;
 import com.github.dockerjava.api.model.Event;
-import com.google.common.base.Preconditions;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Response;
 
 public class EventsCmdExec extends AbstrDockerCmdExec<EventsCmd, ExecutorService> implements EventsCmd.Exec {
     private static final Logger LOGGER = LoggerFactory.getLogger(EventsCmdExec.class);
@@ -54,8 +55,8 @@ public class EventsCmdExec extends AbstrDockerCmdExec<EventsCmd, ExecutorService
         }
 
         public static EventNotifier create(EventCallback eventCallback, WebTarget webTarget) {
-            Preconditions.checkNotNull(eventCallback, "An EventCallback must be provided");
-            Preconditions.checkNotNull(webTarget, "An WebTarget must be provided");
+            checkNotNull(eventCallback, "An EventCallback must be provided");
+            checkNotNull(webTarget, "An WebTarget must be provided");
             return new EventNotifier(eventCallback, webTarget);
         }
 

--- a/src/main/java/com/github/dockerjava/jaxrs/ListImagesCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/ListImagesCmdExec.java
@@ -1,19 +1,18 @@
 package com.github.dockerjava.jaxrs;
 
+import static com.github.dockerjava.jaxrs.util.guava.Guava.urlPathSegmentEscaper;
+
 import java.util.List;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 
-import com.google.common.net.UrlEscapers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.dockerjava.api.command.ListImagesCmd;
 import com.github.dockerjava.api.model.Image;
-
-import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
 
 public class ListImagesCmdExec extends
 		AbstrDockerCmdExec<ListImagesCmd, List<Image>> implements

--- a/src/main/java/com/github/dockerjava/jaxrs/util/SelectiveLoggingFilter.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/util/SelectiveLoggingFilter.java
@@ -1,14 +1,14 @@
 package com.github.dockerjava.jaxrs.util;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Logger;
 
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
-
-import com.google.common.collect.ImmutableSet;
 
 import org.glassfish.jersey.filter.LoggingFilter;
 
@@ -21,10 +21,15 @@ import org.glassfish.jersey.filter.LoggingFilter;
  */
 public class SelectiveLoggingFilter extends LoggingFilter {
     
-    private static final Set<String> SKIPPED_CONTENT = ImmutableSet.<String>builder()
-            .add(MediaType.APPLICATION_OCTET_STREAM)
-            .add("application/tar")
-            .build();
+    // Immutable'ish
+    private static final Set<String> SKIPPED_CONTENT; 
+    static {
+        Set<String> s = new HashSet<String>();
+        s.add(MediaType.APPLICATION_OCTET_STREAM);
+        s.add("application/tar");
+        SKIPPED_CONTENT = Collections.unmodifiableSet(s);
+    }
+
 
     public SelectiveLoggingFilter(Logger logger, boolean b) {
 		super(logger, b);

--- a/src/main/java/com/github/dockerjava/jaxrs/util/guava/Guava.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/util/guava/Guava.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2008 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.dockerjava.jaxrs.util.guava;
+
+public class Guava {
+
+    static final String URL_PATH_OTHER_SAFE_CHARS_LACKING_PLUS =
+            "-._~" +        // Unreserved characters.
+            "!$'()*,;&=" +  // The subdelim characters (excluding '+').
+            "@:";           // The gendelim characters permitted in paths.
+
+    public static PercentEscaper urlPathSegmentEscaper() {
+        return URL_PATH_SEGMENT_ESCAPER;
+      }
+
+    private static final PercentEscaper URL_PATH_SEGMENT_ESCAPER =
+            new PercentEscaper(URL_PATH_OTHER_SAFE_CHARS_LACKING_PLUS + "+", false);
+
+    public static String join(String[] joins, String sep, boolean skipNulls) {
+        StringBuilder sb = new StringBuilder();
+        for(int i = 0; i < joins.length; i++) {
+           if(skipNulls && joins[i] == null) {
+               continue;
+           }
+           sb.append(joins[i]);
+           if(i < joins.length -1) {
+               sb.append(sep);
+           }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/github/dockerjava/jaxrs/util/guava/PercentEscaper.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/util/guava/PercentEscaper.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2008 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.dockerjava.jaxrs.util.guava;
+
+import com.github.dockerjava.Preconditions;
+
+/**
+ * A {@code UnicodeEscaper} that escapes some set of Java characters using a
+ * UTF-8 based percent encoding scheme. The set of safe characters (those which
+ * remain unescaped) can be specified on construction.
+ *
+ * <p>This class is primarily used for creating URI escapers in UrlEscapers
+ * but can be used directly if required. While URI escapers impose
+ * specific semantics on which characters are considered 'safe', this class has
+ * a minimal set of restrictions.
+ *
+ * <p>When escaping a String, the following rules apply:
+ * <ul>
+ * <li>All specified safe characters remain unchanged.
+ * <li>If {@code plusForSpace} was specified, the space character " " is
+ *     converted into a plus sign {@code "+"}.
+ * <li>All other characters are converted into one or more bytes using UTF-8
+ *     encoding and each byte is then represented by the 3-character string
+ *     "%XX", where "XX" is the two-digit, uppercase, hexadecimal representation
+ *     of the byte value.
+ * </ul>
+ *
+ * <p>For performance reasons the only currently supported character encoding of
+ * this class is UTF-8.
+ *
+ * <p><b>Note:</b> This escaper produces uppercase hexadecimal sequences. From
+ * <a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a>:<br>
+ * <i>"URI producers and normalizers should use uppercase hexadecimal digits
+ * for all percent-encodings."</i>
+ *
+ * @author David Beaumont
+ * @since 15.0
+ */
+public final class PercentEscaper extends UnicodeEscaper {
+
+  // In some escapers spaces are escaped to '+'
+  private static final char[] PLUS_SIGN = { '+' };
+
+  // Percent escapers output upper case hex digits (uri escapers require this).
+  private static final char[] UPPER_HEX_DIGITS =
+      "0123456789ABCDEF".toCharArray();
+
+  /**
+   * If true we should convert space to the {@code +} character.
+   */
+  private final boolean plusForSpace;
+
+  /**
+   * An array of flags where for any {@code char c} if {@code safeOctets[c]} is
+   * true then {@code c} should remain unmodified in the output. If
+   * {@code c > safeOctets.length} then it should be escaped.
+   */
+  private final boolean[] safeOctets;
+
+  /**
+   * Constructs a percent escaper with the specified safe characters and
+   * optional handling of the space character.
+   *
+   * <p>Not that it is allowed, but not necessarily desirable to specify {@code %}
+   * as a safe character. This has the effect of creating an escaper which has no
+   * well defined inverse but it can be useful when escaping additional characters.
+   *
+   * @param safeChars a non null string specifying additional safe characters
+   *        for this escaper (the ranges 0..9, a..z and A..Z are always safe and
+   *        should not be specified here)
+   * @param plusForSpace true if ASCII space should be escaped to {@code +}
+   *        rather than {@code %20}
+   * @throws IllegalArgumentException if any of the parameters were invalid
+   */
+  public PercentEscaper(String safeChars, boolean plusForSpace) {
+    // TODO(user): Switch to static factory methods for creation now that class is final.
+    // TODO(user): Support escapers where alphanumeric chars are not safe.
+    Preconditions.checkNotNull(safeChars);  // eager for GWT.
+    // Avoid any misunderstandings about the behavior of this escaper
+    if (safeChars.matches(".*[0-9A-Za-z].*")) {
+      throw new IllegalArgumentException(
+          "Alphanumeric characters are always 'safe' and should not be " +
+          "explicitly specified");
+    }
+    safeChars += "abcdefghijklmnopqrstuvwxyz" +
+                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+                 "0123456789";
+    // Avoid ambiguous parameters. Safe characters are never modified so if
+    // space is a safe character then setting plusForSpace is meaningless.
+    if (plusForSpace && safeChars.contains(" ")) {
+      throw new IllegalArgumentException(
+          "plusForSpace cannot be specified when space is a 'safe' character");
+    }
+    this.plusForSpace = plusForSpace;
+    this.safeOctets = createSafeOctets(safeChars);
+  }
+
+  /**
+   * Creates a boolean array with entries corresponding to the character values
+   * specified in safeChars set to true. The array is as small as is required to
+   * hold the given character information.
+   */
+  private static boolean[] createSafeOctets(String safeChars) {
+    int maxChar = -1;
+    char[] safeCharArray = safeChars.toCharArray();
+    for (char c : safeCharArray) {
+      maxChar = Math.max(c, maxChar);
+    }
+    boolean[] octets = new boolean[maxChar + 1];
+    for (char c : safeCharArray) {
+      octets[c] = true;
+    }
+    return octets;
+  }
+
+  /*
+   * Overridden for performance. For unescaped strings this improved the
+   * performance of the uri escaper from ~760ns to ~400ns as measured by
+   * CharEscapersBenchmark.
+   */
+  @Override
+  protected int nextEscapeIndex(CharSequence csq, int index, int end) {
+    Preconditions.checkNotNull(csq);
+    for (; index < end; index++) {
+      char c = csq.charAt(index);
+      if (c >= safeOctets.length || !safeOctets[c]) {
+        break;
+      }
+    }
+    return index;
+  }
+
+  /*
+   * Overridden for performance. For unescaped strings this improved the
+   * performance of the uri escaper from ~400ns to ~170ns as measured by
+   * CharEscapersBenchmark.
+   */
+  @Override
+  public String escape(String s) {
+    Preconditions.checkNotNull(s);
+    int slen = s.length();
+    for (int index = 0; index < slen; index++) {
+      char c = s.charAt(index);
+      if (c >= safeOctets.length || !safeOctets[c]) {
+        return escapeSlow(s, index);
+      }
+    }
+    return s;
+  }
+
+  /**
+   * Escapes the given Unicode code point in UTF-8.
+   */
+  @Override
+  protected char[] escape(int cp) {
+    // We should never get negative values here but if we do it will throw an
+    // IndexOutOfBoundsException, so at least it will get spotted.
+    if (cp < safeOctets.length && safeOctets[cp]) {
+      return null;
+    } else if (cp == ' ' && plusForSpace) {
+      return PLUS_SIGN;
+    } else if (cp <= 0x7F) {
+      // Single byte UTF-8 characters
+      // Start with "%--" and fill in the blanks
+      char[] dest = new char[3];
+      dest[0] = '%';
+      dest[2] = UPPER_HEX_DIGITS[cp & 0xF];
+      dest[1] = UPPER_HEX_DIGITS[cp >>> 4];
+      return dest;
+    } else if (cp <= 0x7ff) {
+      // Two byte UTF-8 characters [cp >= 0x80 && cp <= 0x7ff]
+      // Start with "%--%--" and fill in the blanks
+      char[] dest = new char[6];
+      dest[0] = '%';
+      dest[3] = '%';
+      dest[5] = UPPER_HEX_DIGITS[cp & 0xF];
+      cp >>>= 4;
+      dest[4] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+      cp >>>= 2;
+      dest[2] = UPPER_HEX_DIGITS[cp & 0xF];
+      cp >>>= 4;
+      dest[1] = UPPER_HEX_DIGITS[0xC | cp];
+      return dest;
+    } else if (cp <= 0xffff) {
+      // Three byte UTF-8 characters [cp >= 0x800 && cp <= 0xffff]
+      // Start with "%E-%--%--" and fill in the blanks
+      char[] dest = new char[9];
+      dest[0] = '%';
+      dest[1] = 'E';
+      dest[3] = '%';
+      dest[6] = '%';
+      dest[8] = UPPER_HEX_DIGITS[cp & 0xF];
+      cp >>>= 4;
+      dest[7] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+      cp >>>= 2;
+      dest[5] = UPPER_HEX_DIGITS[cp & 0xF];
+      cp >>>= 4;
+      dest[4] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+      cp >>>= 2;
+      dest[2] = UPPER_HEX_DIGITS[cp];
+      return dest;
+    } else if (cp <= 0x10ffff) {
+      char[] dest = new char[12];
+      // Four byte UTF-8 characters [cp >= 0xffff && cp <= 0x10ffff]
+      // Start with "%F-%--%--%--" and fill in the blanks
+      dest[0] = '%';
+      dest[1] = 'F';
+      dest[3] = '%';
+      dest[6] = '%';
+      dest[9] = '%';
+      dest[11] = UPPER_HEX_DIGITS[cp & 0xF];
+      cp >>>= 4;
+      dest[10] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+      cp >>>= 2;
+      dest[8] = UPPER_HEX_DIGITS[cp & 0xF];
+      cp >>>= 4;
+      dest[7] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+      cp >>>= 2;
+      dest[5] = UPPER_HEX_DIGITS[cp & 0xF];
+      cp >>>= 4;
+      dest[4] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+      cp >>>= 2;
+      dest[2] = UPPER_HEX_DIGITS[cp & 0x7];
+      return dest;
+    } else {
+      // If this ever happens it is due to bug in UnicodeEscaper, not bad input.
+      throw new IllegalArgumentException(
+          "Invalid unicode character value " + cp);
+    }
+  }
+}

--- a/src/main/java/com/github/dockerjava/jaxrs/util/guava/UnicodeEscaper.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/util/guava/UnicodeEscaper.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (C) 2008 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.dockerjava.jaxrs.util.guava;
+
+
+import com.github.dockerjava.Preconditions;
+
+/**
+ * An Escaper that converts literal text into a format safe for
+ * inclusion in a particular context (such as an XML document). Typically (but
+ * not always), the inverse process of "unescaping" the text is performed
+ * automatically by the relevant parser.
+ *
+ * <p>For example, an XML escaper would convert the literal string {@code
+ * "Foo<Bar>"} into {@code "Foo&lt;Bar&gt;"} to prevent {@code "<Bar>"} from
+ * being confused with an XML tag. When the resulting XML document is parsed,
+ * the parser API will return this text as the original literal string {@code
+ * "Foo<Bar>"}.
+ *
+ * <p><b>Note:</b> This class is similar to CharEscaper but with one
+ * very important difference. A CharEscaper can only process Java
+ * <a href="http://en.wikipedia.org/wiki/UTF-16">UTF16</a> characters in
+ * isolation and may not cope when it encounters surrogate pairs. This class
+ * facilitates the correct escaping of all Unicode characters.
+ *
+ * <p>As there are important reasons, including potential security issues, to
+ * handle Unicode correctly if you are considering implementing a new escaper
+ * you should favor using UnicodeEscaper wherever possible.
+ *
+ * <p>A {@code UnicodeEscaper} instance is required to be stateless, and safe
+ * when used concurrently by multiple threads.
+ *
+ * <p>Several popular escapers are defined as constants in classes like
+ * com.google.common.html.HtmlEscapers, com.google.common.xml.XmlEscapers,
+ * and SourceCodeEscapers. To create
+ * your own escapers extend this class and implement the #escape(int)
+ * method.
+ *
+ * @author David Beaumont
+ * @since 15.0
+ */
+public abstract class UnicodeEscaper {
+  /** The amount of padding (chars) to use when growing the escape buffer. */
+  private static final int DEST_PAD = 32;
+
+  /** Constructor for use by subclasses. */
+  protected UnicodeEscaper() {}
+
+  /**
+   * Returns the escaped form of the given Unicode code point, or {@code null}
+   * if this code point does not need to be escaped. When called as part of an
+   * escaping operation, the given code point is guaranteed to be in the range
+   * {@code 0 <= cp <= Character#MAX_CODE_POINT}.
+   *
+   * <p>If an empty array is returned, this effectively strips the input
+   * character from the resulting text.
+   *
+   * <p>If the character does not need to be escaped, this method should return
+   * {@code null}, rather than an array containing the character representation
+   * of the code point. This enables the escaping algorithm to perform more
+   * efficiently.
+   *
+   * <p>If the implementation of this method cannot correctly handle a
+   * particular code point then it should either throw an appropriate runtime
+   * exception or return a suitable replacement character. It must never
+   * silently discard invalid input as this may constitute a security risk.
+   *
+   * @param cp the Unicode code point to escape if necessary
+   * @return the replacement characters, or {@code null} if no escaping was
+   *     needed
+   */
+  protected abstract char[] escape(int cp);
+
+  /**
+   * Scans a sub-sequence of characters from a given CharSequence,
+   * returning the index of the next character that requires escaping.
+   *
+   * <p><b>Note:</b> When implementing an escaper, it is a good idea to override
+   * this method for efficiency. The base class implementation determines
+   * successive Unicode code points and invokes #escape(int) for each of
+   * them. If the semantics of your escaper are such that code points in the
+   * supplementary range are either all escaped or all unescaped, this method
+   * can be implemented more efficiently using CharSequence#charAt(int).
+   *
+   * <p>Note however that if your escaper does not escape characters in the
+   * supplementary range, you should either continue to validate the correctness
+   * of any surrogate characters encountered or provide a clear warning to users
+   * that your escaper does not validate its input.
+   *
+   * <p>See com.google.common.net.PercentEscaper for an example.
+   *
+   * @param csq a sequence of characters
+   * @param start the index of the first character to be scanned
+   * @param end the index immediately after the last character to be scanned
+   * @throws IllegalArgumentException if the scanned sub-sequence of {@code csq}
+   *     contains invalid surrogate pairs
+   */
+  protected int nextEscapeIndex(CharSequence csq, int start, int end) {
+    int index = start;
+    while (index < end) {
+      int cp = codePointAt(csq, index, end);
+      if (cp < 0 || escape(cp) != null) {
+        break;
+      }
+      index += Character.isSupplementaryCodePoint(cp) ? 2 : 1;
+    }
+    return index;
+  }
+
+  /**
+   * Returns the escaped form of a given literal string.
+   *
+   * <p>If you are escaping input in arbitrary successive chunks, then it is not
+   * generally safe to use this method. If an input string ends with an
+   * unmatched high surrogate character, then this method will throw
+   * IllegalArgumentException. You should ensure your input is valid <a
+   * href="http://en.wikipedia.org/wiki/UTF-16">UTF-16</a> before calling this
+   * method.
+   *
+   * <p><b>Note:</b> When implementing an escaper it is a good idea to override
+   * this method for efficiency by inlining the implementation of
+   * #nextEscapeIndex(CharSequence, int, int) directly. Doing this for
+   * com.google.common.net.PercentEscaper more than doubled the
+   * performance for unescaped strings (as measured by CharEscapersBenchmark}.
+   *
+   * @param string the literal string to be escaped
+   * @return the escaped form of {@code string}
+   * @throws NullPointerException if {@code string} is null
+   * @throws IllegalArgumentException if invalid surrogate characters are
+   *         encountered
+   */
+  public String escape(String string) {
+    Preconditions.checkNotNull(string);
+    int end = string.length();
+    int index = nextEscapeIndex(string, 0, end);
+    return index == end ? string : escapeSlow(string, index);
+  }
+
+  /**
+   * Returns the escaped form of a given literal string, starting at the given
+   * index.  This method is called by the #escape(String) method when it
+   * discovers that escaping is required.  It is protected to allow subclasses
+   * to override the fastpath escaping function to inline their escaping test.
+   * See CharEscaperBuilder for an example usage.
+   *
+   * <p>This method is not reentrant and may only be invoked by the top level
+   * #escape(String) method.
+   *
+   * @param s the literal string to be escaped
+   * @param index the index to start escaping from
+   * @return the escaped form of {@code string}
+   * @throws NullPointerException if {@code string} is null
+   * @throws IllegalArgumentException if invalid surrogate characters are
+   *         encountered
+   */
+  protected final String escapeSlow(String s, int index) {
+    int end = s.length();
+
+    // Get a destination buffer and setup some loop variables.
+    char[] dest = new char[1024];
+    int destIndex = 0;
+    int unescapedChunkStart = 0;
+
+    while (index < end) {
+      int cp = codePointAt(s, index, end);
+      if (cp < 0) {
+        throw new IllegalArgumentException(
+            "Trailing high surrogate at end of input");
+      }
+      // It is possible for this to return null because nextEscapeIndex() may
+      // (for performance reasons) yield some false positives but it must never
+      // give false negatives.
+      char[] escaped = escape(cp);
+      int nextIndex = index + (Character.isSupplementaryCodePoint(cp) ? 2 : 1);
+      if (escaped != null) {
+        int charsSkipped = index - unescapedChunkStart;
+
+        // This is the size needed to add the replacement, not the full
+        // size needed by the string.  We only regrow when we absolutely must.
+        int sizeNeeded = destIndex + charsSkipped + escaped.length;
+        if (dest.length < sizeNeeded) {
+          int destLength = sizeNeeded + (end - index) + DEST_PAD;
+          dest = growBuffer(dest, destIndex, destLength);
+        }
+        // If we have skipped any characters, we need to copy them now.
+        if (charsSkipped > 0) {
+          s.getChars(unescapedChunkStart, index, dest, destIndex);
+          destIndex += charsSkipped;
+        }
+        if (escaped.length > 0) {
+          System.arraycopy(escaped, 0, dest, destIndex, escaped.length);
+          destIndex += escaped.length;
+        }
+        // If we dealt with an escaped character, reset the unescaped range.
+        unescapedChunkStart = nextIndex;
+      }
+      index = nextEscapeIndex(s, nextIndex, end);
+    }
+
+    // Process trailing unescaped characters - no need to account for escaped
+    // length or padding the allocation.
+    int charsSkipped = end - unescapedChunkStart;
+    if (charsSkipped > 0) {
+      int endIndex = destIndex + charsSkipped;
+      if (dest.length < endIndex) {
+        dest = growBuffer(dest, destIndex, endIndex);
+      }
+      s.getChars(unescapedChunkStart, end, dest, destIndex);
+      destIndex = endIndex;
+    }
+    return new String(dest, 0, destIndex);
+  }
+
+  /**
+   * Returns the Unicode code point of the character at the given index.
+   *
+   * <p>Unlike Character#codePointAt(CharSequence, int) or
+   * String#codePointAt(int) this method will never fail silently when
+   * encountering an invalid surrogate pair.
+   *
+   * <p>The behaviour of this method is as follows:
+   * <ol>
+   * <li>If {@code index >= end}, IndexOutOfBoundsException is thrown.
+   * <li><b>If the character at the specified index is not a surrogate, it is
+   *     returned.</b>
+   * <li>If the first character was a high surrogate value, then an attempt is
+   *     made to read the next character.
+   *     <ol>
+   *     <li><b>If the end of the sequence was reached, the negated value of
+   *         the trailing high surrogate is returned.</b>
+   *     <li><b>If the next character was a valid low surrogate, the code point
+   *         value of the high/low surrogate pair is returned.</b>
+   *     <li>If the next character was not a low surrogate value, then
+   *         IllegalArgumentException is thrown.
+   *     </ol>
+   * <li>If the first character was a low surrogate value,
+   *     IllegalArgumentException is thrown.
+   * </ol>
+   *
+   * @param seq the sequence of characters from which to decode the code point
+   * @param index the index of the first character to decode
+   * @param end the index beyond the last valid character to decode
+   * @return the Unicode code point for the given index or the negated value of
+   *         the trailing high surrogate character at the end of the sequence
+   */
+  protected static int codePointAt(CharSequence seq, int index, int end) {
+    Preconditions.checkNotNull(seq);
+    if (index < end) {
+      char c1 = seq.charAt(index++);
+      if (c1 < Character.MIN_HIGH_SURROGATE ||
+          c1 > Character.MAX_LOW_SURROGATE) {
+        // Fast path (first test is probably all we need to do)
+        return c1;
+      } else if (c1 <= Character.MAX_HIGH_SURROGATE) {
+        // If the high surrogate was the last character, return its inverse
+        if (index == end) {
+          return -c1;
+        }
+        // Otherwise look for the low surrogate following it
+        char c2 = seq.charAt(index);
+        if (Character.isLowSurrogate(c2)) {
+          return Character.toCodePoint(c1, c2);
+        }
+        throw new IllegalArgumentException(
+            "Expected low surrogate but got char '" + c2 +
+            "' with value " + (int) c2 + " at index " + index +
+            " in '" + seq + "'");
+      } else {
+        throw new IllegalArgumentException(
+            "Unexpected low surrogate character '" + c1 +
+            "' with value " + (int) c1 + " at index " + (index - 1) +
+            " in '" + seq + "'");
+      }
+    }
+    throw new IndexOutOfBoundsException("Index exceeds specified range");
+  }
+
+  /**
+   * Helper method to grow the character buffer as needed, this only happens
+   * once in a while so it's ok if it's in a method call.  If the index passed
+   * in is 0 then no copying will be done.
+   */
+  private static char[] growBuffer(char[] dest, int index, int size) {
+    char[] copy = new char[size];
+    if (index > 0) {
+      System.arraycopy(dest, 0, copy, 0, index);
+    }
+    return copy;
+  }
+}


### PR DESCRIPTION
This pull request is the start of an attempt to slim down the docker-java footprint a bit.

Guava is a 2.3MB library and is used within docker-java primarily as a replacement for

```java
if(obj == null) {
   throw new NullPointerException();
}
```