### PR TITLE
Add support for configuring ExtraHosts

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/HostConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/HostConfig.java
@@ -53,12 +53,16 @@ public class HostConfig {
 	@JsonProperty("Devices")
 	private Device[] devices;
 
+	@JsonProperty("ExtraHosts")
+	private String[] extraHosts;
+
 	public HostConfig() {
 	}
 
 	public HostConfig(String[] binds, Links links, LxcConf[] lxcConf, Ports portBindings, boolean publishAllPorts,
 			boolean privileged, String[] dns, String[] dnsSearch, VolumesFrom[] volumesFrom, String containerIDFile,
-			Capability[] capAdd, Capability[] capDrop, RestartPolicy restartPolicy, String networkMode, Device[] devices) {
+			Capability[] capAdd, Capability[] capDrop, RestartPolicy restartPolicy, String networkMode, Device[] devices,
+            String[] extraHosts) {
 		this.binds = binds;
 		this.links = links;
 		this.lxcConf = lxcConf;
@@ -74,6 +78,7 @@ public class HostConfig {
 		this.restartPolicy = restartPolicy;
 		this.networkMode = networkMode;
 		this.devices = devices;
+		this.extraHosts = extraHosts;
 	}
 
 	public String[] getBinds() {
@@ -122,6 +127,10 @@ public class HostConfig {
 
 	public Device[] getDevices() {
 		return devices;
+	}
+
+	public String[] getExtraHosts() {
+		return extraHosts;
 	}
 
 	public RestartPolicy getRestartPolicy() {
@@ -194,6 +203,10 @@ public class HostConfig {
 
 	public void setDevices(Device[] devices) {
 		this.devices = devices;
+	}
+
+	public void setExtraHosts(String[] extraHosts) {
+		this.extraHosts = extraHosts;
 	}
 
 	@Override

--- a/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
@@ -311,4 +311,27 @@ public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
 
 	}
 
+	@Test
+	public void createContainerWithExtraHosts() throws DockerException {
+
+		String[] extraHosts = {"dockerhost:127.0.0.1", "otherhost:10.0.0.1"};
+
+		HostConfig hostConfig = new HostConfig();
+		hostConfig.setExtraHosts(extraHosts);
+
+		CreateContainerResponse container = dockerClient
+				.createContainerCmd("busybox").withName("container")
+				.withHostConfig(hostConfig).exec();
+
+		LOG.info("Created container {}", container.toString());
+
+		assertThat(container.getId(), not(isEmptyString()));
+
+		InspectContainerResponse inspectContainerResponse = dockerClient
+				.inspectContainerCmd(container.getId()).exec();
+
+		assertThat(Arrays.asList(inspectContainerResponse.getHostConfig().getExtraHosts()),
+				containsInAnyOrder("dockerhost:127.0.0.1", "otherhost:10.0.0.1"));
+	}
+
 }


### PR DESCRIPTION
Extends HostConfig to support adding entries to /etc/hosts on startup.

See https://docs.docker.com/reference/api/docker_remote_api_v1.16/ for details on the API