### PR TITLE
Restore guava as a dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
 		<jnr.unixsocket.version>0.3</jnr.unixsocket.version>
 		<bouncycastle.version>1.51</bouncycastle.version>
 		<unix-socket-factory.version>2015-01-27T15-02-14</unix-socket-factory.version>
+		<guava.version>18.0</guava.version>
 
 		<!--test dependencies -->
 		<version.logback>1.1.0</version.logback>
@@ -141,6 +142,12 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>${slf4j-api.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>${guava.version}</version>
 		</dependency>
 
 <!-- 		<dependency> -->

--- a/src/main/java/com/github/dockerjava/api/model/Device.java
+++ b/src/main/java/com/github/dockerjava/api/model/Device.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.api.model;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;

--- a/src/main/java/com/github/dockerjava/api/model/EventStreamItem.java
+++ b/src/main/java/com/github/dockerjava/api/model/EventStreamItem.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
 
-import jersey.repackaged.com.google.common.base.Objects;
+import com.google.common.base.Objects;
 
 /**
  * Represents an event stream

--- a/src/main/java/com/github/dockerjava/api/model/PushEventStreamItem.java
+++ b/src/main/java/com/github/dockerjava/api/model/PushEventStreamItem.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
 
-import jersey.repackaged.com.google.common.base.Objects;
+import com.google.common.base.Objects;
 
 /**
  * Represents an item returned from push

--- a/src/main/java/com/github/dockerjava/api/model/RestartPolicy.java
+++ b/src/main/java/com/github/dockerjava/api/model/RestartPolicy.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.api.model;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;

--- a/src/main/java/com/github/dockerjava/core/DockerClientConfig.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientConfig.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.Closeable;
 import java.io.File;

--- a/src/main/java/com/github/dockerjava/core/KeystoreSSLConfig.java
+++ b/src/main/java/com/github/dockerjava/core/KeystoreSSLConfig.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/main/java/com/github/dockerjava/core/LocalDirectorySSLConfig.java
+++ b/src/main/java/com/github/dockerjava/core/LocalDirectorySSLConfig.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.Serializable;
 import java.security.Security;

--- a/src/main/java/com/github/dockerjava/core/command/AbstrAuthCfgDockerCmd.java
+++ b/src/main/java/com/github/dockerjava/core/command/AbstrAuthCfgDockerCmd.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.IOException;
 

--- a/src/main/java/com/github/dockerjava/core/command/AbstrDockerCmd.java
+++ b/src/main/java/com/github/dockerjava/core/command/AbstrDockerCmd.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.IOException;
 

--- a/src/main/java/com/github/dockerjava/core/command/AttachContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/AttachContainerCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.InputStream;
 

--- a/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
@@ -26,7 +26,7 @@ import com.github.dockerjava.core.GoLangFileMatchException;
 import com.github.dockerjava.core.GoLangMatchFileFilter;
 import com.github.dockerjava.core.dockerfile.Dockerfile;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.*;
+import static com.google.common.base.Preconditions.*;
 
 /**
  * 

--- a/src/main/java/com/github/dockerjava/core/command/CommitCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CommitCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 

--- a/src/main/java/com/github/dockerjava/core/command/ContainerDiffCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ContainerDiffCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 

--- a/src/main/java/com/github/dockerjava/core/command/CopyFileFromContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CopyFileFromContainerCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.InputStream;
 

--- a/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 

--- a/src/main/java/com/github/dockerjava/core/command/CreateImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CreateImageCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.InputStream;
 

--- a/src/main/java/com/github/dockerjava/core/command/ExecCreateCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ExecCreateCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.dockerjava.api.NotFoundException;

--- a/src/main/java/com/github/dockerjava/core/command/ExecStartCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ExecStartCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.InputStream;
 

--- a/src/main/java/com/github/dockerjava/core/command/InspectContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/InspectContainerCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.InspectContainerCmd;

--- a/src/main/java/com/github/dockerjava/core/command/InspectImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/InspectImageCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.InspectImageCmd;

--- a/src/main/java/com/github/dockerjava/core/command/KillContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/KillContainerCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.KillContainerCmd;

--- a/src/main/java/com/github/dockerjava/core/command/ListContainersCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ListContainersCmdImpl.java
@@ -1,7 +1,7 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkArgument;
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 

--- a/src/main/java/com/github/dockerjava/core/command/ListImagesCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ListImagesCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 

--- a/src/main/java/com/github/dockerjava/core/command/LogContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/LogContainerCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.InputStream;
 

--- a/src/main/java/com/github/dockerjava/core/command/PauseContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/PauseContainerCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.PauseContainerCmd;

--- a/src/main/java/com/github/dockerjava/core/command/PullImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/PullImageCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.InputStream;
 

--- a/src/main/java/com/github/dockerjava/core/command/PushImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/PushImageCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.PushImageCmd;

--- a/src/main/java/com/github/dockerjava/core/command/RemoveContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/RemoveContainerCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.RemoveContainerCmd;

--- a/src/main/java/com/github/dockerjava/core/command/RemoveImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/RemoveImageCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.RemoveImageCmd;

--- a/src/main/java/com/github/dockerjava/core/command/RestartContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/RestartContainerCmdImpl.java
@@ -1,7 +1,7 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkArgument;
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.RestartContainerCmd;

--- a/src/main/java/com/github/dockerjava/core/command/SaveImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/SaveImageCmdImpl.java
@@ -5,7 +5,7 @@ import com.github.dockerjava.api.command.SaveImageCmd;
 
 import java.io.InputStream;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class SaveImageCmdImpl extends AbstrAuthCfgDockerCmd<SaveImageCmd, InputStream> implements SaveImageCmd {
     private String name;

--- a/src/main/java/com/github/dockerjava/core/command/SearchImagesCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/SearchImagesCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 

--- a/src/main/java/com/github/dockerjava/core/command/StartContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/StartContainerCmdImpl.java
@@ -1,7 +1,7 @@
 package com.github.dockerjava.core.command;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.apache.commons.lang.builder.ToStringBuilder;
 

--- a/src/main/java/com/github/dockerjava/core/command/StopContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/StopContainerCmdImpl.java
@@ -1,7 +1,7 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkArgument;
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.NotModifiedException;

--- a/src/main/java/com/github/dockerjava/core/command/TagImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/TagImageCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.github.dockerjava.api.command.TagImageCmd;
 

--- a/src/main/java/com/github/dockerjava/core/command/TopContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/TopContainerCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.TopContainerCmd;

--- a/src/main/java/com/github/dockerjava/core/command/UnpauseContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/UnpauseContainerCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.UnpauseContainerCmd;

--- a/src/main/java/com/github/dockerjava/core/command/WaitContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/WaitContainerCmdImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.command;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.github.dockerjava.api.command.WaitContainerCmd;
 

--- a/src/main/java/com/github/dockerjava/core/dockerfile/Dockerfile.java
+++ b/src/main/java/com/github/dockerjava/core/dockerfile/Dockerfile.java
@@ -20,11 +20,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import jersey.repackaged.com.google.common.base.Function;
-import jersey.repackaged.com.google.common.base.Objects;
-import jersey.repackaged.com.google.common.base.Optional;
-import jersey.repackaged.com.google.common.base.Predicate;
-import jersey.repackaged.com.google.common.collect.Collections2;
+import com.google.common.base.Function;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
 
 /**
  * Parse a Dockerfile.

--- a/src/main/java/com/github/dockerjava/core/dockerfile/DockerfileStatement.java
+++ b/src/main/java/com/github/dockerjava/core/dockerfile/DockerfileStatement.java
@@ -8,8 +8,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import jersey.repackaged.com.google.common.base.Objects;
-import jersey.repackaged.com.google.common.base.Optional;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
 
 /**
  * A statement present in a dockerfile.

--- a/src/main/java/com/github/dockerjava/core/util/guava/PercentEscaper.java
+++ b/src/main/java/com/github/dockerjava/core/util/guava/PercentEscaper.java
@@ -16,7 +16,7 @@
 
 package com.github.dockerjava.core.util.guava;
 
-import jersey.repackaged.com.google.common.base.Preconditions;
+import com.google.common.base.Preconditions;
 
 /**
  * A {@code UnicodeEscaper} that escapes some set of Java characters using a

--- a/src/main/java/com/github/dockerjava/core/util/guava/UnicodeEscaper.java
+++ b/src/main/java/com/github/dockerjava/core/util/guava/UnicodeEscaper.java
@@ -16,7 +16,7 @@
 
 package com.github.dockerjava.core.util.guava;
 
-import jersey.repackaged.com.google.common.base.Preconditions;
+import com.google.common.base.Preconditions;
 
 
 /**

--- a/src/main/java/com/github/dockerjava/jaxrs/AbstrDockerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/AbstrDockerCmdExec.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.jaxrs;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.IOException;
 

--- a/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
@@ -24,7 +24,7 @@ import com.github.dockerjava.api.command.PushImageCmd;
 import com.github.dockerjava.api.model.EventStreamItem;
 import com.github.dockerjava.api.model.PushEventStreamItem;
 
-import jersey.repackaged.com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList;
 
 public class BuildImageCmdExec extends AbstrDockerCmdExec<BuildImageCmd, BuildImageCmd.Response> implements BuildImageCmd.Exec {
 	

--- a/src/main/java/com/github/dockerjava/jaxrs/DockerCmdExecFactoryImpl.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/DockerCmdExecFactoryImpl.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.jaxrs;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.IOException;
 import java.net.URI;

--- a/src/main/java/com/github/dockerjava/jaxrs/EventsCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/EventsCmdExec.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.jaxrs;
 
-import static jersey.repackaged.com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.InputStream;
 import java.util.concurrent.Callable;

--- a/src/main/java/com/github/dockerjava/jaxrs/PushImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/PushImageCmdExec.java
@@ -22,7 +22,7 @@ import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.PushEventStreamItem;
 
 // Shaded, but imported
-import jersey.repackaged.com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList;
 
 public class PushImageCmdExec extends AbstrDockerCmdExec<PushImageCmd, Response> implements PushImageCmd.Exec {
 	

--- a/src/main/java/com/github/dockerjava/jaxrs/SaveImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/SaveImageCmdExec.java
@@ -6,7 +6,7 @@ import com.github.dockerjava.api.command.PushImageCmd;
 import com.github.dockerjava.api.command.SaveImageCmd;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.PushEventStreamItem;
-import jersey.repackaged.com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
The repackaged guava classes provided by Jersey are incomplete and
attempting to export these repackaged types will lead to path lookup
errors in consumers.

Fixes #151