### PR TITLE
Remove temp tar files created by CompressArchiveUtil

### DIFF
--- a/src/main/java/com/github/dockerjava/core/CompressArchiveUtil.java
+++ b/src/main/java/com/github/dockerjava/core/CompressArchiveUtil.java
@@ -12,6 +12,7 @@ public class CompressArchiveUtil {
 
     public static File archiveTARFiles(File base, Iterable<File> files, String archiveNameWithOutExtension) throws IOException {
         File tarFile = new File(FileUtils.getTempDirectoryPath(), archiveNameWithOutExtension + ".tar");
+        tarFile.deleteOnExit();
         TarArchiveOutputStream tos = new TarArchiveOutputStream(new FileOutputStream(tarFile));
         try {
             tos.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);


### PR DESCRIPTION
`CompressArchiveUtil` creates tar files in a temporary directory, but does not clean them up after. Call `deleteOnExit` on this file so that they are automatically cleaned up when the JVM terminates.

Fixes #243 