### PR TITLE
Added override for bulk-read variant of InputStream.read() in anonymous

### DIFF
--- a/src/main/java/com/github/dockerjava/core/dockerfile/Dockerfile.java
+++ b/src/main/java/com/github/dockerjava/core/dockerfile/Dockerfile.java
@@ -143,6 +143,11 @@ public class Dockerfile {
                     }
 
                     @Override
+                    public int read(byte [] buff, int offset, int len) throws IOException {
+                        return tarInputStream.read(buff, offset, len);
+                    }
+
+                    @Override
                     public void close() throws IOException {
                         IOUtils.closeQuietly(tarInputStream);
                         FileUtils.deleteQuietly(tarFile);


### PR DESCRIPTION
inner class created by Dockerfile.ScannedResult.buildDockerFolderTar().
This fixes an IO performance issue that occurs when only the single-byte
variant of the read() method on InputStream is overriden.