### PR TITLE
Fix connection leak when building images. Added tests for FrameReader when multi-threaded.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 		<jdk.source>1.7</jdk.source>
 		<jdk.target>1.7</jdk.target>
 
-		<jersey.version>2.11</jersey.version>
+		<jersey.version>2.17</jersey.version>
 		<jackson-jaxrs.version>2.1.2</jackson-jaxrs.version>
 		<httpclient.version>4.3.1</httpclient.version>
 		<commons-compress.version>1.5</commons-compress.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 		<jdk.source>1.7</jdk.source>
 		<jdk.target>1.7</jdk.target>
 
-		<jersey.version>2.17</jersey.version>
+		<jersey.version>2.11</jersey.version>
 		<jackson-jaxrs.version>2.1.2</jackson-jaxrs.version>
 		<httpclient.version>4.3.1</httpclient.version>
 		<commons-compress.version>1.5</commons-compress.version>

--- a/src/main/java/com/github/dockerjava/api/model/Frame.java
+++ b/src/main/java/com/github/dockerjava/api/model/Frame.java
@@ -34,7 +34,7 @@ public class Frame {
 
         Frame frame = (Frame) o;
 
-        return Arrays.equals(payload, frame.payload) && streamType == frame.streamType;
+        return streamType == frame.streamType && Arrays.equals(payload, frame.payload);
 
     }
 

--- a/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
@@ -1,21 +1,5 @@
 package com.github.dockerjava.jaxrs;
 
-import static javax.ws.rs.client.Entity.entity;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Iterator;
-
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
-import org.glassfish.jersey.client.ClientProperties;
-import org.glassfish.jersey.client.RequestEntityProcessing;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.github.dockerjava.api.command.BuildImageCmd;
@@ -23,6 +7,20 @@ import com.github.dockerjava.api.model.AuthConfigurations;
 import com.github.dockerjava.api.model.EventStreamItem;
 import com.github.dockerjava.jaxrs.util.WrappedResponseInputStream;
 import com.google.common.collect.ImmutableList;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.RequestEntityProcessing;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+
+import static javax.ws.rs.client.Entity.entity;
 
 public class BuildImageCmdExec extends
 		AbstrDockerCmdExec<BuildImageCmd, BuildImageCmd.Response> implements
@@ -111,6 +109,12 @@ public class BuildImageCmdExec extends
 		@Override
 		public int read() throws IOException {
 			return proxy.read();
+		}
+
+		@Override
+		public void close() throws IOException {
+			proxy.close();
+			super.close();
 		}
 	}
 }

--- a/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
+++ b/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
@@ -2,6 +2,7 @@ package com.github.dockerjava.core.command;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.NotFoundException;
+import com.github.dockerjava.api.model.Image;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,16 +33,18 @@ public class DockerfileFixture implements AutoCloseable {
                 .exec()
                 .close();
 
-        repository = dockerClient
+        Image lastCreatedImage = dockerClient
                 .listImagesCmd()
                 .exec()
-                .get(0)
+                .get(0);
+
+        repository = lastCreatedImage
                 .getRepoTags()[0];
 
-        LOGGER.info("created {}", repository);
+        LOGGER.info("created {} {}", lastCreatedImage.getId(), repository);
 
         containerId = dockerClient
-                .createContainerCmd(repository)
+                .createContainerCmd(lastCreatedImage.getId())
                 .exec()
                 .getId();
 

--- a/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
+++ b/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
@@ -66,7 +66,7 @@ public class DockerfileFixture implements AutoCloseable {
                         .removeContainerCmd(containerId)
                         .withForce() // stop too
                         .exec();
-            } catch (NotFoundException ignored) {
+            } catch (NotFoundException | InternalServerErrorException ignored) {
                 LOGGER.info("ignoring {}", ignored.getMessage());
             }
             containerId = null;

--- a/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
+++ b/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
@@ -1,6 +1,8 @@
 package com.github.dockerjava.core.command;
 
 import com.github.dockerjava.api.DockerClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
@@ -9,6 +11,7 @@ import java.io.File;
  */
 public class DockerfileFixture implements AutoCloseable {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(DockerfileFixture.class);
     private final DockerClient dockerClient;
     private String directory;
     private String repository;
@@ -21,6 +24,7 @@ public class DockerfileFixture implements AutoCloseable {
 
     public void open() throws Exception {
 
+        LOGGER.info("building {}", directory);
         dockerClient
                 .buildImageCmd(new File("src/test/resources", directory))
                 .withNoCache() // remove alternatives, cause problems
@@ -33,10 +37,14 @@ public class DockerfileFixture implements AutoCloseable {
                 .get(0)
                 .getRepoTags()[0];
 
+        LOGGER.info("created {}", repository);
+
         containerId = dockerClient
                 .createContainerCmd(repository)
                 .exec()
                 .getId();
+
+        LOGGER.info("starting {}", containerId);
 
         dockerClient
                 .startContainerCmd(containerId)
@@ -46,15 +54,23 @@ public class DockerfileFixture implements AutoCloseable {
     @Override
     public void close() throws Exception {
 
-        dockerClient
-                .removeContainerCmd(containerId)
-                .withForce() // stop too
-                .exec();
+        if (containerId != null) {
+            LOGGER.info("removing container {}", containerId);
+            dockerClient
+                    .removeContainerCmd(containerId)
+                    .withForce() // stop too
+                    .exec();
+            containerId = null;
+        }
 
-        dockerClient
-                .removeImageCmd(repository)
-                .withForce()
-                .exec();
+        if (repository != null) {
+            LOGGER.info("removing repostiory {}", repository);
+            dockerClient
+                    .removeImageCmd(repository)
+                    .withForce()
+                    .exec();
+            repository = null;
+        }
     }
 
     public String getContainerId() {

--- a/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
+++ b/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
@@ -1,6 +1,7 @@
 package com.github.dockerjava.core.command;
 
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.InternalServerErrorException;
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.model.Image;
 import org.slf4j.Logger;
@@ -73,10 +74,14 @@ public class DockerfileFixture implements AutoCloseable {
 
         if (repository != null) {
             LOGGER.info("removing repository {}", repository);
-            dockerClient
-                    .removeImageCmd(repository)
-                    .withForce()
-                    .exec();
+            try {
+                dockerClient
+                        .removeImageCmd(repository)
+                        .withForce()
+                        .exec();
+            } catch (InternalServerErrorException e) {
+                LOGGER.info("ignoring {}", e.getMessage());
+            }
             repository = null;
         }
     }

--- a/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
+++ b/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
@@ -1,0 +1,63 @@
+package com.github.dockerjava.core.command;
+
+import com.github.dockerjava.api.DockerClient;
+
+import java.io.File;
+
+/**
+ * Start and stop a single container for testing.
+ */
+public class DockerfileFixture implements AutoCloseable {
+
+    private final DockerClient dockerClient;
+    private String directory;
+    private String repository;
+    private String containerId;
+
+    public DockerfileFixture(DockerClient dockerClient, String directory) {
+        this.dockerClient = dockerClient;
+        this.directory = directory;
+    }
+
+    public void open() throws Exception {
+
+        dockerClient
+                .buildImageCmd(new File("src/test/resources", directory))
+                .withNoCache() // remove alternatives, cause problems
+                .exec()
+                .close();
+
+        repository = dockerClient
+                .listImagesCmd()
+                .exec()
+                .get(0)
+                .getRepoTags()[0];
+
+        containerId = dockerClient
+                .createContainerCmd(repository)
+                .exec()
+                .getId();
+
+        dockerClient
+                .startContainerCmd(containerId)
+                .exec();
+    }
+
+    @Override
+    public void close() throws Exception {
+
+        dockerClient
+                .removeContainerCmd(containerId)
+                .withForce() // stop too
+                .exec();
+
+        dockerClient
+                .removeImageCmd(repository)
+                .withForce()
+                .exec();
+    }
+
+    public String getContainerId() {
+        return containerId;
+    }
+}

--- a/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
+++ b/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
@@ -1,6 +1,7 @@
 package com.github.dockerjava.core.command;
 
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.NotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,15 +57,19 @@ public class DockerfileFixture implements AutoCloseable {
 
         if (containerId != null) {
             LOGGER.info("removing container {}", containerId);
-            dockerClient
-                    .removeContainerCmd(containerId)
-                    .withForce() // stop too
-                    .exec();
+            try {
+                dockerClient
+                        .removeContainerCmd(containerId)
+                        .withForce() // stop too
+                        .exec();
+            } catch (NotFoundException ignored) {
+                LOGGER.info("ignoring {}", ignored.getMessage());
+            }
             containerId = null;
         }
 
         if (repository != null) {
-            LOGGER.info("removing repostiory {}", repository);
+            LOGGER.info("removing repository {}", repository);
             dockerClient
                     .removeImageCmd(repository)
                     .withForce()

--- a/src/test/java/com/github/dockerjava/core/command/FrameReaderITest.java
+++ b/src/test/java/com/github/dockerjava/core/command/FrameReaderITest.java
@@ -1,0 +1,58 @@
+package com.github.dockerjava.core.command;
+
+
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.api.model.StreamType;
+import com.github.dockerjava.client.AbstractDockerClientTest;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.InputStream;
+
+@Test(groups = "integration")
+public class FrameReaderITest extends AbstractDockerClientTest {
+
+    private DockerfileFixture dockerfileFixture;
+
+    @BeforeMethod
+    @Override
+    public void beforeTest() {
+        super.beforeTest();
+        dockerfileFixture = new DockerfileFixture(dockerClient, "frameReaderDockerfile");
+    }
+
+    @BeforeMethod
+    public void createAndStartDockerContainer() throws Exception {
+        dockerfileFixture.open();
+    }
+
+    @AfterMethod
+    public void deleteDockerContainerImage() throws Exception {
+        dockerfileFixture.close();
+    }
+
+    @AfterMethod
+    @Override
+    public void afterTest() {
+        super.afterTest();
+    }
+
+    @Test
+    public void canCloseFrameReaderAndReadExpectedLinens() throws Exception {
+
+        InputStream log = dockerClient
+                .logContainerCmd(dockerfileFixture.getContainerId())
+                .withStdOut()
+                .withStdErr()
+                .withFollowStream()
+                .withTailAll()
+                .exec();
+
+        try (FrameReader reader = new FrameReader(log)) {
+            assertEquals(reader.readFrame(), new Frame(StreamType.STDOUT, String.format("to stdout%n").getBytes()));
+            assertEquals(reader.readFrame(), new Frame(StreamType.STDERR, String.format("to stderr%n").getBytes()));
+            assertNull(reader.readFrame());
+        }
+    }
+}

--- a/src/test/java/com/github/dockerjava/core/command/FrameReaderITest.java
+++ b/src/test/java/com/github/dockerjava/core/command/FrameReaderITest.java
@@ -5,7 +5,9 @@ import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.StreamType;
 import com.github.dockerjava.client.AbstractDockerClientTest;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.io.InputStream;
@@ -15,7 +17,7 @@ public class FrameReaderITest extends AbstractDockerClientTest {
 
     private DockerfileFixture dockerfileFixture;
 
-    @BeforeMethod
+    @BeforeTest
     @Override
     public void beforeTest() {
         super.beforeTest();
@@ -32,7 +34,7 @@ public class FrameReaderITest extends AbstractDockerClientTest {
         dockerfileFixture.close();
     }
 
-    @AfterMethod
+    @AfterTest
     @Override
     public void afterTest() {
         super.afterTest();

--- a/src/test/resources/busyboxDockerfile/Dockerfile
+++ b/src/test/resources/busyboxDockerfile/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox:latest
+
+CMD ["cat"]

--- a/src/test/resources/frameReaderDockerfile/Dockerfile
+++ b/src/test/resources/frameReaderDockerfile/Dockerfile
@@ -1,0 +1,10 @@
+FROM busybox:latest
+
+# log to stdout and stderr so we can make sure logging with FrameReader works
+
+RUN echo '#! /bin/sh' > cmd.sh
+RUN echo 'echo "to stdout"' >> cmd.sh
+RUN echo 'echo "to stderr" > /dev/stderr' >> cmd.sh
+RUN chmod +x cmd.sh
+
+CMD ["./cmd.sh"]

--- a/src/test/resources/frameReaderDockerfile/Dockerfile
+++ b/src/test/resources/frameReaderDockerfile/Dockerfile
@@ -3,8 +3,11 @@ FROM busybox:latest
 # log to stdout and stderr so we can make sure logging with FrameReader works
 
 RUN echo '#! /bin/sh' > cmd.sh
+RUN echo 'sleep 1' >> cmd.sh
 RUN echo 'echo "to stdout"' >> cmd.sh
 RUN echo 'echo "to stderr" > /dev/stderr' >> cmd.sh
+# block for ever
+RUN echo 'cat' >> cmd.sh
 RUN chmod +x cmd.sh
 
 CMD ["./cmd.sh"]


### PR DESCRIPTION
The code was not releasing connections when building containers. I've 

1. Fixed the bug.
2. Added `DockerfileFixture` to make it easier to test single builds.
3. Added a test for `FrameReader` to a make sure multi-threading works OK.