### PR TITLE
Add API versioning support

### DIFF
--- a/src/main/java/com/github/dockerjava/core/DockerClientConfig.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientConfig.java
@@ -1,6 +1,10 @@
 package com.github.dockerjava.core;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import com.github.dockerjava.api.DockerClientException;
+import com.github.dockerjava.api.model.AuthConfig;
+import com.github.dockerjava.api.model.AuthConfigurations;
+import com.github.dockerjava.core.NameParser.HostnameReposName;
+import com.github.dockerjava.core.NameParser.ReposTag;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -12,11 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import com.github.dockerjava.api.DockerClientException;
-import com.github.dockerjava.api.model.AuthConfig;
-import com.github.dockerjava.api.model.AuthConfigurations;
-import com.github.dockerjava.core.NameParser.HostnameReposName;
-import com.github.dockerjava.core.NameParser.ReposTag;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class DockerClientConfig implements Serializable {
 
@@ -66,14 +66,16 @@ public class DockerClientConfig implements Serializable {
 
     private URI uri;
 
-    private final String version, username, password, email, serverAddress, dockerCfgPath;
+    private final String username, password, email, serverAddress, dockerCfgPath;
+
+    private final RemoteApiVersion version;
 
     private final SSLConfig sslConfig;
 
     DockerClientConfig(URI uri, String version, String username, String password, String email, String serverAddress,
             String dockerCfgPath, SSLConfig sslConfig) {
         this.uri = uri;
-        this.version = version;
+        this.version = RemoteApiVersion.parseConfigWithDefault(version);
         this.username = username;
         this.password = password;
         this.email = email;
@@ -209,7 +211,7 @@ public class DockerClientConfig implements Serializable {
         this.uri = uri;
     }
 
-    public String getVersion() {
+    public RemoteApiVersion getVersion() {
         return version;
     }
 

--- a/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
@@ -1,12 +1,5 @@
 package com.github.dockerjava.core;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.io.Closeable;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.AttachContainerCmd;
 import com.github.dockerjava.api.command.AuthCmd;
@@ -46,7 +39,6 @@ import com.github.dockerjava.api.command.UnpauseContainerCmd;
 import com.github.dockerjava.api.command.VersionCmd;
 import com.github.dockerjava.api.command.WaitContainerCmd;
 import com.github.dockerjava.api.model.AuthConfig;
-import com.github.dockerjava.api.model.AuthConfigurations;
 import com.github.dockerjava.api.model.Identifier;
 import com.github.dockerjava.core.command.AttachContainerCmdImpl;
 import com.github.dockerjava.core.command.AuthCmdImpl;
@@ -84,6 +76,13 @@ import com.github.dockerjava.core.command.TopContainerCmdImpl;
 import com.github.dockerjava.core.command.UnpauseContainerCmdImpl;
 import com.github.dockerjava.core.command.VersionCmdImpl;
 import com.github.dockerjava.core.command.WaitContainerCmdImpl;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Konstantin Pelykh (kpelykh@gmail.com)
@@ -332,28 +331,19 @@ public class DockerClientImpl implements Closeable, DockerClient {
 
     @Override
     public BuildImageCmd buildImageCmd() {
-        return augmentBuildImageCmd(new BuildImageCmdImpl(getDockerCmdExecFactory().createBuildImageCmdExec()));
+        return new BuildImageCmdImpl(getDockerCmdExecFactory().createBuildImageCmdExec());
     }
 
     @Override
     public BuildImageCmd buildImageCmd(File dockerFileOrFolder) {
-        return augmentBuildImageCmd(new BuildImageCmdImpl(getDockerCmdExecFactory().createBuildImageCmdExec(),
-                dockerFileOrFolder));
+        return new BuildImageCmdImpl(getDockerCmdExecFactory().createBuildImageCmdExec(),
+                dockerFileOrFolder);
     }
 
     @Override
     public BuildImageCmd buildImageCmd(InputStream tarInputStream) {
-        return augmentBuildImageCmd(new BuildImageCmdImpl(getDockerCmdExecFactory().createBuildImageCmdExec(),
-                tarInputStream));
-    }
-
-    private BuildImageCmd augmentBuildImageCmd(BuildImageCmd buildImageCmd) {
-        final AuthConfigurations authConfigurations = dockerClientConfig.getAuthConfigurations();
-        if (!authConfigurations.getConfigs().isEmpty()) {
-            buildImageCmd.withBuildAuthConfigs(authConfigurations);
-        }
-
-        return buildImageCmd;
+        return new BuildImageCmdImpl(getDockerCmdExecFactory().createBuildImageCmdExec(),
+                tarInputStream);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/core/RemoteApiVersion.java
+++ b/src/main/java/com/github/dockerjava/core/RemoteApiVersion.java
@@ -1,0 +1,111 @@
+package com.github.dockerjava.core;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Bean to encapsulate the version of the Docker Remote API (REST API)
+ * <p>
+ * Contains the minor and major version of the API as well as operations to compare API versions.
+ *
+ * @author Marcus Thiesen
+ */
+public class RemoteApiVersion {
+
+    public static final RemoteApiVersion VERSION_1_19 = RemoteApiVersion.create(1, 19);
+    private static final Pattern VERSION_REGEX = Pattern.compile("v?(\\d+)\\.(\\d+)");
+    private static final RemoteApiVersion UNKNOWN_VERSION = new RemoteApiVersion(0, 0) {
+
+        @Override
+        public boolean isGreaterOrEqual(final RemoteApiVersion other) {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this).addValue("UNKNOWN_VERSION").toString();
+        }
+
+        @Override
+        public String asWebPathPart() {
+            return "";
+        }
+    };
+    private final int major;
+    private final int minor;
+    private RemoteApiVersion(final int major, final int minor) {
+        this.major = major;
+        this.minor = minor;
+    }
+
+    public static RemoteApiVersion create(final int major, final int minor) {
+        Preconditions.checkArgument(major > 0, "Major version must be bigger than 0 but is " + major);
+        Preconditions.checkArgument(minor > 0, "Minor version must be bigger than 0 but is " + minor);
+        return new RemoteApiVersion(major, minor);
+    }
+
+    public static RemoteApiVersion unknown() {
+        return UNKNOWN_VERSION;
+    }
+
+    public static RemoteApiVersion parseConfig(final String version) {
+        Preconditions.checkArgument(version != null, "Version must not be null");
+        final Matcher matcher = VERSION_REGEX.matcher(version);
+        if (matcher.matches()) {
+            return create(Integer.parseInt(matcher.group(1)), Integer.parseInt(matcher.group(2)));
+        }
+        throw new IllegalArgumentException(version + " can not be parsed");
+    }
+
+    public static RemoteApiVersion parseConfigWithDefault(final String version) {
+        if (Strings.isNullOrEmpty(version)) {
+            return UNKNOWN_VERSION;
+        }
+
+        try {
+            return parseConfig(version);
+        } catch (IllegalArgumentException e) {
+            return UNKNOWN_VERSION;
+        }
+    }
+
+    public boolean isGreaterOrEqual(final RemoteApiVersion other) {
+        if (major >= other.major) {
+            if (minor >= other.minor) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final RemoteApiVersion that = (RemoteApiVersion) o;
+        return Objects.equal(major, that.major) &&
+                Objects.equal(minor, that.minor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(major, minor);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("major", major)
+                .add("minor", minor)
+                .toString();
+    }
+
+    public String asWebPathPart() {
+        return "v" + major + "." + minor;
+    }
+}

--- a/src/main/java/com/github/dockerjava/jaxrs/AbstrAsyncDockerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/AbstrAsyncDockerCmdExec.java
@@ -1,20 +1,20 @@
 package com.github.dockerjava.jaxrs;
 
-import java.io.Closeable;
-import java.io.IOException;
-
-import javax.ws.rs.client.WebTarget;
-
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.AsyncDockerCmd;
 import com.github.dockerjava.api.command.DockerCmdAsyncExec;
+import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.jaxrs.async.AbstractCallbackNotifier;
+
+import javax.ws.rs.client.WebTarget;
+import java.io.Closeable;
+import java.io.IOException;
 
 public abstract class AbstrAsyncDockerCmdExec<CMD_T extends AsyncDockerCmd<CMD_T, A_RES_T>, A_RES_T> extends
         AbstrDockerCmdExec implements DockerCmdAsyncExec<CMD_T, A_RES_T> {
 
-    public AbstrAsyncDockerCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public AbstrAsyncDockerCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/AbstrSyncDockerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/AbstrSyncDockerCmdExec.java
@@ -1,19 +1,18 @@
 package com.github.dockerjava.jaxrs;
 
-import java.io.IOException;
+import com.github.dockerjava.api.DockerException;
+import com.github.dockerjava.api.command.DockerCmd;
+import com.github.dockerjava.api.command.DockerCmdSyncExec;
+import com.github.dockerjava.core.DockerClientConfig;
 
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.WebTarget;
 
-import com.github.dockerjava.api.DockerException;
-import com.github.dockerjava.api.command.DockerCmd;
-import com.github.dockerjava.api.command.DockerCmdSyncExec;
-
 public abstract class AbstrSyncDockerCmdExec<CMD_T extends DockerCmd<RES_T>, RES_T> extends AbstrDockerCmdExec
         implements DockerCmdSyncExec<CMD_T, RES_T> {
 
-    public AbstrSyncDockerCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public AbstrSyncDockerCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/AttachContainerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/AttachContainerCmdExec.java
@@ -1,24 +1,24 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.AttachContainerCmd;
 import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.async.FrameStreamProcessor;
 import com.github.dockerjava.jaxrs.async.AbstractCallbackNotifier;
 import com.github.dockerjava.jaxrs.async.POSTCallbackNotifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.client.WebTarget;
 
 public class AttachContainerCmdExec extends AbstrAsyncDockerCmdExec<AttachContainerCmd, Frame> implements
         AttachContainerCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AttachContainerCmdExec.class);
 
-    public AttachContainerCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public AttachContainerCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/AuthCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/AuthCmdExec.java
@@ -1,24 +1,24 @@
 package com.github.dockerjava.jaxrs;
 
-import static javax.ws.rs.client.Entity.entity;
+import com.github.dockerjava.api.UnauthorizedException;
+import com.github.dockerjava.api.command.AuthCmd;
+import com.github.dockerjava.api.model.AuthResponse;
+import com.github.dockerjava.core.DockerClientConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.github.dockerjava.api.UnauthorizedException;
-import com.github.dockerjava.api.command.AuthCmd;
-import com.github.dockerjava.api.model.AuthResponse;
+import static javax.ws.rs.client.Entity.entity;
 
 public class AuthCmdExec extends AbstrSyncDockerCmdExec<AuthCmd, AuthResponse> implements AuthCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthCmdExec.class);
 
-    public AuthCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public AuthCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
@@ -1,38 +1,48 @@
 package com.github.dockerjava.jaxrs;
 
-import static javax.ws.rs.client.Entity.entity;
-
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.BuildImageCmd;
+import com.github.dockerjava.api.model.AuthConfigurations;
+import com.github.dockerjava.api.model.BuildResponseItem;
+import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.core.async.JsonStreamProcessor;
+import com.github.dockerjava.jaxrs.async.AbstractCallbackNotifier;
+import com.github.dockerjava.jaxrs.async.POSTCallbackNotifier;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.RequestEntityProcessing;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.async.ResultCallback;
-import com.github.dockerjava.api.command.BuildImageCmd;
-import com.github.dockerjava.api.model.AuthConfigurations;
-import com.github.dockerjava.api.model.BuildResponseItem;
-import com.github.dockerjava.core.async.JsonStreamProcessor;
-import com.github.dockerjava.jaxrs.async.AbstractCallbackNotifier;
-import com.github.dockerjava.jaxrs.async.POSTCallbackNotifier;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+
+import static javax.ws.rs.client.Entity.entity;
 
 public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, BuildResponseItem> implements
         BuildImageCmd.Exec {
     private static final Logger LOGGER = LoggerFactory.getLogger(BuildImageCmdExec.class);
 
-    public BuildImageCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public BuildImageCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     private Invocation.Builder resourceWithOptionalAuthConfig(BuildImageCmd command, Invocation.Builder request) {
-        AuthConfigurations authConfigs = command.getBuildAuthConfigs();
+        final AuthConfigurations authConfigs = firstNonNull(command.getBuildAuthConfigs(), getBuildAuthConfigs());
         if (authConfigs != null) {
             request = request.header("X-Registry-Config", registryConfigs(authConfigs));
         }
         return request;
+    }
+
+    private static AuthConfigurations firstNonNull(final AuthConfigurations fromCommand, final AuthConfigurations fromConfig) {
+        if (fromCommand != null) {
+            return fromCommand;
+        }
+        if (fromConfig != null) {
+            return fromConfig;
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/CommitCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/CommitCmdExec.java
@@ -1,22 +1,22 @@
 package com.github.dockerjava.jaxrs;
 
-import static javax.ws.rs.client.Entity.entity;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.dockerjava.api.command.CommitCmd;
+import com.github.dockerjava.core.DockerClientConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.github.dockerjava.api.command.CommitCmd;
+import static javax.ws.rs.client.Entity.entity;
 
 public class CommitCmdExec extends AbstrSyncDockerCmdExec<CommitCmd, String> implements CommitCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CommitCmdExec.class);
 
-    public CommitCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public CommitCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/ContainerDiffCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/ContainerDiffCmdExec.java
@@ -1,24 +1,23 @@
 package com.github.dockerjava.jaxrs;
 
-import java.util.List;
+import com.github.dockerjava.api.command.ContainerDiffCmd;
+import com.github.dockerjava.api.model.ChangeLog;
+import com.github.dockerjava.core.DockerClientConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.github.dockerjava.api.command.ContainerDiffCmd;
-import com.github.dockerjava.api.model.ChangeLog;
+import java.util.List;
 
 public class ContainerDiffCmdExec extends AbstrSyncDockerCmdExec<ContainerDiffCmd, List<ChangeLog>> implements
         ContainerDiffCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ContainerDiffCmdExec.class);
 
-    public ContainerDiffCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public ContainerDiffCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/CopyFileFromContainerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/CopyFileFromContainerCmdExec.java
@@ -1,26 +1,25 @@
 package com.github.dockerjava.jaxrs;
 
-import static javax.ws.rs.client.Entity.entity;
-
-import java.io.InputStream;
+import com.github.dockerjava.api.command.CopyFileFromContainerCmd;
+import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.jaxrs.util.WrappedResponseInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.io.InputStream;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.github.dockerjava.api.command.CopyFileFromContainerCmd;
-import com.github.dockerjava.jaxrs.util.WrappedResponseInputStream;
+import static javax.ws.rs.client.Entity.entity;
 
 public class CopyFileFromContainerCmdExec extends AbstrSyncDockerCmdExec<CopyFileFromContainerCmd, InputStream>
         implements CopyFileFromContainerCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CopyFileFromContainerCmdExec.class);
 
-    public CopyFileFromContainerCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public CopyFileFromContainerCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/CreateContainerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/CreateContainerCmdExec.java
@@ -1,23 +1,23 @@
 package com.github.dockerjava.jaxrs;
 
-import static javax.ws.rs.client.Entity.entity;
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.core.DockerClientConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.github.dockerjava.api.command.CreateContainerCmd;
-import com.github.dockerjava.api.command.CreateContainerResponse;
+import static javax.ws.rs.client.Entity.entity;
 
 public class CreateContainerCmdExec extends AbstrSyncDockerCmdExec<CreateContainerCmd, CreateContainerResponse>
         implements CreateContainerCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CreateContainerCmdExec.class);
 
-    public CreateContainerCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public CreateContainerCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/CreateImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/CreateImageCmdExec.java
@@ -1,23 +1,23 @@
 package com.github.dockerjava.jaxrs;
 
-import static javax.ws.rs.client.Entity.entity;
+import com.github.dockerjava.api.command.CreateImageCmd;
+import com.github.dockerjava.api.command.CreateImageResponse;
+import com.github.dockerjava.core.DockerClientConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.github.dockerjava.api.command.CreateImageCmd;
-import com.github.dockerjava.api.command.CreateImageResponse;
+import static javax.ws.rs.client.Entity.entity;
 
 public class CreateImageCmdExec extends AbstrSyncDockerCmdExec<CreateImageCmd, CreateImageResponse> implements
         CreateImageCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CreateImageCmdExec.class);
 
-    public CreateImageCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public CreateImageCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/DockerCmdExecFactoryImpl.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/DockerCmdExecFactoryImpl.java
@@ -1,29 +1,5 @@
 package com.github.dockerjava.jaxrs;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.io.IOException;
-import java.net.URI;
-
-import javax.net.ssl.SSLContext;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.ClientRequestFilter;
-import javax.ws.rs.client.ClientResponseFilter;
-import javax.ws.rs.client.WebTarget;
-
-import org.apache.http.config.RegistryBuilder;
-import org.apache.http.conn.socket.ConnectionSocketFactory;
-import org.apache.http.conn.socket.PlainConnectionSocketFactory;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.glassfish.jersey.CommonProperties;
-import org.glassfish.jersey.apache.connector.ApacheClientProperties;
-import org.glassfish.jersey.client.ClientConfig;
-import org.glassfish.jersey.client.ClientProperties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.github.dockerjava.api.DockerClientException;
 import com.github.dockerjava.api.command.AttachContainerCmd;
@@ -64,13 +40,36 @@ import com.github.dockerjava.api.command.UnpauseContainerCmd;
 import com.github.dockerjava.api.command.VersionCmd;
 import com.github.dockerjava.api.command.WaitContainerCmd;
 import com.github.dockerjava.core.DockerClientConfig;
-//import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
-// see https://github.com/docker-java/docker-java/issues/196
+import com.github.dockerjava.core.RemoteApiVersion;
 import com.github.dockerjava.jaxrs.connector.ApacheConnectorProvider;
-import com.github.dockerjava.jaxrs.filter.FollowRedirectsFilter;
 import com.github.dockerjava.jaxrs.filter.JsonClientFilter;
 import com.github.dockerjava.jaxrs.filter.ResponseStatusExceptionFilter;
 import com.github.dockerjava.jaxrs.filter.SelectiveLoggingFilter;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.glassfish.jersey.CommonProperties;
+import org.glassfish.jersey.apache.connector.ApacheClientProperties;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.client.WebTarget;
+import java.io.IOException;
+import java.net.URI;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+//import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
+// see https://github.com/docker-java/docker-java/issues/196
 
 public class DockerCmdExecFactoryImpl implements DockerCmdExecFactory {
 
@@ -91,6 +90,8 @@ public class DockerCmdExecFactoryImpl implements DockerCmdExecFactory {
     private ClientRequestFilter[] clientRequestFilters = null;
 
     private ClientResponseFilter[] clientResponseFilters = null;
+
+    private DockerClientConfig dockerClientConfig;
 
     @Override
     public void init(DockerClientConfig dockerClientConfig) {
@@ -168,11 +169,9 @@ public class DockerCmdExecFactoryImpl implements DockerCmdExecFactory {
         }
         WebTarget webResource = client.target(dockerClientConfig.getUri());
 
-        if (dockerClientConfig.getVersion() == null || dockerClientConfig.getVersion().isEmpty()) {
-            baseResource = webResource;
-        } else {
-            baseResource = webResource.path("v" + dockerClientConfig.getVersion());
-        }
+        baseResource = webResource.path(dockerClientConfig.getVersion().asWebPathPart());
+
+        this.dockerClientConfig = dockerClientConfig;
     }
 
     private org.apache.http.config.Registry<ConnectionSocketFactory> getSchemeRegistry(final URI originalUri,
@@ -187,188 +186,193 @@ public class DockerCmdExecFactoryImpl implements DockerCmdExecFactory {
     }
 
     protected WebTarget getBaseResource() {
-        checkNotNull(baseResource, "Factory not initialized. You probably forgot to call init()!");
+        checkNotNull(baseResource, "Factory not initialized, baseResource not set. You probably forgot to call init()!");
         return baseResource;
+    }
+    
+    protected DockerClientConfig getDockerClientConfig() {
+        checkNotNull(dockerClientConfig, "Factor not initialized, dockerClientConfig not set. You probably forgot to call init()!");
+        return dockerClientConfig;
     }
 
     @Override
     public AuthCmd.Exec createAuthCmdExec() {
-        return new AuthCmdExec(getBaseResource());
+        return new AuthCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public InfoCmd.Exec createInfoCmdExec() {
-        return new InfoCmdExec(getBaseResource());
+        return new InfoCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public PingCmd.Exec createPingCmdExec() {
-        return new PingCmdExec(getBaseResource());
+        return new PingCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public VersionCmd.Exec createVersionCmdExec() {
-        return new VersionCmdExec(getBaseResource());
+        return new VersionCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public PullImageCmd.Exec createPullImageCmdExec() {
-        return new PullImageCmdExec(getBaseResource());
+        return new PullImageCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public PushImageCmd.Exec createPushImageCmdExec() {
-        return new PushImageCmdExec(getBaseResource());
+        return new PushImageCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public SaveImageCmd.Exec createSaveImageCmdExec() {
-        return new SaveImageCmdExec(getBaseResource());
+        return new SaveImageCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public CreateImageCmd.Exec createCreateImageCmdExec() {
-        return new CreateImageCmdExec(getBaseResource());
+        return new CreateImageCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public SearchImagesCmd.Exec createSearchImagesCmdExec() {
-        return new SearchImagesCmdExec(getBaseResource());
+        return new SearchImagesCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public RemoveImageCmd.Exec createRemoveImageCmdExec() {
-        return new RemoveImageCmdExec(getBaseResource());
+        return new RemoveImageCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public ListImagesCmd.Exec createListImagesCmdExec() {
-        return new ListImagesCmdExec(getBaseResource());
+        return new ListImagesCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public InspectImageCmd.Exec createInspectImageCmdExec() {
-        return new InspectImageCmdExec(getBaseResource());
+        return new InspectImageCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public ListContainersCmd.Exec createListContainersCmdExec() {
-        return new ListContainersCmdExec(getBaseResource());
+        return new ListContainersCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public CreateContainerCmd.Exec createCreateContainerCmdExec() {
-        return new CreateContainerCmdExec(getBaseResource());
+        return new CreateContainerCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public StartContainerCmd.Exec createStartContainerCmdExec() {
-        return new StartContainerCmdExec(getBaseResource());
+        return new StartContainerCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public InspectContainerCmd.Exec createInspectContainerCmdExec() {
-        return new InspectContainerCmdExec(getBaseResource());
+        return new InspectContainerCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public ExecCreateCmd.Exec createExecCmdExec() {
-        return new ExecCreateCmdExec(getBaseResource());
+        return new ExecCreateCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public RemoveContainerCmd.Exec createRemoveContainerCmdExec() {
-        return new RemoveContainerCmdExec(getBaseResource());
+        return new RemoveContainerCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public WaitContainerCmd.Exec createWaitContainerCmdExec() {
-        return new WaitContainerCmdExec(getBaseResource());
+        return new WaitContainerCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public AttachContainerCmd.Exec createAttachContainerCmdExec() {
-        return new AttachContainerCmdExec(getBaseResource());
+        return new AttachContainerCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public ExecStartCmd.Exec createExecStartCmdExec() {
-        return new ExecStartCmdExec(getBaseResource());
+        return new ExecStartCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public InspectExecCmd.Exec createInspectExecCmdExec() {
-        return new InspectExecCmdExec(getBaseResource());
+        return new InspectExecCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public LogContainerCmd.Exec createLogContainerCmdExec() {
-        return new LogContainerCmdExec(getBaseResource());
+        return new LogContainerCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public CopyFileFromContainerCmd.Exec createCopyFileFromContainerCmdExec() {
-        return new CopyFileFromContainerCmdExec(getBaseResource());
+        return new CopyFileFromContainerCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public StopContainerCmd.Exec createStopContainerCmdExec() {
-        return new StopContainerCmdExec(getBaseResource());
+        return new StopContainerCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public ContainerDiffCmd.Exec createContainerDiffCmdExec() {
-        return new ContainerDiffCmdExec(getBaseResource());
+        return new ContainerDiffCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public KillContainerCmd.Exec createKillContainerCmdExec() {
-        return new KillContainerCmdExec(getBaseResource());
+        return new KillContainerCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public RestartContainerCmd.Exec createRestartContainerCmdExec() {
-        return new RestartContainerCmdExec(getBaseResource());
+        return new RestartContainerCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public CommitCmd.Exec createCommitCmdExec() {
-        return new CommitCmdExec(getBaseResource());
+        return new CommitCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public BuildImageCmd.Exec createBuildImageCmdExec() {
-        return new BuildImageCmdExec(getBaseResource());
+        return new BuildImageCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public TopContainerCmd.Exec createTopContainerCmdExec() {
-        return new TopContainerCmdExec(getBaseResource());
+        return new TopContainerCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public TagImageCmd.Exec createTagImageCmdExec() {
-        return new TagImageCmdExec(getBaseResource());
+        return new TagImageCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public PauseContainerCmd.Exec createPauseContainerCmdExec() {
-        return new PauseContainerCmdExec(getBaseResource());
+        return new PauseContainerCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public UnpauseContainerCmd.Exec createUnpauseContainerCmdExec() {
-        return new UnpauseContainerCmdExec(baseResource);
+        return new UnpauseContainerCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public EventsCmd.Exec createEventsCmdExec() {
-        return new EventsCmdExec(getBaseResource());
+        return new EventsCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override
     public StatsCmd.Exec createStatsCmdExec() {
-        return new StatsCmdExec(getBaseResource());
+        return new StatsCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/EventsCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/EventsCmdExec.java
@@ -1,16 +1,16 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.EventsCmd;
 import com.github.dockerjava.api.model.Event;
+import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.async.JsonStreamProcessor;
 import com.github.dockerjava.jaxrs.async.AbstractCallbackNotifier;
 import com.github.dockerjava.jaxrs.async.GETCallbackNotifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.client.WebTarget;
 
 import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
 
@@ -18,8 +18,8 @@ public class EventsCmdExec extends AbstrAsyncDockerCmdExec<EventsCmd, Event> imp
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EventsCmdExec.class);
 
-    public EventsCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public EventsCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/ExecCreateCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/ExecCreateCmdExec.java
@@ -1,23 +1,23 @@
 package com.github.dockerjava.jaxrs;
 
-import static javax.ws.rs.client.Entity.entity;
+import com.github.dockerjava.api.command.ExecCreateCmd;
+import com.github.dockerjava.api.command.ExecCreateCmdResponse;
+import com.github.dockerjava.core.DockerClientConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.github.dockerjava.api.command.ExecCreateCmd;
-import com.github.dockerjava.api.command.ExecCreateCmdResponse;
+import static javax.ws.rs.client.Entity.entity;
 
 public class ExecCreateCmdExec extends AbstrSyncDockerCmdExec<ExecCreateCmd, ExecCreateCmdResponse> implements
         ExecCreateCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(VersionCmdExec.class);
 
-    public ExecCreateCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public ExecCreateCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/ExecStartCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/ExecStartCmdExec.java
@@ -1,25 +1,24 @@
 package com.github.dockerjava.jaxrs;
 
-import static javax.ws.rs.client.Entity.entity;
-
-import java.io.InputStream;
+import com.github.dockerjava.api.command.ExecStartCmd;
+import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.jaxrs.util.WrappedResponseInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.io.InputStream;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.github.dockerjava.api.command.ExecStartCmd;
-import com.github.dockerjava.jaxrs.util.WrappedResponseInputStream;
+import static javax.ws.rs.client.Entity.entity;
 
 public class ExecStartCmdExec extends AbstrSyncDockerCmdExec<ExecStartCmd, InputStream> implements ExecStartCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ExecStartCmdExec.class);
 
-    public ExecStartCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public ExecStartCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/InfoCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/InfoCmdExec.java
@@ -1,20 +1,20 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-
+import com.github.dockerjava.api.command.InfoCmd;
+import com.github.dockerjava.api.model.Info;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.command.InfoCmd;
-import com.github.dockerjava.api.model.Info;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 
 public class InfoCmdExec extends AbstrSyncDockerCmdExec<InfoCmd, Info> implements InfoCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InfoCmdExec.class);
 
-    public InfoCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public InfoCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/InspectContainerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/InspectContainerCmdExec.java
@@ -1,21 +1,21 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.command.InspectContainerCmd;
-import com.github.dockerjava.api.command.InspectContainerResponse;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 
 public class InspectContainerCmdExec extends AbstrSyncDockerCmdExec<InspectContainerCmd, InspectContainerResponse>
         implements InspectContainerCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InspectContainerCmdExec.class);
 
-    public InspectContainerCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public InspectContainerCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/InspectExecCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/InspectExecCmdExec.java
@@ -1,20 +1,20 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-
+import com.github.dockerjava.api.command.InspectExecCmd;
+import com.github.dockerjava.api.command.InspectExecResponse;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.command.InspectExecCmd;
-import com.github.dockerjava.api.command.InspectExecResponse;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 
 public class InspectExecCmdExec extends AbstrSyncDockerCmdExec<InspectExecCmd, InspectExecResponse> implements
         InspectExecCmd.Exec {
     private static final Logger LOGGER = LoggerFactory.getLogger(InspectExecCmdExec.class);
 
-    public InspectExecCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public InspectExecCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/InspectImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/InspectImageCmdExec.java
@@ -1,21 +1,21 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-
+import com.github.dockerjava.api.command.InspectImageCmd;
+import com.github.dockerjava.api.command.InspectImageResponse;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.command.InspectImageCmd;
-import com.github.dockerjava.api.command.InspectImageResponse;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 
 public class InspectImageCmdExec extends AbstrSyncDockerCmdExec<InspectImageCmd, InspectImageResponse> implements
         InspectImageCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InspectImageCmdExec.class);
 
-    public InspectImageCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public InspectImageCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/KillContainerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/KillContainerCmdExec.java
@@ -1,20 +1,20 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-
+import com.github.dockerjava.api.command.KillContainerCmd;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.command.KillContainerCmd;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 
 public class KillContainerCmdExec extends AbstrSyncDockerCmdExec<KillContainerCmd, Void> implements
         KillContainerCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KillContainerCmdExec.class);
 
-    public KillContainerCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public KillContainerCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/ListContainersCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/ListContainersCmdExec.java
@@ -1,26 +1,25 @@
 package com.github.dockerjava.jaxrs;
 
-import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
-
-import java.util.List;
+import com.github.dockerjava.api.command.ListContainersCmd;
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.core.DockerClientConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
+import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.github.dockerjava.api.command.ListContainersCmd;
-import com.github.dockerjava.api.model.Container;
+import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
 
 public class ListContainersCmdExec extends AbstrSyncDockerCmdExec<ListContainersCmd, List<Container>> implements
         ListContainersCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ListContainersCmdExec.class);
 
-    public ListContainersCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public ListContainersCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/ListImagesCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/ListImagesCmdExec.java
@@ -1,25 +1,24 @@
 package com.github.dockerjava.jaxrs;
 
-import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
-
-import java.util.List;
+import com.github.dockerjava.api.command.ListImagesCmd;
+import com.github.dockerjava.api.model.Image;
+import com.github.dockerjava.core.DockerClientConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
+import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.github.dockerjava.api.command.ListImagesCmd;
-import com.github.dockerjava.api.model.Image;
+import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
 
 public class ListImagesCmdExec extends AbstrSyncDockerCmdExec<ListImagesCmd, List<Image>> implements ListImagesCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ListImagesCmdExec.class);
 
-    public ListImagesCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public ListImagesCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/LogContainerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/LogContainerCmdExec.java
@@ -1,24 +1,24 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.LogContainerCmd;
 import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.async.FrameStreamProcessor;
 import com.github.dockerjava.jaxrs.async.AbstractCallbackNotifier;
 import com.github.dockerjava.jaxrs.async.GETCallbackNotifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.client.WebTarget;
 
 public class LogContainerCmdExec extends AbstrAsyncDockerCmdExec<LogContainerCmd, Frame> implements
         LogContainerCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LogContainerCmdExec.class);
 
-    public LogContainerCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public LogContainerCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/PauseContainerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/PauseContainerCmdExec.java
@@ -1,20 +1,20 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-
+import com.github.dockerjava.api.command.PauseContainerCmd;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.command.PauseContainerCmd;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 
 public class PauseContainerCmdExec extends AbstrSyncDockerCmdExec<PauseContainerCmd, Void> implements
         PauseContainerCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PauseContainerCmdExec.class);
 
-    public PauseContainerCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public PauseContainerCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/PingCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/PingCmdExec.java
@@ -1,18 +1,18 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-
+import com.github.dockerjava.api.command.PingCmd;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.command.PingCmd;
+import javax.ws.rs.client.WebTarget;
 
 public class PingCmdExec extends AbstrSyncDockerCmdExec<PingCmd, Void> implements PingCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PingCmdExec.class);
 
-    public PingCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public PingCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/PullImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/PullImageCmdExec.java
@@ -1,30 +1,30 @@
 package com.github.dockerjava.jaxrs;
 
-import static javax.ws.rs.client.Entity.entity;
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.PullImageCmd;
+import com.github.dockerjava.api.model.AuthConfig;
+import com.github.dockerjava.api.model.PullResponseItem;
+import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.core.async.JsonStreamProcessor;
+import com.github.dockerjava.jaxrs.async.AbstractCallbackNotifier;
+import com.github.dockerjava.jaxrs.async.POSTCallbackNotifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.github.dockerjava.api.async.ResultCallback;
-import com.github.dockerjava.api.command.PullImageCmd;
-import com.github.dockerjava.api.model.AuthConfig;
-import com.github.dockerjava.api.model.PullResponseItem;
-import com.github.dockerjava.core.async.JsonStreamProcessor;
-import com.github.dockerjava.jaxrs.async.AbstractCallbackNotifier;
-import com.github.dockerjava.jaxrs.async.POSTCallbackNotifier;
+import static javax.ws.rs.client.Entity.entity;
 
 public class PullImageCmdExec extends AbstrAsyncDockerCmdExec<PullImageCmd, PullResponseItem> implements
         PullImageCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PullImageCmdExec.class);
 
-    public PullImageCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public PullImageCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     private Invocation.Builder resourceWithOptionalAuthConfig(PullImageCmd command, Invocation.Builder request) {

--- a/src/main/java/com/github/dockerjava/jaxrs/PushImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/PushImageCmdExec.java
@@ -1,29 +1,29 @@
 package com.github.dockerjava.jaxrs;
 
-import static javax.ws.rs.client.Entity.entity;
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.PushImageCmd;
+import com.github.dockerjava.api.model.AuthConfig;
+import com.github.dockerjava.api.model.PushResponseItem;
+import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.core.async.JsonStreamProcessor;
+import com.github.dockerjava.jaxrs.async.AbstractCallbackNotifier;
+import com.github.dockerjava.jaxrs.async.POSTCallbackNotifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.github.dockerjava.api.async.ResultCallback;
-import com.github.dockerjava.api.command.PushImageCmd;
-import com.github.dockerjava.api.model.AuthConfig;
-import com.github.dockerjava.api.model.PushResponseItem;
-import com.github.dockerjava.core.async.JsonStreamProcessor;
-import com.github.dockerjava.jaxrs.async.AbstractCallbackNotifier;
-import com.github.dockerjava.jaxrs.async.POSTCallbackNotifier;
+import static javax.ws.rs.client.Entity.entity;
 
 public class PushImageCmdExec extends AbstrAsyncDockerCmdExec<PushImageCmd, PushResponseItem> implements
         PushImageCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PushImageCmdExec.class);
 
-    public PushImageCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public PushImageCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     private String name(PushImageCmd command) {

--- a/src/main/java/com/github/dockerjava/jaxrs/RemoveContainerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/RemoveContainerCmdExec.java
@@ -1,20 +1,20 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-
+import com.github.dockerjava.api.command.RemoveContainerCmd;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.command.RemoveContainerCmd;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 
 public class RemoveContainerCmdExec extends AbstrSyncDockerCmdExec<RemoveContainerCmd, Void> implements
         RemoveContainerCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RemoveContainerCmdExec.class);
 
-    public RemoveContainerCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public RemoveContainerCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/RemoveImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/RemoveImageCmdExec.java
@@ -1,18 +1,18 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-
+import com.github.dockerjava.api.command.RemoveImageCmd;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.command.RemoveImageCmd;
+import javax.ws.rs.client.WebTarget;
 
 public class RemoveImageCmdExec extends AbstrSyncDockerCmdExec<RemoveImageCmd, Void> implements RemoveImageCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RemoveImageCmdExec.class);
 
-    public RemoveImageCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public RemoveImageCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/RestartContainerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/RestartContainerCmdExec.java
@@ -1,20 +1,20 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-
+import com.github.dockerjava.api.command.RestartContainerCmd;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.command.RestartContainerCmd;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 
 public class RestartContainerCmdExec extends AbstrSyncDockerCmdExec<RestartContainerCmd, Void> implements
         RestartContainerCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RestartContainerCmdExec.class);
 
-    public RestartContainerCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public RestartContainerCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/SaveImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/SaveImageCmdExec.java
@@ -1,22 +1,21 @@
 package com.github.dockerjava.jaxrs;
 
-import java.io.InputStream;
+import com.github.dockerjava.api.command.SaveImageCmd;
+import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.jaxrs.util.WrappedResponseInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.github.dockerjava.api.command.SaveImageCmd;
-import com.github.dockerjava.jaxrs.util.WrappedResponseInputStream;
+import java.io.InputStream;
 
 public class SaveImageCmdExec extends AbstrSyncDockerCmdExec<SaveImageCmd, InputStream> implements SaveImageCmd.Exec {
     private static final Logger LOGGER = LoggerFactory.getLogger(SaveImageCmdExec.class);
 
-    public SaveImageCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public SaveImageCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/SearchImagesCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/SearchImagesCmdExec.java
@@ -1,24 +1,23 @@
 package com.github.dockerjava.jaxrs;
 
-import java.util.List;
+import com.github.dockerjava.api.command.SearchImagesCmd;
+import com.github.dockerjava.api.model.SearchItem;
+import com.github.dockerjava.core.DockerClientConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.github.dockerjava.api.command.SearchImagesCmd;
-import com.github.dockerjava.api.model.SearchItem;
+import java.util.List;
 
 public class SearchImagesCmdExec extends AbstrSyncDockerCmdExec<SearchImagesCmd, List<SearchItem>> implements
         SearchImagesCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SearchImagesCmdExec.class);
 
-    public SearchImagesCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public SearchImagesCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/StartContainerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/StartContainerCmdExec.java
@@ -1,22 +1,22 @@
 package com.github.dockerjava.jaxrs;
 
-import static javax.ws.rs.client.Entity.entity;
+import com.github.dockerjava.api.command.StartContainerCmd;
+import com.github.dockerjava.core.DockerClientConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.github.dockerjava.api.command.StartContainerCmd;
+import static javax.ws.rs.client.Entity.entity;
 
 public class StartContainerCmdExec extends AbstrSyncDockerCmdExec<StartContainerCmd, Void> implements
         StartContainerCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StartContainerCmdExec.class);
 
-    public StartContainerCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public StartContainerCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/StatsCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/StatsCmdExec.java
@@ -1,22 +1,22 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.StatsCmd;
 import com.github.dockerjava.api.model.Statistics;
+import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.async.JsonStreamProcessor;
 import com.github.dockerjava.jaxrs.async.AbstractCallbackNotifier;
 import com.github.dockerjava.jaxrs.async.GETCallbackNotifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.client.WebTarget;
 
 public class StatsCmdExec extends AbstrAsyncDockerCmdExec<StatsCmd, Statistics> implements StatsCmd.Exec {
     private static final Logger LOGGER = LoggerFactory.getLogger(StatsCmdExec.class);
 
-    public StatsCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public StatsCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/StopContainerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/StopContainerCmdExec.java
@@ -1,20 +1,20 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-
+import com.github.dockerjava.api.command.StopContainerCmd;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.command.StopContainerCmd;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 
 public class StopContainerCmdExec extends AbstrSyncDockerCmdExec<StopContainerCmd, Void> implements
         StopContainerCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StopContainerCmdExec.class);
 
-    public StopContainerCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public StopContainerCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/TagImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/TagImageCmdExec.java
@@ -1,18 +1,18 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-
+import com.github.dockerjava.api.command.TagImageCmd;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.command.TagImageCmd;
+import javax.ws.rs.client.WebTarget;
 
 public class TagImageCmdExec extends AbstrSyncDockerCmdExec<TagImageCmd, Void> implements TagImageCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TagImageCmdExec.class);
 
-    public TagImageCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public TagImageCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/TopContainerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/TopContainerCmdExec.java
@@ -1,22 +1,22 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-
+import com.github.dockerjava.api.command.TopContainerCmd;
+import com.github.dockerjava.api.command.TopContainerResponse;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.command.TopContainerCmd;
-import com.github.dockerjava.api.command.TopContainerResponse;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 
 public class TopContainerCmdExec extends AbstrSyncDockerCmdExec<TopContainerCmd, TopContainerResponse> implements
         TopContainerCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TopContainerCmdExec.class);
 
-    public TopContainerCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public TopContainerCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/UnpauseContainerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/UnpauseContainerCmdExec.java
@@ -1,20 +1,20 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-
+import com.github.dockerjava.api.command.UnpauseContainerCmd;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.command.UnpauseContainerCmd;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 
 public class UnpauseContainerCmdExec extends AbstrSyncDockerCmdExec<UnpauseContainerCmd, Void> implements
         UnpauseContainerCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UnpauseContainerCmdExec.class);
 
-    public UnpauseContainerCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public UnpauseContainerCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/VersionCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/VersionCmdExec.java
@@ -1,20 +1,20 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-
+import com.github.dockerjava.api.command.VersionCmd;
+import com.github.dockerjava.api.model.Version;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.command.VersionCmd;
-import com.github.dockerjava.api.model.Version;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 
 public class VersionCmdExec extends AbstrSyncDockerCmdExec<VersionCmd, Version> implements VersionCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(VersionCmdExec.class);
 
-    public VersionCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public VersionCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/jaxrs/WaitContainerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/WaitContainerCmdExec.java
@@ -1,21 +1,21 @@
 package com.github.dockerjava.jaxrs;
 
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.dockerjava.api.command.WaitContainerCmd;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.github.dockerjava.api.command.WaitContainerCmd;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
 
 public class WaitContainerCmdExec extends AbstrSyncDockerCmdExec<WaitContainerCmd, Integer> implements
         WaitContainerCmd.Exec {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WaitContainerCmdExec.class);
 
-    public WaitContainerCmdExec(WebTarget baseResource) {
-        super(baseResource);
+    public WaitContainerCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
     }
 
     @Override

--- a/src/test/java/com/github/dockerjava/core/DockerClientConfigTest.java
+++ b/src/test/java/com/github/dockerjava/core/DockerClientConfigTest.java
@@ -1,6 +1,7 @@
 package com.github.dockerjava.core;
 
-import static org.testng.Assert.assertEquals;
+import com.github.dockerjava.api.model.AuthConfig;
+import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.util.Collections;
@@ -8,9 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import org.testng.annotations.Test;
-
-import com.github.dockerjava.api.model.AuthConfig;
+import static org.testng.Assert.assertEquals;
 
 public class DockerClientConfigTest {
 
@@ -25,7 +24,7 @@ public class DockerClientConfigTest {
     public void string() throws Exception {
         assertEquals(
                 EXAMPLE_CONFIG.toString(),
-                "DockerClientConfig{uri=http://foo, version='bar', username='baz', password='qux', email='blam', serverAddress='wham', dockerCfgPath='flam', sslConfig='LocalDirectorySSLConfig{dockerCertPath=flim}'}");
+                "DockerClientConfig{uri=http://foo, version='{UNKNOWN_VERSION}', username='baz', password='qux', email='blam', serverAddress='wham', dockerCfgPath='flam', sslConfig='LocalDirectorySSLConfig{dockerCertPath=flim}'}");
     }
 
     @Test
@@ -159,7 +158,7 @@ public class DockerClientConfigTest {
         assertEquals(config.getUri(), URI.create("https://localhost:2376"));
         assertEquals(config.getUsername(), "someUserName");
         assertEquals(config.getServerAddress(), AuthConfig.DEFAULT_SERVER_ADDRESS);
-        assertEquals(config.getVersion(), null);
+        assertEquals(config.getVersion(), RemoteApiVersion.unknown());
         assertEquals(config.getDockerCfgPath(), "someHomeDir/.dockercfg");
         assertEquals(((LocalDirectorySSLConfig) config.getSslConfig()).getDockerCertPath(), "someHomeDir/.docker");
     }


### PR DESCRIPTION
An issue with docker-java currently is that API < 1.19 has a different
authentication scheme than newer API versions. This leads to major problems
in environments with different docker installations
(see alexec/docker-java-orchestration#49)

docker-java Issue #288 fixed the issue for API >= 1.19, but let older servers
out of the consideration.

This patch allows clients at least to state which version of the API and thus
which authentication scheme they like to use.