### PR TITLE
Docker Swarm returns a "node" element with all events

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/Event.java
+++ b/src/main/java/com/github/dockerjava/api/model/Event.java
@@ -1,10 +1,12 @@
 package com.github.dockerjava.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 /**
  * Representation of a Docker event.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Event {
     private String status;
 
@@ -13,6 +15,9 @@ public class Event {
     private String from;
 
     private long time;
+
+    @JsonIgnoreProperties
+    private Node node;
 
     /**
      * Default constructor for the deserialization.
@@ -69,6 +74,10 @@ public class Event {
      */
     public long getTime() {
         return time;
+    }
+
+    public Node getNode() {
+        return node;
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/api/model/Node.java
+++ b/src/main/java/com/github/dockerjava/api/model/Node.java
@@ -1,0 +1,37 @@
+package com.github.dockerjava.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A node as returned by the /events API, for instance, when Swarm is used.
+ */
+public class Node {
+
+  @JsonProperty("Name")
+  private String name;
+
+  @JsonProperty("Id")
+  private String id;
+
+  @JsonProperty("Addr")
+  private String addr;
+
+  @JsonProperty("Ip")
+  private String ip;
+
+  public String getName() {
+    return name;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getAddr() {
+    return addr;
+  }
+
+  public String getIp() {
+    return ip;
+  }
+}


### PR DESCRIPTION
This adds a class for the Node element and wires it into Event. Because "node" only seems to appear in Swarm responses, `@JsonIgnoreProperties(ignoreUnknown = true)` was added to Event.

Here's a sample response for `/events` when pointing to a Swarm master:

```json
{
   "status":"create",
   "id":"2c8ef1f72206f4c497cafbd512017b364a32000d9a8bdae70a2d38464f1e2b6d",
   "from":"hello-world node:swarm-agent-00",
   "time":1434852012,
   "node":{
      "Name":"swarm-agent-00",
      "Id":"7E5D:QIA6:WC5O:Z72N:RHC7:5FNX:SX62:VIZJ:47DQ:EVEI:PWH4:NRXV",
      "Addr":"123.456.789.012:2376",
      "Ip":"123.456.789.012"
   }
}
```