### PR TITLE
Dockerfiles not called 'dockerfile'

### DIFF
--- a/src/main/java/com/github/dockerjava/api/DockerClient.java
+++ b/src/main/java/com/github/dockerjava/api/DockerClient.java
@@ -98,7 +98,9 @@ public interface DockerClient extends Closeable {
 
 	public CommitCmd commitCmd(String containerId);
 
-	public BuildImageCmd buildImageCmd(File dockerFolder);
+    public BuildImageCmd buildImageCmd();
+
+	public BuildImageCmd buildImageCmd(File dockerFileOrFolder);
 
 	public BuildImageCmd buildImageCmd(InputStream tarInputStream);
 

--- a/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
@@ -28,8 +28,12 @@ public interface BuildImageCmd extends DockerCmd<BuildImageCmd.Response>{
 
 	public boolean isQuiet();
 
+    public String getPathToDockerfile();
+
 	public AuthConfigurations getBuildAuthConfigs();
-	
+
+    public BuildImageCmd withBaseDirectory(File baseDirectory);
+
     public BuildImageCmd withDockerfile(File dockerfile);
 	
 	public BuildImageCmd withTarInputStream(InputStream tarInputStream);

--- a/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
@@ -291,6 +291,12 @@ public class DockerClientImpl implements Closeable, DockerClient {
 				.createCommitCmdExec(), containerId);
 	}
 
+    @Override
+    public BuildImageCmd buildImageCmd() {
+        return new BuildImageCmdImpl(getDockerCmdExecFactory()
+                .createBuildImageCmdExec());
+    }
+
 	@Override
 	public BuildImageCmd buildImageCmd(File dockerFileOrFolder) {
 		return new BuildImageCmdImpl(getDockerCmdExecFactory()

--- a/src/main/java/com/github/dockerjava/core/dockerfile/Dockerfile.java
+++ b/src/main/java/com/github/dockerjava/core/dockerfile/Dockerfile.java
@@ -166,6 +166,10 @@ public class Dockerfile {
     final List<File> filesToAdd = new ArrayList<File>();
 
     public InputStream buildDockerFolderTar() {
+        return buildDockerFolderTar(getDockerFolder());
+    }
+
+    public InputStream buildDockerFolderTar(File directory) {
 
       // ARCHIVE TAR
       File dockerFolderTar = null;
@@ -173,7 +177,7 @@ public class Dockerfile {
       try {
         String archiveNameWithOutExtension = UUID.randomUUID().toString();
 
-        dockerFolderTar = CompressArchiveUtil.archiveTARFiles(getDockerFolder(),
+        dockerFolderTar = CompressArchiveUtil.archiveTARFiles(directory,
                                                               filesToAdd,
                                                               archiveNameWithOutExtension);
         return FileUtils.openInputStream(dockerFolderTar);

--- a/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
@@ -35,6 +35,7 @@ public class BuildImageCmdExec extends AbstrDockerCmdExec<BuildImageCmd, BuildIm
 	@Override
 	protected ResponseImpl execute(BuildImageCmd command) {
 		WebTarget webResource = getBaseResource().path("/build");
+        String dockerFilePath = command.getPathToDockerfile();
 		
 		if(command.getTag() != null) {
 			webResource = webResource.queryParam("t", command.getTag());
@@ -47,6 +48,9 @@ public class BuildImageCmdExec extends AbstrDockerCmdExec<BuildImageCmd, BuildIm
         }
         if (command.isQuiet()) {
             webResource = webResource.queryParam("q", "true");
+        }
+        if( dockerFilePath != null && !"Dockerfile".equals(dockerFilePath)) {
+            webResource = webResource.queryParam("dockerfile", dockerFilePath);
         }
 		
 

--- a/src/test/java/com/github/dockerjava/core/command/BuildImageCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/BuildImageCmdImplTest.java
@@ -76,6 +76,34 @@ public class BuildImageCmdImplTest extends AbstractDockerClientTest {
 				equalTo("Guillaume J. Charmes \"guillaume@dotcloud.com\""));
 	}
 
+    @Test
+    public void testNonstandard1() {
+        File baseDir = new File(Thread.currentThread().getContextClassLoader()
+                .getResource("nonstandard/subdirectory/Dockerfile-nonstandard").getFile());
+
+        InputStream response = dockerClient.buildImageCmd(baseDir).withNoCache().exec();
+
+        String fullLog = asString(response);
+        assertThat(fullLog, containsString("Successfully built"));
+    }
+
+    @Test
+    public void testNonstandard2() {
+        File baseDir = new File(Thread.currentThread().getContextClassLoader()
+                .getResource("nonstandard").getFile());
+        File dockerFile = new File(Thread.currentThread().getContextClassLoader()
+                .getResource("nonstandard/subdirectory/Dockerfile-nonstandard").getFile());
+
+
+            InputStream response = dockerClient.buildImageCmd()
+                    .withBaseDirectory(baseDir)
+                    .withDockerfile(dockerFile)
+                    .withNoCache().exec();
+
+        String fullLog = asString(response);
+        assertThat(fullLog, containsString("Successfully built"));
+    }
+
 	@Test
 	public void testDockerBuilderAddUrl()  {
 		File baseDir = new File(Thread.currentThread().getContextClassLoader()

--- a/src/test/resources/nonstandard/subdirectory/Dockerfile-nonstandard
+++ b/src/test/resources/nonstandard/subdirectory/Dockerfile-nonstandard
@@ -1,0 +1,12 @@
+# Nginx
+#
+# VERSION               0.0.1
+
+FROM      ubuntu:latest
+MAINTAINER Guillaume J. Charmes "guillaume@dotcloud.com"
+
+# make sure the package repository is up to date
+RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
+RUN apt-get update
+
+RUN apt-get install -y inotify-tools nginx apache2 openssh-server


### PR DESCRIPTION
Pass the name of the Dockerfile to docker (required or it doesn't know where to find it).
Adjust the TAR file to build from the correct path
Implement some tests to show it working with a nonstandard name.

Signed-off-by: Nigel Magnay <nigel.magnay@gmail.com>