### PR TITLE
Since docker 1.5.0, it has been allowable to specify files other

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.api.command;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -26,8 +27,10 @@ public interface BuildImageCmd extends DockerCmd<BuildImageCmd.Response>{
 	public boolean hasRemoveEnabled();
 
 	public boolean isQuiet();
-	
+
 	public AuthConfigurations getBuildAuthConfigs();
+	
+    public BuildImageCmd withDockerfile(File dockerfile);
 	
 	public BuildImageCmd withTarInputStream(InputStream tarInputStream);
 

--- a/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
@@ -292,9 +292,9 @@ public class DockerClientImpl implements Closeable, DockerClient {
 	}
 
 	@Override
-	public BuildImageCmd buildImageCmd(File dockerFolder) {
+	public BuildImageCmd buildImageCmd(File dockerFileOrFolder) {
 		return new BuildImageCmdImpl(getDockerCmdExecFactory()
-				.createBuildImageCmdExec(), dockerFolder);
+				.createBuildImageCmdExec(), dockerFileOrFolder);
 	}
 
 	@Override


### PR DESCRIPTION
than 'Dockerfile' for building images.

Alter the BuildImageCmd so that you can either specify the directory
(which assumes Dockerfile, for backwards compat) or the actual file you
wish to use.

Signed-off-by: Nigel Magnay <nigel.magnay@gmail.com>