### PR TITLE
Fix for #218

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
@@ -10,6 +10,7 @@ import com.github.dockerjava.api.model.Device;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Link;
+import com.github.dockerjava.api.model.LogConfig;
 import com.github.dockerjava.api.model.LxcConf;
 import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.api.model.Ports;
@@ -88,6 +89,8 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
     public Link[] getLinks();
 
     public LxcConf[] getLxcConf();
+    
+    public LogConfig getLogConfig();
 
     public String getMacAddress();
 
@@ -223,6 +226,8 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
     public CreateContainerCmd withLinks(Link... links);
 
     public CreateContainerCmd withLxcConf(LxcConf... lxcConf);
+
+    public CreateContainerCmd withLogConfig(LogConfig logConfig);
 
     public CreateContainerCmd withMemoryLimit(long memoryLimit);
 

--- a/src/main/java/com/github/dockerjava/api/model/HostConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/HostConfig.java
@@ -17,6 +17,9 @@ public class HostConfig {
 
     @JsonProperty("LxcConf")
     private LxcConf[] lxcConf;
+    
+    @JsonProperty("LogConfig")
+    private LogConfig logConfig;
 
     @JsonProperty("PortBindings")
     private Ports portBindings;
@@ -66,13 +69,14 @@ public class HostConfig {
     public HostConfig() {
     }
 
-    public HostConfig(Bind[] binds, Link[] links, LxcConf[] lxcConf, Ports portBindings, boolean publishAllPorts,
+    public HostConfig(Bind[] binds, Link[] links, LxcConf[] lxcConf, LogConfig logConfig, Ports portBindings, boolean publishAllPorts,
             boolean privileged, boolean readonlyRootfs, String[] dns, String[] dnsSearch, VolumesFrom[] volumesFrom,
             String containerIDFile, Capability[] capAdd, Capability[] capDrop, RestartPolicy restartPolicy,
             String networkMode, Device[] devices, String[] extraHosts, Ulimit[] ulimits) {
         this.binds = new Binds(binds);
         this.links = new Links(links);
         this.lxcConf = lxcConf;
+        this.logConfig = logConfig;
         this.portBindings = portBindings;
         this.publishAllPorts = publishAllPorts;
         this.privileged = privileged;
@@ -97,6 +101,11 @@ public class HostConfig {
 
     public LxcConf[] getLxcConf() {
         return lxcConf;
+    }
+    
+    @JsonIgnore
+    public LogConfig getLogConfig() {
+        return (logConfig == null) ? new LogConfig() : logConfig;
     }
 
     public Ports getPortBindings() {
@@ -176,6 +185,11 @@ public class HostConfig {
 
     public void setLxcConf(LxcConf[] lxcConf) {
         this.lxcConf = lxcConf;
+    }
+    
+    @JsonIgnore
+    public void setLogConfig(LogConfig logConfig) {
+        this.logConfig = logConfig;
     }
 
     public void setPortBindings(Ports portBindings) {

--- a/src/main/java/com/github/dockerjava/api/model/LogConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/LogConfig.java
@@ -1,20 +1,37 @@
 package com.github.dockerjava.api.model;
 
-import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * Log driver to use for a created/running container. The
+ * available types are:
+ * 
+ *     json-file (default)
+ *     syslog
+ *     journald
+ *     none
+ *
+ * If a driver is specified that is NOT supported,docker
+ * will default to null. If configs are supplied that are
+ * not supported by the type docker will ignore them. In most 
+ * cases setting the config option to null will suffice. Consult 
+ * the docker remote API for a more detailed and up-to-date 
+ * explanation of the available types and their options.
+ */
 public class LogConfig {
     
     @JsonProperty("Type")
-    public String type = "json-file";
+    public String type;
     
     @JsonProperty("Config")
-    public List<String> config = null;
+    public Map<String, String> config;
 
-    public LogConfig(String type) {
+    public LogConfig(String type, Map<String, String> config) {
         this.type = type;
+        this.config = config;
     }
 
     public LogConfig() {
@@ -23,14 +40,20 @@ public class LogConfig {
     public String getType() {
         return type;
     }
-    
-    @JsonIgnore
-    public List<String> getConfig() {
-    	return config;
-    }
 
     public LogConfig setType(String type) {
         this.type = type;
         return this;
+    }
+
+    @JsonIgnore
+    public Map<String, String> getConfig() {
+    	return config;
+    }
+    
+    @JsonIgnore
+    public LogConfig setConfig(Map<String, String> config) {
+    	this.config = config;
+    	return this;
     }
 }

--- a/src/main/java/com/github/dockerjava/api/model/LogConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/LogConfig.java
@@ -1,0 +1,36 @@
+package com.github.dockerjava.api.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class LogConfig {
+    
+    @JsonProperty("Type")
+    public String type = "json-file";
+    
+    @JsonProperty("Config")
+    public List<String> config = null;
+
+    public LogConfig(String type) {
+        this.type = type;
+    }
+
+    public LogConfig() {
+    }
+
+    public String getType() {
+        return type;
+    }
+    
+    @JsonIgnore
+    public List<String> getConfig() {
+    	return config;
+    }
+
+    public LogConfig setType(String type) {
+        this.type = type;
+        return this;
+    }
+}

--- a/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
@@ -19,6 +19,7 @@ import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.ExposedPorts;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Link;
+import com.github.dockerjava.api.model.LogConfig;
 import com.github.dockerjava.api.model.LxcConf;
 import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.api.model.Ports;
@@ -268,6 +269,12 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     @JsonIgnore
     public LxcConf[] getLxcConf() {
         return hostConfig.getLxcConf();
+    }
+    
+    @Override
+    @JsonIgnore
+    public LogConfig getLogConfig() {
+        return hostConfig.getLogConfig();
     }
 
     public String getMacAddress() {
@@ -556,6 +563,13 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     public CreateContainerCmd withLxcConf(LxcConf... lxcConf) {
         checkNotNull(lxcConf, "lxcConf was not specified");
         this.hostConfig.setLxcConf(lxcConf);
+        return this;
+    }
+    
+    @Override
+    public CreateContainerCmd withLogConfig(LogConfig logConfig) {
+        checkNotNull(logConfig, "logConfig was not specified");
+        this.hostConfig.setLogConfig(logConfig);
         return this;
     }
 

--- a/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
@@ -38,6 +38,7 @@ import com.github.dockerjava.api.model.Device;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Link;
+import com.github.dockerjava.api.model.LogConfig;
 import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.RestartPolicy;
 import com.github.dockerjava.api.model.Ulimit;
@@ -533,5 +534,22 @@ public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
         // null becomes empty string
         labels.put("com.github.dockerjava.null", "");
         assertThat(inspectContainerResponse.getConfig().getLabels(), is(equalTo(labels)));
+    }
+    
+    @Test(groups = "ignoreInCircleCi")
+    public void createContainerWithLogConfig() throws DockerException {
+
+    	LogConfig logConfig = new LogConfig("none", null);
+        CreateContainerResponse container = dockerClient.createContainerCmd("busybox").
+        		withLogConfig(logConfig).exec();
+
+        LOG.info("Created container {}", container.toString());
+
+        assertThat(container.getId(), not(isEmptyString()));
+
+        InspectContainerResponse inspectContainerResponse = dockerClient.inspectContainerCmd(container.getId()).exec();
+
+        // null becomes empty string
+        assertEquals(inspectContainerResponse.getHostConfig().getLogConfig().type, logConfig.type);
     }
 }


### PR DESCRIPTION
6 failures running integration tests locally but they do not appear to be related to this change. All look to be coming from commands being run inside containers and returning non-zero exit codes.