### PR TITLE
Add support for configuring ExtraHosts - version 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -397,10 +397,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-			</plugin>
 		</plugins>
 	</build>
 
@@ -425,10 +421,6 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-source-plugin</artifactId>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-javadoc-plugin</artifactId>
 					</plugin>
 				</plugins>
 			</build>

--- a/src/main/java/com/github/dockerjava/api/command/StartContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/StartContainerCmd.java
@@ -40,6 +40,8 @@ public interface StartContainerCmd extends DockerCmd<Void> {
 
 	public Device[] getDevices();
 
+	public String[] getExtraHosts();
+
 	public RestartPolicy getRestartPolicy();
 
 	public Capability[] getCapAdd();
@@ -106,6 +108,11 @@ public interface StartContainerCmd extends DockerCmd<Void> {
 	 * Add host devices to the container
 	 */
 	public StartContainerCmd withDevices(Device... devices);
+
+	/**
+	 * Add hostnames to /etc/hosts in the container
+	 */
+	public StartContainerCmd withExtraHosts(String... extraHosts);
 
 	/**
 	 * Set custom {@link RestartPolicy} for the container. Defaults to

--- a/src/main/java/com/github/dockerjava/api/model/HostConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/HostConfig.java
@@ -53,12 +53,16 @@ public class HostConfig {
 	@JsonProperty("Devices")
 	private Device[] devices;
 
+	@JsonProperty("ExtraHosts")
+	private String[] extraHosts;
+
 	public HostConfig() {
 	}
 
 	public HostConfig(String[] binds, Links links, LxcConf[] lxcConf, Ports portBindings, boolean publishAllPorts,
 			boolean privileged, String[] dns, String[] dnsSearch, VolumesFrom[] volumesFrom, String containerIDFile,
-			Capability[] capAdd, Capability[] capDrop, RestartPolicy restartPolicy, String networkMode, Device[] devices) {
+			Capability[] capAdd, Capability[] capDrop, RestartPolicy restartPolicy, String networkMode, Device[] devices,
+            String[] extraHosts) {
 		this.binds = binds;
 		this.links = links;
 		this.lxcConf = lxcConf;
@@ -74,6 +78,7 @@ public class HostConfig {
 		this.restartPolicy = restartPolicy;
 		this.networkMode = networkMode;
 		this.devices = devices;
+		this.extraHosts = extraHosts;
 	}
 
 	public String[] getBinds() {
@@ -122,6 +127,10 @@ public class HostConfig {
 
 	public Device[] getDevices() {
 		return devices;
+	}
+
+	public String[] getExtraHosts() {
+		return extraHosts;
 	}
 
 	public RestartPolicy getRestartPolicy() {
@@ -194,6 +203,10 @@ public class HostConfig {
 
 	public void setDevices(Device[] devices) {
 		this.devices = devices;
+	}
+
+	public void setExtraHosts(String[] extraHosts) {
+		this.extraHosts = extraHosts;
 	}
 
 	@Override

--- a/src/main/java/com/github/dockerjava/core/command/StartContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/StartContainerCmdImpl.java
@@ -65,6 +65,9 @@ public class StartContainerCmdImpl extends AbstrDockerCmd<StartContainerCmd, Voi
 	@JsonProperty("Devices")
 	private Device[] devices;
 	
+	@JsonProperty("ExtraHosts")
+	private String[] extraHosts;
+	
 	@JsonProperty("RestartPolicy")
 	private RestartPolicy restartPolicy;
 	
@@ -139,6 +142,11 @@ public class StartContainerCmdImpl extends AbstrDockerCmd<StartContainerCmd, Voi
     @Override
     public Device[] getDevices() {
 		return devices;
+	}
+    
+    @Override
+    public String[] getExtraHosts() {
+		return extraHosts;
 	}
     
     @Override
@@ -250,6 +258,14 @@ public class StartContainerCmdImpl extends AbstrDockerCmd<StartContainerCmd, Voi
 		this.devices = devices;
 		return this;
 	}
+
+    @Override
+	public StartContainerCmd withExtraHosts(String... extraHosts) {
+		checkNotNull(extraHosts, "extraHosts was not specified");
+		this.extraHosts = extraHosts;
+		return this;
+	}
+    
     
     @Override
    	public StartContainerCmd withRestartPolicy(RestartPolicy restartPolicy) {

--- a/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
@@ -311,4 +311,27 @@ public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
 
 	}
 
+	@Test
+	public void createContainerWithExtraHosts() throws DockerException {
+
+		String[] extraHosts = {"dockerhost:127.0.0.1", "otherhost:10.0.0.1"};
+
+		HostConfig hostConfig = new HostConfig();
+		hostConfig.setExtraHosts(extraHosts);
+
+		CreateContainerResponse container = dockerClient
+				.createContainerCmd("busybox").withName("container")
+				.withHostConfig(hostConfig).exec();
+
+		LOG.info("Created container {}", container.toString());
+
+		assertThat(container.getId(), not(isEmptyString()));
+
+		InspectContainerResponse inspectContainerResponse = dockerClient
+				.inspectContainerCmd(container.getId()).exec();
+
+		assertThat(Arrays.asList(inspectContainerResponse.getHostConfig().getExtraHosts()),
+				containsInAnyOrder("dockerhost:127.0.0.1", "otherhost:10.0.0.1"));
+	}
+
 }

--- a/src/test/java/com/github/dockerjava/core/command/StartContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/StartContainerCmdImplTest.java
@@ -438,6 +438,29 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
 	}
 
 	@Test
+	public void startContainerWithExtraHosts() throws DockerException {
+
+		CreateContainerResponse container = dockerClient
+				.createContainerCmd("busybox").withCmd("sleep", "9999").exec();
+
+		LOG.info("Created container {}", container.toString());
+
+		assertThat(container.getId(), not(isEmptyString()));
+
+		dockerClient.startContainerCmd(container.getId())
+				.withExtraHosts("dockerhost:127.0.0.1")
+				.exec();
+
+		InspectContainerResponse inspectContainerResponse = dockerClient
+				.inspectContainerCmd(container.getId()).exec();
+
+		assertThat(inspectContainerResponse.getState().isRunning(), is(true));
+
+		assertThat(Arrays.asList(inspectContainerResponse.getHostConfig()
+				.getExtraHosts()), contains("dockerhost:127.0.0.1"));
+	}
+
+	@Test
 	public void startContainerWithRestartPolicy() throws DockerException {
 
 		CreateContainerResponse container = dockerClient


### PR DESCRIPTION
Extends HostConfig to support adding entries to /etc/hosts on startup.

See https://docs.docker.com/reference/api/docker_remote_api_v1.16/ for details on the API