### PR TITLE
PushImageCmd assumes that you have an auth config setup 

### DIFF
--- a/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
@@ -126,8 +126,13 @@ public class DockerClientImpl implements Closeable, DockerClient {
 
 	@Override
 	public PushImageCmd pushImageCmd(String name) {
-		return new PushImageCmdImpl(getDockerCmdExecFactory()
-				.createPushImageCmdExec(), name).withAuthConfig(dockerClientConfig.effectiveAuthConfig(name));		
+          PushImageCmd cmd = new PushImageCmdImpl(getDockerCmdExecFactory()
+				.createPushImageCmdExec(), name);
+
+          AuthConfig cfg = dockerClientConfig.effectiveAuthConfig(name);
+          if( cfg != null )
+            cmd.withAuthConfig(cfg);
+          return cmd;
 	}
     
     @Override


### PR DESCRIPTION
for the host that you are pushing to, which is not mandatory.

This generates an exception because if fails the precondition of
the config not being null.

Signed-off-by: Nigel Magnay <nigel.magnay@gmail.com>