### PR TITLE
Only override AuthConfig iff username/password/email/server address are ...

### DIFF
--- a/src/main/java/com/github/dockerjava/core/DockerClientConfig.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientConfig.java
@@ -253,7 +253,8 @@ public class DockerClientConfig implements Serializable {
     
     private AuthConfig getAuthConfig() {
     	AuthConfig authConfig = null;
-    	if(getUsername() != null) {
+    	if (getUsername() != null && getPassword() != null && getEmail() != null
+    			&& getServerAddress() != null) {
     		authConfig = new AuthConfig();
     		authConfig.setUsername(getUsername());
     		authConfig.setPassword(getPassword());


### PR DESCRIPTION
...all set

Unless this is done, it is possible to create an invalid AuthConfig with null
values for password and other fields.