### PR TITLE
Implemented HTTP Basic Auth for DockerClient.

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
@@ -1,9 +1,10 @@
 package com.github.dockerjava.api.command;
 
-import com.github.dockerjava.api.model.EventStreamItem;
-
 import java.io.IOException;
 import java.io.InputStream;
+
+import com.github.dockerjava.api.model.AuthConfigurations;
+import com.github.dockerjava.api.model.EventStreamItem;
 
 /**
  * 
@@ -26,6 +27,8 @@ public interface BuildImageCmd extends DockerCmd<BuildImageCmd.Response>{
 
 	public boolean isQuiet();
 	
+	public AuthConfigurations getBuildAuthConfigs();
+	
 	public BuildImageCmd withTarInputStream(InputStream tarInputStream);
 
 	public BuildImageCmd withNoCache();
@@ -40,10 +43,13 @@ public interface BuildImageCmd extends DockerCmd<BuildImageCmd.Response>{
 
 	public BuildImageCmd withQuiet(boolean quiet);
 	
+  	public BuildImageCmd withBuildAuthConfigs(AuthConfigurations authConfig);
+	
 	public static interface Exec extends DockerCmdExec<BuildImageCmd, BuildImageCmd.Response> {
 	}
 
   public static abstract class Response extends InputStream {
     public abstract Iterable<EventStreamItem> getItems() throws IOException;
   }
+
 }

--- a/src/main/java/com/github/dockerjava/api/model/AuthConfigurations.java
+++ b/src/main/java/com/github/dockerjava/api/model/AuthConfigurations.java
@@ -1,0 +1,21 @@
+package com.github.dockerjava.api.model;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AuthConfigurations {
+
+	@JsonProperty("configs")
+	private Map<String, AuthConfig> configs = new TreeMap<>();
+	
+	public void addConfig(AuthConfig authConfig){
+		configs.put(authConfig.getServerAddress(), authConfig);
+	}
+	
+	public Map<String, AuthConfig> getConfigs(){
+		return this.configs;
+	}
+	
+}

--- a/src/main/java/com/github/dockerjava/api/model/EventStreamItem.java
+++ b/src/main/java/com/github/dockerjava/api/model/EventStreamItem.java
@@ -15,7 +15,9 @@ import com.google.common.base.Objects;
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class EventStreamItem implements Serializable {
 
-    @JsonProperty("stream")
+	private static final long serialVersionUID = 638778515773898651L;
+
+	@JsonProperty("stream")
     private String stream;
 
     // {"error":"Error...", "errorDetail":{"code": 123, "message": "Error..."}}

--- a/src/main/java/com/github/dockerjava/api/model/PushEventStreamItem.java
+++ b/src/main/java/com/github/dockerjava/api/model/PushEventStreamItem.java
@@ -13,7 +13,9 @@ import com.google.common.base.Objects;
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class PushEventStreamItem implements Serializable {
 
-    @JsonProperty("status")
+	private static final long serialVersionUID = -5187169652557467828L;
+
+	@JsonProperty("status")
     private String status;
 
     @JsonProperty("progress")

--- a/src/main/java/com/github/dockerjava/core/DockerClientConfig.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientConfig.java
@@ -39,6 +39,7 @@ public class DockerClientConfig implements Serializable {
     // connection pooling properties
     private static final String DOCKER_IO_MAX_PER_ROUTE_PROPERTY = "docker.io.perRouteConnections";
     private static final String DOCKER_IO_MAX_TOTAL_PROPERTY = "docker.io.totalConnections";
+    
     /**
      * A map from the environment name to the interval name.
      */
@@ -62,7 +63,7 @@ public class DockerClientConfig implements Serializable {
 
     private static final String DOCKER_IO_PROPERTIES_PROPERTY = "docker.io.properties";
     private URI uri;
-    private final String version, username, password, email, serverAddress, dockerCfgPath;
+    private final String version, username, password, email, serverAddress, dockerCfgPath, basicAuthUsername, basicAuthPassword;
     private final Integer readTimeout;
     private final boolean loggingFilterEnabled;
     private final boolean followRedirectsFilterEnabled;
@@ -73,7 +74,7 @@ public class DockerClientConfig implements Serializable {
 
     DockerClientConfig(URI uri, String version, String username, String password, String email, String serverAddress,
                        String dockerCfgPath, Integer readTimeout, boolean loggingFilterEnabled, boolean followRedirectsFilterEnabled, 
-                       SSLConfig sslConfig, Integer maxTotalConns, Integer maxPerRouteConns) {
+                       SSLConfig sslConfig, Integer maxTotalConns, Integer maxPerRouteConns, String basicAuthUsername, String basicAuthPassword) {
         this.uri = uri;
         this.version = version;
         this.username = username;
@@ -87,6 +88,8 @@ public class DockerClientConfig implements Serializable {
         this.sslConfig = sslConfig;
         this.maxTotalConnections = maxTotalConns;
         this.maxPerRouteConnections = maxPerRouteConns;
+        this.basicAuthUsername = basicAuthUsername;
+        this.basicAuthPassword = basicAuthPassword;
     }
 
     private static Properties loadIncludedDockerProperties(Properties systemProperties) {
@@ -267,6 +270,14 @@ public class DockerClientConfig implements Serializable {
     public Integer getMaxPerRoutConnections() {
       return maxPerRouteConnections;
     }
+
+    public String getBasicAuthUsername(){
+    	return this.basicAuthUsername;
+    }
+
+    public String getBasicAuthPassword(){
+    	return this.basicAuthPassword;
+    }
     
     private AuthConfig getAuthConfig() {
     	AuthConfig authConfig = null;
@@ -330,7 +341,8 @@ public class DockerClientConfig implements Serializable {
         if (uri != null ? !uri.equals(that.uri) : that.uri != null) return false;
         if (username != null ? !username.equals(that.username) : that.username != null) return false;
         if (version != null ? !version.equals(that.version) : that.version != null) return false;
-
+        if (basicAuthUsername != null ? !basicAuthUsername.equals(that.basicAuthUsername) : that.basicAuthUsername != null) return false;
+        if (basicAuthPassword != null ? !basicAuthPassword.equals(that.version) : that.basicAuthPassword != null) return false;
         return true;
     }
 
@@ -345,6 +357,8 @@ public class DockerClientConfig implements Serializable {
         result = 31 * result + (dockerCfgPath != null ? dockerCfgPath.hashCode() : 0);
         result = 31 * result + (sslConfig != null ? sslConfig.hashCode() : 0);
         result = 31 * result + (readTimeout != null ? readTimeout.hashCode() : 0);
+        result = 31 * result + (basicAuthUsername != null ? basicAuthUsername.hashCode() : 0);
+        result = 31 * result + (basicAuthPassword != null ? basicAuthPassword.hashCode() : 0);
         result = 31 * result + (loggingFilterEnabled ? 1 : 0);
         return result;
     }
@@ -363,12 +377,14 @@ public class DockerClientConfig implements Serializable {
                 ", readTimeout=" + readTimeout +
                 ", loggingFilterEnabled=" + loggingFilterEnabled +
                 ", followRedirectsFilterEnabled=" + followRedirectsFilterEnabled +
+                ", basicAuthUsername=" + basicAuthUsername +
+                ", basicAuthPassword=" + basicAuthPassword +
                 '}';
     }
 
     public static class DockerClientConfigBuilder {
         private URI uri;
-        private String version, username, password, email, serverAddress, dockerCfgPath;
+        private String version, username, password, email, serverAddress, dockerCfgPath, basicAuthUsername, basicAuthPassword;
         private Integer readTimeout, maxTotalConnections, maxPerRouteConnections;
         private boolean loggingFilterEnabled, followRedirectsFilterEnabled;
         private SSLConfig sslConfig;
@@ -391,6 +407,7 @@ public class DockerClientConfig implements Serializable {
                     .withFollowRedirectsFilter(Boolean.valueOf(p.getProperty(DOCKER_IO_FOLLOW_REDIRECTS_FILTER_PROPERTY, "false")))
                     .withDockerCertPath(p.getProperty(DOCKER_IO_DOCKER_CERT_PATH_PROPERTY))
                     .withDockerCfgPath(p.getProperty(DOCKER_IO_DOCKER_CFG_PATH_PROPERTY))
+                    .withMaxPerRouteConnections(integerValue(p.getProperty(DOCKER_IO_MAX_PER_ROUTE_PROPERTY)))
                     .withMaxPerRouteConnections(integerValue(p.getProperty(DOCKER_IO_MAX_PER_ROUTE_PROPERTY)))
                     .withMaxTotalConnections(integerValue(p.getProperty(DOCKER_IO_MAX_TOTAL_PROPERTY)));
         }
@@ -474,6 +491,17 @@ public class DockerClientConfig implements Serializable {
             return this;
         }
 
+
+        public final DockerClientConfigBuilder withBasicAuthUsername(String username) {
+            this.basicAuthUsername = username;
+            return this;
+        }
+
+        public final DockerClientConfigBuilder withBasicAuthPassword(String password) {
+            this.basicAuthPassword = password;
+            return this;
+        }
+
         public DockerClientConfig build() {
             return new DockerClientConfig(
                     uri,
@@ -488,7 +516,9 @@ public class DockerClientConfig implements Serializable {
                     followRedirectsFilterEnabled,
                     sslConfig,
                     maxTotalConnections,
-                    maxPerRouteConnections
+                    maxPerRouteConnections,
+                    basicAuthUsername,
+                    basicAuthPassword
             );
         }
     }

--- a/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import com.github.dockerjava.api.command.BuildImageCmd;
+import com.github.dockerjava.api.model.AuthConfigurations;
 import com.github.dockerjava.core.dockerfile.Dockerfile;
 
 /**
@@ -22,6 +23,7 @@ public class BuildImageCmdImpl extends AbstrDockerCmd<BuildImageCmd, BuildImageC
 	private boolean noCache;
 	private boolean remove = true;
 	private boolean quiet;
+	private AuthConfigurations buildAuthConfigs;
 
 	public BuildImageCmdImpl(BuildImageCmd.Exec exec, File dockerFolder) {
 		super(exec);
@@ -84,6 +86,11 @@ public class BuildImageCmdImpl extends AbstrDockerCmd<BuildImageCmd, BuildImageC
 	}
 
 	@Override
+	public AuthConfigurations getBuildAuthConfigs() {
+		return buildAuthConfigs;
+	}
+
+	@Override
 	public BuildImageCmdImpl withNoCache() {
 		return withNoCache(true);
 	}
@@ -113,6 +120,13 @@ public class BuildImageCmdImpl extends AbstrDockerCmd<BuildImageCmd, BuildImageC
 	@Override
 	public BuildImageCmdImpl withQuiet(boolean quiet) {
 		this.quiet = quiet;
+		return this;
+	}
+
+	@Override
+	public BuildImageCmd withBuildAuthConfigs(AuthConfigurations authConfigs) {
+		checkNotNull(authConfigs, "authConfig is null");
+		this.buildAuthConfigs = authConfigs;
 		return this;
 	}
 

--- a/src/main/java/com/github/dockerjava/core/util/BasicAuthenticationFilter.java
+++ b/src/main/java/com/github/dockerjava/core/util/BasicAuthenticationFilter.java
@@ -1,0 +1,36 @@
+package com.github.dockerjava.core.util;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.xml.bind.DatatypeConverter;
+
+public class BasicAuthenticationFilter implements ClientRequestFilter {
+
+    private final String user;
+    private final String password;
+
+    public BasicAuthenticationFilter(String user, String password) {
+        this.user = user;
+        this.password = password;
+    }
+
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        MultivaluedMap<String, Object> headers = requestContext.getHeaders();
+        final String basicAuthentication = getBasicAuthentication();
+        headers.add("Authorization", basicAuthentication);
+
+    }
+
+    private String getBasicAuthentication() {
+        String token = this.user + ":" + this.password;
+        try {
+            return "BASIC " + DatatypeConverter.printBase64Binary(token.getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException ex) {
+            throw new IllegalStateException("Cannot encode with UTF-8", ex);
+        }
+    }
+}

--- a/src/main/java/com/github/dockerjava/jaxrs/AbstrDockerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/AbstrDockerCmdExec.java
@@ -14,6 +14,7 @@ import com.github.dockerjava.api.DockerException;
 import com.github.dockerjava.api.command.DockerCmd;
 import com.github.dockerjava.api.command.DockerCmdExec;
 import com.github.dockerjava.api.model.AuthConfig;
+import com.github.dockerjava.api.model.AuthConfigurations;
 
 public abstract class AbstrDockerCmdExec<CMD_T extends DockerCmd<RES_T>, RES_T>
 		implements DockerCmdExec<CMD_T, RES_T> {
@@ -34,6 +35,15 @@ public abstract class AbstrDockerCmdExec<CMD_T extends DockerCmd<RES_T>, RES_T>
 		try {
 			return Base64.encodeBase64String(new ObjectMapper()
 					.writeValueAsString(authConfig).getBytes());
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String registryConfigs(AuthConfigurations authConfigs) {
+		try {
+			return Base64.encodeBase64String(new ObjectMapper()
+					.writeValueAsString(authConfigs).getBytes());
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/src/test/java/com/github/dockerjava/core/DockerClientConfigTest.java
+++ b/src/test/java/com/github/dockerjava/core/DockerClientConfigTest.java
@@ -16,7 +16,7 @@ public class DockerClientConfigTest {
     public static final DockerClientConfig EXAMPLE_CONFIG = newExampleConfig();
 
     private static DockerClientConfig newExampleConfig() {
-        return new DockerClientConfig(URI.create("http://foo"), "bar", "baz", "qux", "blam", "wham", "flam", 877, false, false, new LocalDirectorySSLConfig("flim"), 20, 2);
+        return new DockerClientConfig(URI.create("http://foo"), "bar", "baz", "qux", "blam", "wham", "flam", 877, false, false, new LocalDirectorySSLConfig("flim"), 20, 2, null, null);
     }
 
     @Test

--- a/src/test/java/com/github/dockerjava/core/DockerClientImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/DockerClientImplTest.java
@@ -10,7 +10,7 @@ public class DockerClientImplTest {
     @Test
     public void configuredInstanceAuthConfig() throws Exception {
         // given a config with null serverAddress
-        DockerClientConfig dockerClientConfig = new DockerClientConfig(null, null, "", "", "", null, null,  0, false, false, null, 20, 2);
+        DockerClientConfig dockerClientConfig = new DockerClientConfig(null, null, "", "", "", null, null,  0, false, false, null, 20, 2, null, null);
         DockerClientImpl dockerClient = DockerClientImpl.getInstance(dockerClientConfig);
 
         // when we get the auth config


### PR DESCRIPTION
As described in the following issue:
https://github.com/docker-java/docker-java/issues/162

@marcuslinke 
Your link helped a lot.
Adding config.property(ClientProperties.REQUEST_ENTITY_PROCESSING, RequestEntityProcessing.BUFFERED); allowed me to get a 401 error, instead of an ugly java stack trace.

I still had to add a new BasicAuthenticationFilter to the client to fully enable the basic authentication.

Please find this feature implemented in here.

Thanks for your help.

Best regards,

Eric