### PR TITLE
 * Fixed remove intermediate containers bug on build goal - it was alway...

### DIFF
--- a/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
@@ -46,8 +46,8 @@ public class BuildImageCmdExec extends
 		if (command.hasNoCacheEnabled()) {
 			webResource = webResource.queryParam("nocache", "true");
 		}
-		if (command.hasRemoveEnabled()) {
-			webResource = webResource.queryParam("rm", "true");
+		if (!command.hasRemoveEnabled()) {
+			webResource = webResource.queryParam("rm", "false");
 		}
 		if (command.isQuiet()) {
 			webResource = webResource.queryParam("q", "true");


### PR DESCRIPTION
Fixed remove intermediate containers bug when building containers. It was always set to true. 

In the documentation it says:
rm - remove intermediate containers after a successful build (default behavior)

So it has to be set to false to disable it. 
Could you please merge that as soon as possible and release it. Thanks