### PR TITLE
Add filters option to events operation

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/EventsCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/EventsCmd.java
@@ -23,6 +23,10 @@ public interface EventsCmd extends DockerCmd<ExecutorService> {
 
     public EventsCmd withEventCallback(EventCallback eventCallback);
 
+    public String getFilters();
+
+    public EventsCmd withFilters(String filters);
+
     public static interface Exec extends DockerCmdExec<EventsCmd, ExecutorService> {
     }
 }

--- a/src/main/java/com/github/dockerjava/core/command/EventsCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/EventsCmdImpl.java
@@ -1,5 +1,7 @@
 package com.github.dockerjava.core.command;
 
+import static com.google.common.base.Preconditions.*;
+
 import java.util.concurrent.ExecutorService;
 
 import com.github.dockerjava.api.command.EventCallback;
@@ -15,6 +17,8 @@ public class EventsCmdImpl extends AbstrDockerCmd<EventsCmd, ExecutorService> im
     private String until;
 
     private EventCallback eventCallback;
+
+    private String filters;
 
     public EventsCmdImpl(EventsCmd.Exec exec, EventCallback eventCallback) {
         super(exec);
@@ -40,6 +44,13 @@ public class EventsCmdImpl extends AbstrDockerCmd<EventsCmd, ExecutorService> im
     }
 
     @Override
+    public EventsCmd withFilters(String filters) {
+        checkNotNull(filters, "filters have not been specified");
+        this.filters = filters;
+        return this;
+    }
+
+    @Override
     public String getSince() {
         return since;
     }
@@ -55,6 +66,11 @@ public class EventsCmdImpl extends AbstrDockerCmd<EventsCmd, ExecutorService> im
     }
 
     @Override
+    public String getFilters() {
+        return filters;
+    }
+
+    @Override
     public ExecutorService exec() {
         return super.exec();
     }
@@ -62,6 +78,7 @@ public class EventsCmdImpl extends AbstrDockerCmd<EventsCmd, ExecutorService> im
     @Override
     public String toString() {
         return new StringBuilder("events").append(since != null ? " --since=" + since : "")
-                .append(until != null ? " --until=" + until : "").toString();
+                .append(until != null ? " --until=" + until : "")
+                .append(filters != null ? " --filters=" + filters : "").toString();
     }
 }

--- a/src/main/java/com/github/dockerjava/jaxrs/EventsCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/EventsCmdExec.java
@@ -1,6 +1,7 @@
 package com.github.dockerjava.jaxrs;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.net.UrlEscapers.*;
 
 import java.io.InputStream;
 import java.util.concurrent.Callable;
@@ -35,6 +36,9 @@ public class EventsCmdExec extends AbstrDockerCmdExec<EventsCmd, ExecutorService
 
         WebTarget webResource = getBaseResource().path("/events").queryParam("since", command.getSince())
                 .queryParam("until", command.getUntil());
+
+        if (command.getFilters() != null)
+            webResource = webResource.queryParam("filters", urlPathSegmentEscaper().escape(command.getFilters()));
 
         LOGGER.trace("GET: {}", webResource);
         EventNotifier eventNotifier = EventNotifier.create(command.getEventCallback(), webResource);

--- a/src/test/java/com/github/dockerjava/core/command/EventsCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/EventsCmdImplTest.java
@@ -94,6 +94,25 @@ public class EventsCmdImplTest extends AbstractDockerClientTest {
         assertTrue(zeroCount, "Received only: " + eventCallback.getEvents());
     }
 
+    @Test
+    public void testEventStreamingWithFilter() throws InterruptedException, IOException {
+        // Don't include other tests events
+        TimeUnit.SECONDS.sleep(1);
+
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        EventCallbackTest eventCallback = new EventCallbackTest(countDownLatch);
+
+        EventsCmd eventsCmd = dockerClient.eventsCmd(eventCallback).withFilters("{\"event\":[\"start\"]}");
+        ExecutorService executorService = eventsCmd.exec();
+
+        generateEvents();
+
+        boolean zeroCount = countDownLatch.await(10, TimeUnit.SECONDS);
+        executorService.shutdown();
+        eventCallback.close();
+        assertTrue(zeroCount, "Received only: " + eventCallback.getEvents());
+    }
+
     @Test(groups = "ignoreInCircleCi")
     public void testEventStreaming2() throws InterruptedException, IOException {
         // Don't include other tests events


### PR DESCRIPTION
I'm not particularly happy with the filters as a String but it is the same way implemented in `ListImages`
https://github.com/docker-java/docker-java/blob/master/src/main/java/com/github/dockerjava/core/command/ListImagesCmdImpl.java#L45

Would rather have a Map<String,String> at least.
