### PR TITLE
Update start container api

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
@@ -14,7 +14,6 @@ import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.RestartPolicy;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.api.model.VolumesFrom;
-import com.github.dockerjava.core.command.CreateContainerCmdImpl;
 
 public interface CreateContainerCmd extends DockerCmd<CreateContainerResponse>{
 
@@ -134,9 +133,11 @@ public interface CreateContainerCmd extends DockerCmd<CreateContainerResponse>{
 	public CreateContainerCmd withCmd(String... cmd);
 
 	public CreateContainerCmd withCpuset(String cpuset);
-	
+
 	public CreateContainerCmd withCpuShares(int cpuShares);
-	
+
+	public CreateContainerCmd withCpusetCpus(String cpusetCpus);
+
 	/**
 	 * Add host devices to the container
 	 */

--- a/src/main/java/com/github/dockerjava/api/command/StartContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/StartContainerCmd.java
@@ -13,8 +13,6 @@ import com.github.dockerjava.api.model.RestartPolicy;
 
 /**
  * Start a container.
- * 
- * TODO: Almost all methods are deprecated as they have corresponding siblings in {@link CreateContainerCmd} now.
  */
 public interface StartContainerCmd extends DockerCmd<Void> {
 
@@ -36,6 +34,16 @@ public interface StartContainerCmd extends DockerCmd<Void> {
 
 	public Capability[] getCapDrop();
 
+	public Boolean getReadonlyRootfs();
+
+	public long getCpuShares();
+
+	public String getCpusetCpus();
+
+	public Boolean getPublishAllPorts();
+
+	public Boolean getPrivileged();
+
 	public String getContainerId();
 
 	public Device[] getDevices();
@@ -50,6 +58,10 @@ public interface StartContainerCmd extends DockerCmd<Void> {
 
 	public LxcConf[] getLxcConf();
 
+	public long getMemoryLimit();
+
+	public long getMemorySwap();
+
 	public String getNetworkMode();
 
 	public Ports getPortBindings();
@@ -60,9 +72,10 @@ public interface StartContainerCmd extends DockerCmd<Void> {
 
 	public Boolean isPrivileged();
 
+	public Boolean isReadonlyRootfs();
+
 	public Boolean isPublishAllPorts();
 
-	@Deprecated
 	public StartContainerCmd withBinds(Bind... binds);
 
 	/**
@@ -80,7 +93,6 @@ public interface StartContainerCmd extends DockerCmd<Void> {
 	 * capability</a> from the container. For example: dropping {@link Capability#CHOWN}
 	 * prevents the container from changing the owner of any files.
 	 */
-	@Deprecated
 	public StartContainerCmd withCapDrop(Capability... capDrop);
 
 	@Deprecated
@@ -89,35 +101,37 @@ public interface StartContainerCmd extends DockerCmd<Void> {
 	/**
 	 * Add host devices to the container
 	 */
-	@Deprecated
 	public StartContainerCmd withDevices(Device... devices);
 
 	/**
 	 * Set custom DNS servers
 	 */
-	@Deprecated
 	public StartContainerCmd withDns(String... dns);
 
 	/**
 	 * Set custom DNS search domains
 	 */
-	@Deprecated
 	public StartContainerCmd withDnsSearch(String... dnsSearch);
 
 	/**
 	 * Add hostnames to /etc/hosts in the container
 	 */
-	@Deprecated
 	public StartContainerCmd withExtraHosts(String... extraHosts);
 
 	/**
 	 * Add link to another container.
 	 */
-	@Deprecated
 	public StartContainerCmd withLinks(Link... links);
 
-	@Deprecated
 	public StartContainerCmd withLxcConf(LxcConf... lxcConf);
+
+	public StartContainerCmd withMemoryLimit(long memoryLimit);
+
+	public StartContainerCmd withMemorySwap(long memorySwap);
+
+	public StartContainerCmd withCpusetCpus(String cpuset);
+
+	public StartContainerCmd withCpuShares(int cpuShares);
 
 	/**
 	 * Set the Network mode for the container
@@ -131,7 +145,6 @@ public interface StartContainerCmd extends DockerCmd<Void> {
 	 * as D-bus and is therefore considered insecure.</li>
 	 * </ul>
 	 */
-	@Deprecated
 	public StartContainerCmd withNetworkMode(String networkMode);
 
 	/**
@@ -139,32 +152,28 @@ public interface StartContainerCmd extends DockerCmd<Void> {
 	 * This corresponds to the <code>--publish</code> (<code>-p</code>)
 	 * option of the <code>docker run</code> CLI command.
 	 */
-	@Deprecated
 	public StartContainerCmd withPortBindings(PortBinding... portBindings);
 
 	/**
 	 * Add the port bindings that are contained in the given {@link Ports}
 	 * object.
-	 * 
+	 *
 	 * @see #withPortBindings(PortBinding...)
 	 */
-	@Deprecated
 	public StartContainerCmd withPortBindings(Ports portBindings);
 
-	@Deprecated
 	public StartContainerCmd withPrivileged(Boolean privileged);
 
-	@Deprecated
+	public StartContainerCmd withReadonlyRootfs(Boolean readonlyRootfs);
+
 	public StartContainerCmd withPublishAllPorts(Boolean publishAllPorts);
 
 	/**
 	 * Set custom {@link RestartPolicy} for the container. Defaults to
 	 * {@link RestartPolicy#noRestart()}
 	 */
-	@Deprecated
 	public StartContainerCmd withRestartPolicy(RestartPolicy restartPolicy);
 
-	@Deprecated
 	public StartContainerCmd withVolumesFrom(String volumesFrom);
 
 }

--- a/src/main/java/com/github/dockerjava/api/model/HostConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/HostConfig.java
@@ -60,13 +60,19 @@ public class HostConfig {
 	@JsonProperty("Ulimits")
 	private Ulimit[] ulimits;
 
+	@JsonProperty("CpuShares")
+	private String cpuShares;
+
+	@JsonProperty("CpusetCpus")
+	private String cpusetCpus;
+
 	public HostConfig() {
 	}
 
 	public HostConfig(Bind[] binds, Link[] links, LxcConf[] lxcConf, Ports portBindings, boolean publishAllPorts,
 			boolean privileged, String[] dns, String[] dnsSearch, VolumesFrom[] volumesFrom, String containerIDFile,
 			Capability[] capAdd, Capability[] capDrop, RestartPolicy restartPolicy, String networkMode, Device[] devices,
-            String[] extraHosts, Ulimit[] ulimits) {
+            String[] extraHosts, Ulimit[] ulimits, String cpuShares, String cpusetCpus) {
 		this.binds = new Binds(binds);
 		this.links = new Links(links);
 		this.lxcConf = lxcConf;
@@ -84,6 +90,8 @@ public class HostConfig {
 		this.devices = devices;
 		this.extraHosts = extraHosts;
 		this.ulimits = ulimits;
+		this.cpuShares = cpuShares;
+		this.cpusetCpus = cpusetCpus;
 	}
 
 
@@ -157,6 +165,14 @@ public class HostConfig {
 		return ulimits;
 	}
 
+	public String getCpuShares() {
+		return cpuShares;
+	}
+
+	public String getCpusetCpus() {
+		return cpusetCpus;
+	}
+
 	@JsonIgnore
 	public void setBinds(Bind... binds) {
 		this.binds = new Binds(binds);
@@ -225,6 +241,14 @@ public class HostConfig {
 
 	public void setUlimits(Ulimit[] ulimits) {
 		this.ulimits = ulimits;
+	}
+
+	public void setCpuShares(String cpuShares) {
+		this.cpuShares = cpuShares;
+	}
+
+	public void setCpusetCpus(String cpusetCpus) {
+		this.cpusetCpus = cpusetCpus;
 	}
 
 	@Override

--- a/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
@@ -46,8 +46,17 @@ public class CreateContainerCmdImpl extends
 	private long memorySwap = 0;
 	@JsonProperty("CpuShares")
 	private int cpuShares = 0;
+
+	/**
+	 * @see #cpusetCpus
+	 */
+	@Deprecated
 	@JsonProperty("Cpuset")
 	private String cpuset;
+
+	@JsonProperty("CpusetCpus")
+	private String cpusetCpus;
+
 	@JsonProperty("AttachStdin")
 	private boolean attachStdin = false;
 	@JsonProperty("AttachStdout")
@@ -359,9 +368,18 @@ public class CreateContainerCmdImpl extends
 		return this;
 	}
 
+	/**
+	 * @deprecated @see #withCpusetCpus(String)
+	 */
+	@Deprecated
 	@Override
 	public CreateContainerCmdImpl withCpuset(String cpuset) {
 		this.cpuset = cpuset;
+		return this;
+	}
+
+	public CreateContainerCmdImpl withCpusetCpus(String cpusetCpus) {
+		this.hostConfig.setCpusetCpus(cpusetCpus);
 		return this;
 	}
 

--- a/src/main/java/com/github/dockerjava/core/command/StartContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/StartContainerCmdImpl.java
@@ -41,6 +41,18 @@ public class StartContainerCmdImpl extends AbstrDockerCmd<StartContainerCmd, Voi
 	@JsonProperty("LxcConf")
 	private LxcConf[] lxcConf;
 
+	@JsonProperty("Memory")
+	private long memoryLimit = 0;
+
+	@JsonProperty("MemorySwap")
+	private long memorySwap = 0;
+
+	@JsonProperty("CpuShares")
+	private long cpuShares = 0;
+
+	@JsonProperty("CpusetCpus")
+	private String cpusetCpus;
+
 	@JsonProperty("PortBindings")
 	private Ports portBindings;
 
@@ -76,7 +88,10 @@ public class StartContainerCmdImpl extends AbstrDockerCmd<StartContainerCmd, Voi
 	
 	@JsonProperty("CapDrop")
 	private Capability[] capDrop;
-	
+
+	@JsonProperty("ReadonlyRootfs")
+	private Boolean readonlyRootfs;
+
 	public StartContainerCmdImpl(StartContainerCmd.Exec exec, String containerId) {
 		super(exec);
 		withContainerId(containerId);
@@ -100,6 +115,16 @@ public class StartContainerCmdImpl extends AbstrDockerCmd<StartContainerCmd, Voi
 	}
 
 	@Override
+	public long getMemoryLimit() {
+		return memoryLimit;
+	}
+
+	@Override
+	public long getMemorySwap() {
+		return memorySwap;
+	}
+
+	@Override
 	public Ports getPortBindings() {
 		return portBindings;
 	}
@@ -112,6 +137,11 @@ public class StartContainerCmdImpl extends AbstrDockerCmd<StartContainerCmd, Voi
 	@Override
 	public Boolean isPrivileged() {
 		return privileged;
+	}
+
+	@Override
+	public Boolean isReadonlyRootfs() {
+		return null;
 	}
 
 	@Override
@@ -164,6 +194,26 @@ public class StartContainerCmdImpl extends AbstrDockerCmd<StartContainerCmd, Voi
     	return capDrop;
     }
 
+	public Boolean getReadonlyRootfs() {
+		return readonlyRootfs;
+	}
+
+	public long getCpuShares() {
+		return cpuShares;
+	}
+
+	public String getCpusetCpus() {
+		return cpusetCpus;
+	}
+
+	public Boolean getPublishAllPorts() {
+		return publishAllPorts;
+	}
+
+	public Boolean getPrivileged() {
+		return privileged;
+	}
+
 	@Override
 	@JsonIgnore
 	public StartContainerCmd withBinds(Bind... binds) {
@@ -188,9 +238,33 @@ public class StartContainerCmdImpl extends AbstrDockerCmd<StartContainerCmd, Voi
 	}
 
 	@Override
+	public StartContainerCmd withMemoryLimit(long memoryLimit) {
+		this.memoryLimit = memoryLimit;
+		return this;
+	}
+
+	@Override
+	public StartContainerCmd withMemorySwap(long memorySwap) {
+		this.memorySwap = memorySwap;
+		return this;
+	}
+
+	@Override
+	public StartContainerCmd withCpusetCpus(String cpusetCpus) {
+		this.cpusetCpus = cpusetCpus;
+		return this;
+	}
+
+	@Override
+	public StartContainerCmd withCpuShares(int cpuShares) {
+		this.cpuShares = cpuShares;
+		return this;
+	}
+
+
+	@Override
 	public StartContainerCmd withPortBindings(Ports portBindings) {
-		checkNotNull(portBindings,
-				"portBindings was not specified");
+		checkNotNull(portBindings, "portBindings was not specified");
 		this.portBindings = portBindings;
 		return this;
 	}
@@ -207,12 +281,21 @@ public class StartContainerCmdImpl extends AbstrDockerCmd<StartContainerCmd, Voi
 
 	@Override
 	public StartContainerCmd withPrivileged(Boolean privileged) {
+		checkNotNull(privileged, "privileged was not specified");
 		this.privileged = privileged;
 		return this;
 	}
 
 	@Override
+	public StartContainerCmd withReadonlyRootfs(Boolean readonlyRootfs) {
+		checkNotNull(readonlyRootfs, "ReadonlyRootfs was not specified");
+		this.readonlyRootfs = readonlyRootfs;
+		return this;
+	}
+
+	@Override
 	public StartContainerCmd withPublishAllPorts(Boolean publishAllPorts) {
+		checkNotNull(publishAllPorts, "PublishAllPorts was not specified");
 		this.publishAllPorts = publishAllPorts;
 		return this;
 	}


### PR DESCRIPTION
for #229 
I tried sync StartContainer with 1.18 api:
- tab based - existed before
- with plus - added new
- not intended - not sure whether they need to be added
```
         "Binds": ["/tmp:/tmp"],
         "Links": ["redis3:redis"],
         "LxcConf": {"lxc.utsname":"docker"},
+ "Memory": 0,
+ "MemorySwap": 0,
+ "CpuShares": 512,
+ "CpusetCpus": "0,1",
        "PortBindings": { "22/tcp": [{ "HostPort": "11022" }] },
        "PublishAllPorts": false,
        "Privileged": false,
+ "ReadonlyRootfs": false,
        "Dns": ["8.8.8.8"],
        "DnsSearch": [""],
         "ExtraHosts": null,
        "VolumesFrom": ["parent", "other:ro"],
         "CapAdd": ["NET_ADMIN"],
        "CapDrop": ["MKNOD"],
        "RestartPolicy": { "Name": "", "MaximumRetryCount": 0 },
        "NetworkMode": "bridge",
        "Devices": [],

"Ulimits": [{}],
"LogConfig": { "Type": "json-file", Config: {} },
"SecurityOpt": [""],
"CgroupParent": ""
```
Didn't get idea how do you think properties because fields, methods and api in different order.