### PR TITLE
Add ulimit support

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/HostConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/HostConfig.java
@@ -1,12 +1,10 @@
 package com.github.dockerjava.api.model;
 
-import java.util.Map;
-
-import org.apache.commons.lang.builder.ToStringBuilder;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HostConfig {
@@ -59,13 +57,16 @@ public class HostConfig {
 	@JsonProperty("ExtraHosts")
 	private String[] extraHosts;
 
+	@JsonProperty("Ulimits")
+	private Ulimit[] ulimits;
+
 	public HostConfig() {
 	}
 
 	public HostConfig(Bind[] binds, Link[] links, LxcConf[] lxcConf, Ports portBindings, boolean publishAllPorts,
 			boolean privileged, String[] dns, String[] dnsSearch, VolumesFrom[] volumesFrom, String containerIDFile,
 			Capability[] capAdd, Capability[] capDrop, RestartPolicy restartPolicy, String networkMode, Device[] devices,
-            String[] extraHosts) {
+            String[] extraHosts, Ulimit[] ulimits) {
 		this.binds = new Binds(binds);
 		this.links = new Links(links);
 		this.lxcConf = lxcConf;
@@ -82,6 +83,7 @@ public class HostConfig {
 		this.networkMode = networkMode;
 		this.devices = devices;
 		this.extraHosts = extraHosts;
+		this.ulimits = ulimits;
 	}
 
 
@@ -151,6 +153,10 @@ public class HostConfig {
 		return capDrop;
 	}
 
+	public Ulimit[] getUlimits() {
+		return ulimits;
+	}
+
 	@JsonIgnore
 	public void setBinds(Bind... binds) {
 		this.binds = new Binds(binds);
@@ -215,6 +221,10 @@ public class HostConfig {
 
 	public void setExtraHosts(String[] extraHosts) {
 		this.extraHosts = extraHosts;
+	}
+
+	public void setUlimits(Ulimit[] ulimits) {
+		this.ulimits = ulimits;
 	}
 
 	@Override

--- a/src/main/java/com/github/dockerjava/api/model/Ulimit.java
+++ b/src/main/java/com/github/dockerjava/api/model/Ulimit.java
@@ -1,0 +1,64 @@
+package com.github.dockerjava.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * @author Vangie Du (duwan@live.com)
+ */
+public class Ulimit {
+
+    @JsonProperty("Name")
+    private String name ;
+
+    @JsonProperty("Soft")
+    private int soft;
+
+    @JsonProperty("Hard")
+    private int hard;
+
+    public Ulimit() {
+
+    }
+
+    public Ulimit(String name, int soft, int hard) {
+        checkNotNull(name, "Name is null");
+
+        this.name = name;
+        this.soft = soft;
+        this.hard = hard;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getSoft() {
+        return soft;
+    }
+
+    public int getHard() {
+        return hard;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Ulimit) {
+            Ulimit other = (Ulimit) obj;
+            return new EqualsBuilder()
+                    .append(name, other.getName())
+                    .append(soft, other.getSoft())
+                    .append(hard, other.getHard()).isEquals();
+        } else
+            return super.equals(obj);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(name).append(soft).append(hard).toHashCode();
+    }
+}

--- a/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
@@ -1,48 +1,23 @@
 package com.github.dockerjava.core.command;
 
-import static com.github.dockerjava.api.model.Capability.MKNOD;
-import static com.github.dockerjava.api.model.Capability.NET_ADMIN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItemInArray;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.startsWith;
+import com.github.dockerjava.api.ConflictException;
+import com.github.dockerjava.api.DockerException;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.*;
+import com.github.dockerjava.client.AbstractDockerClientTest;
+import org.testng.ITestResult;
+import org.testng.annotations.*;
 
 import java.lang.reflect.Method;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.UUID;
 
-import org.testng.ITestResult;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
-import com.github.dockerjava.api.ConflictException;
-import com.github.dockerjava.api.DockerException;
-import com.github.dockerjava.api.command.CreateContainerResponse;
-import com.github.dockerjava.api.command.InspectContainerResponse;
-import com.github.dockerjava.api.model.AccessMode;
-import com.github.dockerjava.api.model.Bind;
-import com.github.dockerjava.api.model.Device;
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.HostConfig;
-import com.github.dockerjava.api.model.Link;
-import com.github.dockerjava.api.model.Ports;
-import com.github.dockerjava.api.model.RestartPolicy;
-import com.github.dockerjava.api.model.Volume;
-import com.github.dockerjava.api.model.VolumeRW;
-import com.github.dockerjava.api.model.Volumes;
-import com.github.dockerjava.api.model.VolumesFrom;
-import com.github.dockerjava.client.AbstractDockerClientTest;
+import static com.github.dockerjava.api.model.Capability.MKNOD;
+import static com.github.dockerjava.api.model.Capability.NET_ADMIN;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 @Test(groups = "integration")
 public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
@@ -563,6 +538,30 @@ public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
 
 		assertEquals(inspectContainerResponse.getConfig().getMacAddress(),
 				"00:80:41:ae:fd:7e");
+	}
+
+	@Test
+	public void createContainerWithULimits() throws DockerException {
+
+		Ulimit[] ulimits = {new Ulimit("nproc", 709, 1026), new Ulimit("nofile", 1024, 4096)};
+
+		HostConfig hostConfig = new HostConfig();
+		hostConfig.setUlimits(ulimits);
+
+		CreateContainerResponse container = dockerClient
+				.createContainerCmd("busybox").withName("container")
+				.withHostConfig(hostConfig).exec();
+
+		LOG.info("Created container {}", container.toString());
+
+		assertThat(container.getId(), not(isEmptyString()));
+
+		InspectContainerResponse inspectContainerResponse = dockerClient
+				.inspectContainerCmd(container.getId()).exec();
+
+		assertThat(Arrays.asList(inspectContainerResponse.getHostConfig().getUlimits()),
+				containsInAnyOrder(new Ulimit("nproc", 709, 1026), new Ulimit("nofile", 1024, 4096)));
+
 	}
 	
 }


### PR DESCRIPTION
Add ulimit support for docker 1.6

Ulimits - A list of ulimits to be set in the container, specified as { "Name": <name>, "Soft": <soft limit>, "Hard": <hard limit> }, for example: Ulimits: { "Name": "nofile", "Soft": 1024, "Hard", 2048 }}