### PR TITLE
SaveImageCmd API doesn't support X-Registry-Auth header

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/SaveImageCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/SaveImageCmd.java
@@ -1,7 +1,6 @@
 package com.github.dockerjava.api.command;
 
 import com.github.dockerjava.api.NotFoundException;
-import com.github.dockerjava.api.model.AuthConfig;
 
 import java.io.InputStream;
 
@@ -20,10 +19,6 @@ public interface SaveImageCmd extends DockerCmd<InputStream>{
      * @param tag The image's tag. Not null.
      */
     public SaveImageCmd withTag(String tag);
-
-    public AuthConfig getAuthConfig();
-
-    public SaveImageCmd withAuthConfig(AuthConfig authConfig);
 
     /**
      * @throws com.github.dockerjava.api.NotFoundException No such image

--- a/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
@@ -151,13 +151,7 @@ public class DockerClientImpl implements Closeable, DockerClient {
 
         @Override
     public SaveImageCmd saveImageCmd(String name) {
-        SaveImageCmdImpl cmd = new SaveImageCmdImpl(getDockerCmdExecFactory().createSaveImageCmdExec(), name);
-
-        AuthConfig cfg = dockerClientConfig.effectiveAuthConfig(name);
-        if (cfg != null)
-            cmd.withAuthConfig(cfg);
-
-        return cmd;
+        return new SaveImageCmdImpl(getDockerCmdExecFactory().createSaveImageCmdExec(), name);
     }
 
 	@Override

--- a/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
@@ -151,9 +151,13 @@ public class DockerClientImpl implements Closeable, DockerClient {
 
         @Override
     public SaveImageCmd saveImageCmd(String name) {
-        return new SaveImageCmdImpl(getDockerCmdExecFactory()
-            .createSaveImageCmdExec(), name).withAuthConfig(dockerClientConfig.effectiveAuthConfig(name));
-        
+        SaveImageCmdImpl cmd = new SaveImageCmdImpl(getDockerCmdExecFactory().createSaveImageCmdExec(), name);
+
+        AuthConfig cfg = dockerClientConfig.effectiveAuthConfig(name);
+        if (cfg != null)
+            cmd.withAuthConfig(cfg);
+
+        return cmd;
     }
 
 	@Override

--- a/src/main/java/com/github/dockerjava/core/command/SaveImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/SaveImageCmdImpl.java
@@ -7,7 +7,7 @@ import java.io.InputStream;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class SaveImageCmdImpl extends AbstrAuthCfgDockerCmd<SaveImageCmd, InputStream> implements SaveImageCmd {
+public class SaveImageCmdImpl extends AbstrDockerCmd<SaveImageCmd, InputStream> implements SaveImageCmd {
     private String name;
     private String tag;
 

--- a/src/main/java/com/github/dockerjava/jaxrs/SaveImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/SaveImageCmdExec.java
@@ -23,11 +23,9 @@ public class SaveImageCmdExec extends AbstrDockerCmdExec<SaveImageCmd, InputStre
         WebTarget webResource = getBaseResource().path("/images/" + command.getName() + "/get")
                 .queryParam("tag", command.getTag());
 
-        final String registryAuth = registryAuth(command.getAuthConfig());
         LOGGER.trace("GET: {}", webResource);
         InputStream is =  webResource
                 .request()
-                .header("X-Registry-Auth", registryAuth)
                 .accept(MediaType.APPLICATION_JSON)
                 .get().readEntity(InputStream.class);
 

--- a/src/main/java/com/github/dockerjava/jaxrs/SaveImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/SaveImageCmdExec.java
@@ -12,7 +12,7 @@ import com.github.dockerjava.api.command.SaveImageCmd;
 
 public class SaveImageCmdExec extends AbstrDockerCmdExec<SaveImageCmd, InputStream> implements SaveImageCmd.Exec {
     private static final Logger LOGGER = LoggerFactory
-            .getLogger(PushImageCmdExec.class);
+            .getLogger(SaveImageCmdExec.class);
 
     public SaveImageCmdExec(WebTarget baseResource) {
         super(baseResource);

--- a/src/test/java/com/github/dockerjava/core/command/SaveImageCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/SaveImageCmdImplTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.not;
 @Test(groups = "integration")
 public class SaveImageCmdImplTest extends AbstractDockerClientTest {
     public static final Logger LOG = LoggerFactory
-            .getLogger(PushImageCmdImplTest.class);
+            .getLogger(SaveImageCmdImplTest.class);
 
     String username;
 


### PR DESCRIPTION
As for #165 a NPE will be throw if the auth config is not complete.
However according the API documentation the X-Registry-Auth header is not part of the save image API, so I removed it