### PR TITLE
Fix NameParser that does not allow for upper-case chars in a name of repository 

### DIFF
--- a/src/main/java/com/github/dockerjava/core/NameParser.java
+++ b/src/main/java/com/github/dockerjava/core/NameParser.java
@@ -15,7 +15,7 @@ public class NameParser {
 
     private static final int RepositoryNameTotalLengthMax = 255;
 
-    private static final Pattern RepositoryNameComponentRegexp = Pattern.compile("[a-z0-9]+(?:[._-][a-z0-9]+)*");
+    private static final Pattern RepositoryNameComponentRegexp = Pattern.compile("[a-zA-Z0-9]+(?:[._-][a-zA-Z0-9]+)*");
 
     private static final Pattern RepositoryNameComponentAnchoredRegexp = Pattern.compile("^"
             + RepositoryNameComponentRegexp.pattern() + "$");


### PR DESCRIPTION
Fix NameParser that does not allow for upper-case chars in a name of repository.

We have a use-case whereby the repositories are auto generated from names of specific feature branches and some branches contain upper case characters. That is causing com.github.dockerjava.core.InvalidRepositoryNameException
for branch like 'features-RTSIX-225'. That fix relaxes the validation and allows for such a repository to be accepted for image push. 