### PR TITLE
Remove ServiceLoader logic

### DIFF
--- a/src/main/java/com/github/dockerjava/core/DockerClientBuilder.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientBuilder.java
@@ -1,25 +1,11 @@
 package com.github.dockerjava.core;
 
-import java.util.Iterator;
-import java.util.ServiceLoader;
-
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.DockerCmdExecFactory;
 import com.github.dockerjava.core.DockerClientConfig.DockerClientConfigBuilder;
+import com.github.dockerjava.jaxrs.DockerCmdExecFactoryImpl;
 
 public class DockerClientBuilder {
-
-    private static Class<? extends DockerCmdExecFactory> factoryClass;
-
-    private static ServiceLoader<DockerCmdExecFactory> serviceLoader = ServiceLoader.load(DockerCmdExecFactory.class);
-
-    static {
-        serviceLoader.reload();
-        Iterator<DockerCmdExecFactory> iterator = serviceLoader.iterator();
-        if (iterator.hasNext()) {
-            factoryClass = iterator.next().getClass();
-        }
-    }
 
     private DockerClientImpl dockerClient = null;
 
@@ -46,25 +32,11 @@ public class DockerClientBuilder {
     }
 
     public static DockerCmdExecFactory getDefaultDockerCmdExecFactory() {
-        if (factoryClass == null) {
-            throw new RuntimeException("Fatal: Can't find any implementation of '"
-                    + DockerCmdExecFactory.class.getName() + "' in the current classpath.");
-        }
-
-        try {
-            return factoryClass.newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
-            throw new RuntimeException("Fatal: Can't create new instance of '" + factoryClass.getName() + "'");
-        }
+        return new DockerCmdExecFactoryImpl();
     }
 
     public DockerClientBuilder withDockerCmdExecFactory(DockerCmdExecFactory dockerCmdExecFactory) {
         this.dockerCmdExecFactory = dockerCmdExecFactory;
-        return this;
-    }
-
-    public DockerClientBuilder withServiceLoaderClassLoader(ClassLoader classLoader) {
-        serviceLoader = ServiceLoader.load(DockerCmdExecFactory.class, classLoader);
         return this;
     }
 


### PR DESCRIPTION
Remove the ServiceLoader logic, as there will be only one implementation of DockerCmdExecFactory.

fixes #349 