### PR TITLE
Improve status check for pulling an image through docker-swarm

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/PullResponseItem.java
+++ b/src/main/java/com/github/dockerjava/api/model/PullResponseItem.java
@@ -23,7 +23,7 @@ public class PullResponseItem extends ResponseItem {
         }
 
         return (getStatus().contains("Download complete") || getStatus().contains("Image is up to date") || getStatus()
-                .contains("Downloaded newer image"));
+                .contains("Downloaded newer image") || getStatus().contains(": downloaded"));
     }
 
 }

--- a/src/main/java/com/github/dockerjava/core/command/PullImageResultCallback.java
+++ b/src/main/java/com/github/dockerjava/core/command/PullImageResultCallback.java
@@ -3,12 +3,14 @@
  */
 package com.github.dockerjava.core.command;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.dockerjava.api.DockerClientException;
 import com.github.dockerjava.api.model.PullResponseItem;
 import com.github.dockerjava.core.async.ResultCallbackTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  *
@@ -19,12 +21,69 @@ public class PullImageResultCallback extends ResultCallbackTemplate<PullImageRes
 
     private final static Logger LOGGER = LoggerFactory.getLogger(PullImageResultCallback.class);
 
+    private boolean isSwarm = false;
+    private Map<String, PullResponseItem> results = null;
     private PullResponseItem latestItem = null;
 
     @Override
     public void onNext(PullResponseItem item) {
-        this.latestItem = item;
+        // only do it once
+        if (results == null && latestItem == null) {
+            checkForDockerSwarmResponse(item);
+        }
+
+        if (isSwarm) {
+            handleDockerSwarmResponse(item);
+        } else {
+            handleDockerClientResponse(item);
+        }
         LOGGER.debug(item.toString());
+    }
+
+    private void checkForDockerSwarmResponse(PullResponseItem item) {
+        if (item.getStatus().matches("Pulling\\s.+\\.{3}$")) {
+            isSwarm = true;
+            LOGGER.debug("Communicating with Docker Swarm.");
+        }
+    }
+
+    private void handleDockerSwarmResponse(PullResponseItem item) {
+        if (results == null) {
+            results = new HashMap<String, PullResponseItem>();
+        }
+        results.put(item.getId(), item);
+    }
+
+    private void checkDockerSwarmPullSuccessful() {
+        if (results.isEmpty()) {
+            throw new DockerClientException("Could not pull image");
+        } else {
+            boolean pullFailed = false;
+            StringBuilder sb = new StringBuilder();
+
+            for (PullResponseItem pullResponseItem : results.values()) {
+                if (!pullResponseItem.isPullSuccessIndicated()) {
+                    pullFailed = true;
+                    sb.append("[" + pullResponseItem.getId() + ";" + pullResponseItem.getError() + "]");
+                }
+            }
+
+            if (pullFailed) {
+                throw new DockerClientException("Could not pull image: " + sb.toString());
+            }
+        }
+    }
+
+    private void handleDockerClientResponse(PullResponseItem item) {
+        latestItem = item;
+    }
+
+    private void checkDockerClientPullSuccessful() {
+        if (latestItem == null) {
+            throw new DockerClientException("Could not pull image");
+        } else if (!latestItem.isPullSuccessIndicated()) {
+            throw new DockerClientException("Could not pull image: " + latestItem.getError());
+        }
     }
 
     /**
@@ -40,10 +99,10 @@ public class PullImageResultCallback extends ResultCallbackTemplate<PullImageRes
             throw new DockerClientException("", e);
         }
 
-        if (latestItem == null) {
-            throw new DockerClientException("Could not pull image");
-        } else if (!latestItem.isPullSuccessIndicated()) {
-            throw new DockerClientException("Could not pull image: " + latestItem.getError());
+        if (isSwarm) {
+            checkDockerSwarmPullSuccessful();
+        } else {
+            checkDockerClientPullSuccessful();
         }
     }
 }


### PR DESCRIPTION
This improves the PullImageCmd for docker-swarm because docker-swarm returns a different status line than the normal docker client.
This fix only checks if the last status line returns successfully when pulling through docker-swarm, which means that the pull on the last node was successful. It does not mean the image pull on all swarm nodes went ok.
I do not know how to check this, because to be fully swarm compatible it would be needed to read the last x lines where x is the number of swarm nodes and check them all if the result is successful.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/337)

<!-- Reviewable:end -->
