### PR TITLE
Moved "Memory", "MemorySwap" and "CpuShares" mappings from ContainerConfig to HostConfig

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/ContainerConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/ContainerConfig.java
@@ -28,12 +28,6 @@ public class ContainerConfig {
     @JsonProperty("Cmd")
     private String[] cmd;
 
-    @JsonProperty("CpuShares")
-    private int cpuShares = 0;
-
-    @JsonProperty("Cpuset")
-    private String cpuset = "";
-
     @JsonProperty("Domainname")
     private String domainName = "";
 
@@ -57,12 +51,6 @@ public class ContainerConfig {
 
     @JsonProperty("MacAddress")
     private String macAddress;
-
-    @JsonProperty("Memory")
-    private long memoryLimit = 0;
-
-    @JsonProperty("MemorySwap")
-    private long memorySwap = 0;
 
     @JsonProperty("NetworkDisabled")
     private boolean networkDisabled = false;
@@ -134,22 +122,6 @@ public class ContainerConfig {
 
     public String getMacAddress() {
         return macAddress;
-    }
-
-    public long getMemoryLimit() {
-        return memoryLimit;
-    }
-
-    public long getMemorySwap() {
-        return memorySwap;
-    }
-
-    public int getCpuShares() {
-        return cpuShares;
-    }
-
-    public String getCpuset() {
-        return cpuset;
     }
 
     public boolean isAttachStdin() {

--- a/src/main/java/com/github/dockerjava/api/model/HostConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/HostConfig.java
@@ -66,6 +66,15 @@ public class HostConfig {
     @JsonProperty("Ulimits")
     private Ulimit[] ulimits;
 
+    @JsonProperty("Memory")
+    private long memoryLimit = 0;
+
+    @JsonProperty("MemorySwap")
+    private long memorySwap = 0;
+
+    @JsonProperty("CpuShares")
+    private int cpuShares = 0;
+
     public HostConfig() {
     }
 
@@ -171,6 +180,18 @@ public class HostConfig {
 
     public Ulimit[] getUlimits() {
         return ulimits;
+    }
+
+    public long getMemoryLimit() {
+        return memoryLimit;
+    }
+
+    public long getMemorySwap() {
+        return memorySwap;
+    }
+
+    public int getCpuShares() {
+        return cpuShares;
     }
 
     @JsonIgnore


### PR DESCRIPTION
Moved "Memory", "MemorySwap" and "CpuShares" fields from ContainerConfig to HostConfig. This is to comply with current Docker Remote API (v1.18 and greater). On inspect command docker server returns json, where these fields are under "HostConfig" section, not "Config". See https://docs.docker.com/docker/reference/api/docker_remote_api_v1.19/#inspect-a-container