### PR TITLE
Remove JAXRS/ApacheConnector implementation specific properties from DockerClientConfig

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/DockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/api/command/DockerCmdExecFactory.java
@@ -4,10 +4,13 @@ import java.io.Closeable;
 import java.io.IOException;
 
 import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.jaxrs.DockerCmdExecFactoryImpl;
 
 public interface DockerCmdExecFactory extends Closeable {
 
-	public void init(DockerClientConfig dockerClientConfig);
+	public DockerCmdExecFactory withDockerClientConfig(DockerClientConfig dockerClientConfig);
+	
+	public void init();
 
 	public AuthCmd.Exec createAuthCmdExec();
 

--- a/src/main/java/com/github/dockerjava/core/DockerClientConfig.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientConfig.java
@@ -31,15 +31,10 @@ public class DockerClientConfig implements Serializable {
     private static final String DOCKER_IO_PASSWORD_PROPERTY = "docker.io.password";
     private static final String DOCKER_IO_EMAIL_PROPERTY = "docker.io.email";
     private static final String DOCKER_IO_SERVER_ADDRESS_PROPERTY = "docker.io.serverAddress";
-    private static final String DOCKER_IO_READ_TIMEOUT_PROPERTY = "docker.io.readTimeout";
-    // this is really confusing, as there are two ways to spell it
-    private static final String DOCKER_IO_ENABLE_LOGGING_FILTER_PROPERTY = "docker.io.enableLoggingFilter";
-    private static final String DOCKER_IO_FOLLOW_REDIRECTS_FILTER_PROPERTY = "docker.io.followRedirectsFilter";
+    private static final String DOCKER_IO_ENABLE_LOGGING_PROPERTY = "docker.io.enableLogging";
     private static final String DOCKER_IO_DOCKER_CERT_PATH_PROPERTY = "docker.io.dockerCertPath";
     private static final String DOCKER_IO_DOCKER_CFG_PATH_PROPERTY = "docker.io.dockerCfgPath";
-    // connection pooling properties
-    private static final String DOCKER_IO_MAX_PER_ROUTE_PROPERTY = "docker.io.perRouteConnections";
-    private static final String DOCKER_IO_MAX_TOTAL_PROPERTY = "docker.io.totalConnections";
+    
     /**
      * A map from the environment name to the interval name.
      */
@@ -53,9 +48,7 @@ public class DockerClientConfig implements Serializable {
         m.put("DOCKER_PASSWORD", DOCKER_IO_PASSWORD_PROPERTY);
         m.put("DOCKER_EMAIL", DOCKER_IO_EMAIL_PROPERTY);
         m.put("DOCKER_SERVER_ADDRESS", DOCKER_IO_SERVER_ADDRESS_PROPERTY);
-        m.put("DOCKER_READ_TIMEOUT", DOCKER_IO_READ_TIMEOUT_PROPERTY);
-        m.put("DOCKER_LOGGING_FILTER_ENABLED", DOCKER_IO_ENABLE_LOGGING_FILTER_PROPERTY);
-        m.put("DOCKER_FOLLOW_REDIRECTS_FILTER_ENABLED", DOCKER_IO_FOLLOW_REDIRECTS_FILTER_PROPERTY);
+        m.put("DOCKER_LOGGING_ENABLED", DOCKER_IO_ENABLE_LOGGING_PROPERTY);
         m.put(DOCKER_CERT_PATH_PROPERTY, DOCKER_IO_DOCKER_CERT_PATH_PROPERTY);
         m.put("DOCKER_CFG_PATH", DOCKER_IO_DOCKER_CFG_PATH_PROPERTY);
         ENV_NAME_TO_IO_NAME = Collections.unmodifiableMap(m);
@@ -64,17 +57,12 @@ public class DockerClientConfig implements Serializable {
     private static final String DOCKER_IO_PROPERTIES_PROPERTY = "docker.io.properties";
     private URI uri;
     private final String version, username, password, email, serverAddress, dockerCfgPath;
-    private final Integer readTimeout;
-    private final boolean loggingFilterEnabled;
-    private final boolean followRedirectsFilterEnabled;
+    private final boolean loggingEnabled;
     private final SSLConfig sslConfig;
-    
-    private final Integer maxTotalConnections;
-    private final Integer maxPerRouteConnections;
 
     DockerClientConfig(URI uri, String version, String username, String password, String email, String serverAddress,
-                       String dockerCfgPath, Integer readTimeout, boolean loggingFilterEnabled, boolean followRedirectsFilterEnabled, 
-                       SSLConfig sslConfig, Integer maxTotalConns, Integer maxPerRouteConns) {
+                       String dockerCfgPath, boolean loggingEnabled, 
+                       SSLConfig sslConfig) {
         this.uri = uri;
         this.version = version;
         this.username = username;
@@ -82,12 +70,8 @@ public class DockerClientConfig implements Serializable {
         this.email = email;
         this.serverAddress = serverAddress;
         this.dockerCfgPath = dockerCfgPath;
-        this.readTimeout = readTimeout;
-        this.loggingFilterEnabled = loggingFilterEnabled;
-        this.followRedirectsFilterEnabled = followRedirectsFilterEnabled;
+        this.loggingEnabled = loggingEnabled;
         this.sslConfig = sslConfig;
-        this.maxTotalConnections = maxTotalConns;
-        this.maxPerRouteConnections = maxPerRouteConns;
     }
 
     private static Properties loadIncludedDockerProperties(Properties systemProperties) {
@@ -185,9 +169,7 @@ public class DockerClientConfig implements Serializable {
                 DOCKER_IO_PASSWORD_PROPERTY,
                 DOCKER_IO_EMAIL_PROPERTY,
                 DOCKER_IO_SERVER_ADDRESS_PROPERTY,
-                DOCKER_IO_READ_TIMEOUT_PROPERTY,
-                DOCKER_IO_ENABLE_LOGGING_FILTER_PROPERTY,
-                DOCKER_IO_FOLLOW_REDIRECTS_FILTER_PROPERTY,
+                DOCKER_IO_ENABLE_LOGGING_PROPERTY,
                 DOCKER_IO_DOCKER_CERT_PATH_PROPERTY,
                 DOCKER_IO_DOCKER_CFG_PATH_PROPERTY,
         }) {
@@ -241,16 +223,8 @@ public class DockerClientConfig implements Serializable {
         return serverAddress;
     }
 
-    public Integer getReadTimeout() {
-        return readTimeout;
-    }
-
-    public boolean isLoggingFilterEnabled() {
-        return loggingFilterEnabled;
-    }
-
-    public boolean followRedirectsFilterEnabled() {
-        return followRedirectsFilterEnabled;
+    public boolean isLoggingEnabled() {
+        return loggingEnabled;
     }
 
     public SSLConfig getSslConfig() {
@@ -260,15 +234,7 @@ public class DockerClientConfig implements Serializable {
     public String getDockerCfgPath() {
         return dockerCfgPath;
     }
-    
-    public Integer getMaxTotalConnections() {
-      return maxTotalConnections;
-    }
 
-    public Integer getMaxPerRoutConnections() {
-      return maxPerRouteConnections;
-    }
-    
     private AuthConfig getAuthConfig() {
     	AuthConfig authConfig = null;
     	if (getUsername() != null && getPassword() != null && getEmail() != null
@@ -336,14 +302,13 @@ public class DockerClientConfig implements Serializable {
 
         DockerClientConfig that = (DockerClientConfig) o;
 
-        if (loggingFilterEnabled != that.loggingFilterEnabled) return false;
+        if (loggingEnabled != that.loggingEnabled) return false;
         if (sslConfig != null ? !sslConfig.equals(that.sslConfig) : that.sslConfig != null)
             return false;
         if (dockerCfgPath != null ? !dockerCfgPath.equals(that.dockerCfgPath) : that.dockerCfgPath != null)
             return false;
         if (email != null ? !email.equals(that.email) : that.email != null) return false;
         if (password != null ? !password.equals(that.password) : that.password != null) return false;
-        if (readTimeout != null ? !readTimeout.equals(that.readTimeout) : that.readTimeout != null) return false;
         if (serverAddress != null ? !serverAddress.equals(that.serverAddress) : that.serverAddress != null)
             return false;
         if (uri != null ? !uri.equals(that.uri) : that.uri != null) return false;
@@ -363,8 +328,7 @@ public class DockerClientConfig implements Serializable {
         result = 31 * result + (serverAddress != null ? serverAddress.hashCode() : 0);
         result = 31 * result + (dockerCfgPath != null ? dockerCfgPath.hashCode() : 0);
         result = 31 * result + (sslConfig != null ? sslConfig.hashCode() : 0);
-        result = 31 * result + (readTimeout != null ? readTimeout.hashCode() : 0);
-        result = 31 * result + (loggingFilterEnabled ? 1 : 0);
+        result = 31 * result + (loggingEnabled ? 1 : 0);
         return result;
     }
 
@@ -379,17 +343,14 @@ public class DockerClientConfig implements Serializable {
                 ", serverAddress='" + serverAddress + '\'' +
                 ", dockerCfgPath='" + dockerCfgPath + '\'' +
                 ", sslConfig='" + sslConfig + '\'' +
-                ", readTimeout=" + readTimeout +
-                ", loggingFilterEnabled=" + loggingFilterEnabled +
-                ", followRedirectsFilterEnabled=" + followRedirectsFilterEnabled +
+                ", loggingEnabled=" + loggingEnabled +
                 '}';
     }
 
     public static class DockerClientConfigBuilder {
         private URI uri;
         private String version, username, password, email, serverAddress, dockerCfgPath;
-        private Integer readTimeout, maxTotalConnections, maxPerRouteConnections;
-        private boolean loggingFilterEnabled, followRedirectsFilterEnabled;
+        private boolean loggingEnabled;
         private SSLConfig sslConfig;
 
         /**
@@ -405,22 +366,11 @@ public class DockerClientConfig implements Serializable {
                     .withPassword(p.getProperty(DOCKER_IO_PASSWORD_PROPERTY))
                     .withEmail(p.getProperty(DOCKER_IO_EMAIL_PROPERTY))
                     .withServerAddress(p.getProperty(DOCKER_IO_SERVER_ADDRESS_PROPERTY))
-                    .withReadTimeout(Integer.valueOf(p.getProperty(DOCKER_IO_READ_TIMEOUT_PROPERTY, "0")))
-                    .withLoggingFilter(Boolean.valueOf(p.getProperty(DOCKER_IO_ENABLE_LOGGING_FILTER_PROPERTY, "true")))
-                    .withFollowRedirectsFilter(Boolean.valueOf(p.getProperty(DOCKER_IO_FOLLOW_REDIRECTS_FILTER_PROPERTY, "false")))
+                    .withLoggingEnabled(Boolean.valueOf(p.getProperty(DOCKER_IO_ENABLE_LOGGING_PROPERTY, "true")))
                     .withDockerCertPath(p.getProperty(DOCKER_IO_DOCKER_CERT_PATH_PROPERTY))
-                    .withDockerCfgPath(p.getProperty(DOCKER_IO_DOCKER_CFG_PATH_PROPERTY))
-                    .withMaxPerRouteConnections(integerValue(p.getProperty(DOCKER_IO_MAX_PER_ROUTE_PROPERTY)))
-                    .withMaxTotalConnections(integerValue(p.getProperty(DOCKER_IO_MAX_TOTAL_PROPERTY)));
+                    .withDockerCfgPath(p.getProperty(DOCKER_IO_DOCKER_CFG_PATH_PROPERTY));
         }
         
-        private Integer integerValue(String value) {
-        	if(value != null)
-        		return Integer.valueOf(value);
-        	else 
-        		return null;
-        }
-
         public final DockerClientConfigBuilder withUri(String uri) {
             checkNotNull(uri, "uri was not specified");
             this.uri = URI.create(uri);
@@ -452,28 +402,8 @@ public class DockerClientConfig implements Serializable {
             return this;
         }
 
-        public final DockerClientConfigBuilder withReadTimeout(Integer readTimeout) {
-            this.readTimeout = readTimeout;
-            return this;
-        }
-        
-        public final DockerClientConfigBuilder withMaxTotalConnections(Integer maxTotalConnections) {
-            this.maxTotalConnections = maxTotalConnections;
-            return this;
-        }
-        
-        public final DockerClientConfigBuilder withMaxPerRouteConnections(Integer maxPerRouteConnections) {
-            this.maxPerRouteConnections = maxPerRouteConnections;
-            return this;
-        }
-
-        public final DockerClientConfigBuilder withLoggingFilter(boolean loggingFilterEnabled) {
-            this.loggingFilterEnabled = loggingFilterEnabled;
-            return this;
-        }
-
-        public final DockerClientConfigBuilder withFollowRedirectsFilter(boolean followRedirectsFilterEnabled) {
-            this.followRedirectsFilterEnabled = followRedirectsFilterEnabled;
+        public final DockerClientConfigBuilder withLoggingEnabled(boolean loggingEnabled) {
+            this.loggingEnabled = loggingEnabled;
             return this;
         }
 
@@ -504,12 +434,8 @@ public class DockerClientConfig implements Serializable {
                     email,
                     serverAddress,
                     dockerCfgPath,
-                    readTimeout,
-                    loggingFilterEnabled,
-                    followRedirectsFilterEnabled,
-                    sslConfig,
-                    maxTotalConnections,
-                    maxPerRouteConnections
+                    loggingEnabled,
+                    sslConfig
             );
         }
     }

--- a/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
@@ -61,8 +61,8 @@ public class DockerClientImpl implements Closeable, DockerClient {
 			DockerCmdExecFactory dockerCmdExecFactory) {
 		checkNotNull(dockerCmdExecFactory,
 				"dockerCmdExecFactory was not specified");
-		this.dockerCmdExecFactory = dockerCmdExecFactory;
-		this.dockerCmdExecFactory.init(dockerClientConfig);
+		this.dockerCmdExecFactory = dockerCmdExecFactory.withDockerClientConfig(dockerClientConfig);
+		this.dockerCmdExecFactory.init();
 		return this;
 	}
 

--- a/src/main/java/com/github/dockerjava/jaxrs/util/FollowRedirectsFilter.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/util/FollowRedirectsFilter.java
@@ -1,4 +1,4 @@
-package com.github.dockerjava.core.util;
+package com.github.dockerjava.jaxrs.util;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/com/github/dockerjava/jaxrs/util/JsonClientFilter.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/util/JsonClientFilter.java
@@ -1,4 +1,4 @@
-package com.github.dockerjava.core.util;
+package com.github.dockerjava.jaxrs.util;
 
 
 import javax.ws.rs.client.ClientRequestContext;

--- a/src/main/java/com/github/dockerjava/jaxrs/util/LoggingFilter.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/util/LoggingFilter.java
@@ -1,4 +1,4 @@
-package com.github.dockerjava.core.util;
+package com.github.dockerjava.jaxrs.util;
 
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.

--- a/src/main/java/com/github/dockerjava/jaxrs/util/ResponseStatusExceptionFilter.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/util/ResponseStatusExceptionFilter.java
@@ -1,4 +1,4 @@
-package com.github.dockerjava.core.util;
+package com.github.dockerjava.jaxrs.util;
 
 import java.io.EOFException;
 import java.io.IOException;

--- a/src/main/java/com/github/dockerjava/jaxrs/util/SelectiveLoggingFilter.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/util/SelectiveLoggingFilter.java
@@ -1,4 +1,4 @@
-package com.github.dockerjava.core.util;
+package com.github.dockerjava.jaxrs.util;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/src/main/resources/docker.io.properties
+++ b/src/main/resources/docker.io.properties
@@ -1,5 +1,5 @@
 docker.io.url=https://localhost:2376
-docker.io.enableLoggingFilter=true
+docker.io.enableLogging=true
 docker.io.dockerCertPath=${user.home}/.docker
 docker.io.dockerCfgPath=${user.home}/.dockercfg
 docker.io.username=${user.name}

--- a/src/test/java/com/github/dockerjava/core/DockerClientConfigTest.java
+++ b/src/test/java/com/github/dockerjava/core/DockerClientConfigTest.java
@@ -16,13 +16,13 @@ public class DockerClientConfigTest {
     public static final DockerClientConfig EXAMPLE_CONFIG = newExampleConfig();
 
     private static DockerClientConfig newExampleConfig() {
-        return new DockerClientConfig(URI.create("http://foo"), "bar", "baz", "qux", "blam", "wham", "flam", 877, false, false, new LocalDirectorySSLConfig("flim"), 20, 2);
+        return new DockerClientConfig(URI.create("http://foo"), "bar", "baz", "qux", "blam", "wham", "flam", false, new LocalDirectorySSLConfig("flim"));
     }
 
     @Test
     public void string() throws Exception {
-        assertEquals("DockerClientConfig{uri=http://foo, version='bar', username='baz', password='qux', email='blam', serverAddress='wham', dockerCfgPath='flam', sslConfig='LocalDirectorySSLConfig{dockerCertPath=flim}', readTimeout=877, loggingFilterEnabled=false, followRedirectsFilterEnabled=false}",
-                EXAMPLE_CONFIG.toString());
+        assertEquals(EXAMPLE_CONFIG.toString(), "DockerClientConfig{uri=http://foo, version='bar', username='baz', password='qux', email='blam', serverAddress='wham', dockerCfgPath='flam', sslConfig='LocalDirectorySSLConfig{dockerCertPath=flim}', loggingEnabled=false}"
+                );
     }
 
     @Test
@@ -127,8 +127,7 @@ public class DockerClientConfigTest {
         env.put("DOCKER_SERVER_ADDRESS", "wham");
         env.put("DOCKER_CERT_PATH", "flim");
         env.put("DOCKER_CFG_PATH", "flam");
-        env.put("DOCKER_READ_TIMEOUT", "877");
-        env.put("DOCKER_LOGGING_FILTER_ENABLED", "false");
+        env.put("DOCKER_LOGGING_ENABLED", "false");
 
         // when you build a config
         DockerClientConfig config = buildConfig(env, new Properties());
@@ -157,7 +156,6 @@ public class DockerClientConfigTest {
         assertEquals(config.getUsername(), "someUserName");
         assertEquals(config.getServerAddress(), AuthConfig.DEFAULT_SERVER_ADDRESS);
         assertEquals(config.getVersion(), null);
-        assertEquals(config.isLoggingFilterEnabled(), true);
         assertEquals(config.getDockerCfgPath(), "someHomeDir/.dockercfg");
         assertEquals( ((LocalDirectorySSLConfig)config.getSslConfig()).getDockerCertPath(), "someHomeDir/.docker");
     }
@@ -175,12 +173,13 @@ public class DockerClientConfigTest {
         systemProperties.setProperty("docker.io.serverAddress", "wham");
         systemProperties.setProperty("docker.io.dockerCertPath", "flim");
         systemProperties.setProperty("docker.io.dockerCfgPath", "flam");
-        systemProperties.setProperty("docker.io.readTimeout", "877");
-        systemProperties.setProperty("docker.io.enableLoggingFilter", "false");
+        systemProperties.setProperty("docker.io.enableLogging", "false");
 
         // when you build new config
         DockerClientConfig config = buildConfig(Collections.<String, String>emptyMap(), systemProperties);
 
+        System.out.println("config: " + config);
+        
         // then it is the same as the example
         assertEquals(config, EXAMPLE_CONFIG);
 

--- a/src/test/java/com/github/dockerjava/core/DockerClientImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/DockerClientImplTest.java
@@ -10,7 +10,7 @@ public class DockerClientImplTest {
     @Test
     public void configuredInstanceAuthConfig() throws Exception {
         // given a config with null serverAddress
-        DockerClientConfig dockerClientConfig = new DockerClientConfig(null, null, "", "", "", null, null,  0, false, false, null, 20, 2);
+        DockerClientConfig dockerClientConfig = new DockerClientConfig(null, null, "", "", "", null, null, false, null);
         DockerClientImpl dockerClient = DockerClientImpl.getInstance(dockerClientConfig);
 
         // when we get the auth config

--- a/src/test/java/com/github/dockerjava/core/TestDockerCmdExecFactory.java
+++ b/src/test/java/com/github/dockerjava/core/TestDockerCmdExecFactory.java
@@ -25,14 +25,23 @@ public class TestDockerCmdExecFactory implements DockerCmdExecFactory {
 	private List<String> imageNames = new ArrayList<String>();
 
 	private DockerCmdExecFactory delegate;
+	
+	private DockerClientConfig dockerClientConfig;
 
 	public TestDockerCmdExecFactory(DockerCmdExecFactory delegate) {
 		this.delegate = delegate;
 	}
+	
+	@Override
+	public DockerCmdExecFactory withDockerClientConfig(
+			DockerClientConfig dockerClientConfig) {
+		this.dockerClientConfig = dockerClientConfig;
+		return this;
+	}
 
 	@Override
-	public void init(DockerClientConfig dockerClientConfig) {
-		delegate.init(dockerClientConfig);
+	public void init() {
+		delegate.withDockerClientConfig(dockerClientConfig).init();
 	}
 
 	@Override

--- a/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
@@ -410,6 +410,7 @@ public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
 
 	}
 	
+	
 	@Test
 	public void createContainerWithLinking() throws DockerException {
 

--- a/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
+++ b/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
@@ -59,11 +59,11 @@ public class DockerfileFixture implements AutoCloseable {
                 .exec()
                 .getId();
 
-        LOGGER.info("starting {}", containerId);
+  //      LOGGER.info("starting {}", containerId);
 
-        dockerClient
-                .startContainerCmd(containerId)
-                .exec();
+//        dockerClient
+//                .startContainerCmd(containerId)
+//                .exec();
     }
 
     @Override

--- a/src/test/java/com/github/dockerjava/core/command/FrameReaderITest.java
+++ b/src/test/java/com/github/dockerjava/core/command/FrameReaderITest.java
@@ -37,13 +37,15 @@ public class FrameReaderITest {
 
 	@Test
 	public void canCloseFrameReaderAndReadExpectedLines() throws Exception {
+		InputStream response = getLoggerStream();
 
-		// wait for the container to be successfully executed 
+		dockerClient.startContainerCmd(dockerfileFixture.getContainerId())
+				.exec();
+
+		// wait for the container to be successfully executed
 		int exitCode = dockerClient.waitContainerCmd(
 				dockerfileFixture.getContainerId()).exec();
 		assertEquals(0, exitCode);
-		
-		InputStream response = getLoggerStream();
 
 		try (FrameReader reader = new FrameReader(response)) {
 			assertEquals(reader.readFrame(), new Frame(StreamType.STDOUT,
@@ -57,11 +59,10 @@ public class FrameReaderITest {
 	private InputStream getLoggerStream() {
 
 		return dockerClient.logContainerCmd(dockerfileFixture.getContainerId())
-				.withStdOut()
-				.withStdErr()
-				.withTailAll()
-				// we can't follow stream here as it blocks reading from resulting InputStream infinitely
-				//.withFollowStream()
+				.withStdOut().withStdErr().withTailAll()
+				// we can't follow stream here as it blocks reading from
+				// resulting InputStream infinitely
+				// .withFollowStream()
 				.exec();
 	}
 

--- a/src/test/resources/frameReaderDockerfile/Dockerfile
+++ b/src/test/resources/frameReaderDockerfile/Dockerfile
@@ -5,7 +5,6 @@ FROM busybox:latest
 RUN echo '#! /bin/sh' > cmd.sh
 RUN echo 'echo "to stdout"' >> cmd.sh
 RUN echo 'echo "to stderr" > /dev/stderr' >> cmd.sh
-RUN echo 'sleep 1' >> cmd.sh
 RUN chmod +x cmd.sh
 
 CMD ["./cmd.sh"]


### PR DESCRIPTION
... so things like readTimeout, maxTotalConnections, maxPerRouteConnections are configurable via `DockerCmdExecFactoryImpl` now