### PR TITLE
Deprecate "network" and enable "networks" stats (remote Docker API 1.21) (branch 2.x)

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/Statistics.java
+++ b/src/main/java/com/github/dockerjava/api/model/Statistics.java
@@ -16,6 +16,13 @@ public class Statistics {
     @JsonProperty("read")
     private String read;
 
+    @JsonProperty("networks")
+    private Map<String, Object> networksStats;
+
+    /**
+     * Deprecated as of Docker Remote API 1.21
+     */
+    @Deprecated
     @JsonProperty("network")
     private Map<String, Object> networkStats;
 
@@ -27,6 +34,10 @@ public class Statistics {
 
     @JsonProperty("cpu_stats")
     private Map<String, Object> cpuStats;
+
+    public Map<String, Object> getNetworksStats() {
+        return networksStats;
+    }
 
     public Map<String, Object> getNetworkStats() {
         return networkStats;

--- a/src/main/java/com/github/dockerjava/api/model/Statistics.java
+++ b/src/main/java/com/github/dockerjava/api/model/Statistics.java
@@ -23,10 +23,10 @@ public class Statistics {
      */
     @CheckForNull
     @JsonProperty("networks")
-    private Map<String, Object> networksStats;
+    private Map<String, Object> networks;
 
     /**
-     * @deprecated as of Docker Remote API 1.21, replaced by {@link #networksStats}
+     * @deprecated as of Docker Remote API 1.21, replaced by {@link #networks}
      */
     @Deprecated
     @JsonProperty("network")
@@ -45,12 +45,12 @@ public class Statistics {
      * @since Docker Remote API 1.21
      */
     @CheckForNull
-    public Map<String, Object> getNetworksStats() {
-        return networksStats;
+    public Map<String, Object> getNetworks() {
+        return networks;
     }
 
     /**
-     * @deprecated as of Docker Remote API 1.21, replaced by {@link #getNetworksStats()}
+     * @deprecated as of Docker Remote API 1.21, replaced by {@link #getNetworks()}
      */
     @Deprecated
     public Map<String, Object> getNetworkStats() {

--- a/src/main/java/com/github/dockerjava/api/model/Statistics.java
+++ b/src/main/java/com/github/dockerjava/api/model/Statistics.java
@@ -2,6 +2,8 @@ package com.github.dockerjava.api.model;
 
 import java.util.Map;
 
+import javax.annotation.CheckForNull;
+
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -16,11 +18,15 @@ public class Statistics {
     @JsonProperty("read")
     private String read;
 
+    /**
+     * @since Docker Remote API 1.21
+     */
+    @CheckForNull
     @JsonProperty("networks")
     private Map<String, Object> networksStats;
 
     /**
-     * Deprecated as of Docker Remote API 1.21
+     * @deprecated as of Docker Remote API 1.21, replaced by {@link #networksStats}
      */
     @Deprecated
     @JsonProperty("network")
@@ -35,10 +41,18 @@ public class Statistics {
     @JsonProperty("cpu_stats")
     private Map<String, Object> cpuStats;
 
+    /**
+     * @since Docker Remote API 1.21
+     */
+    @CheckForNull
     public Map<String, Object> getNetworksStats() {
         return networksStats;
     }
 
+    /**
+     * @deprecated as of Docker Remote API 1.21, replaced by {@link #getNetworksStats()}
+     */
+    @Deprecated
     public Map<String, Object> getNetworkStats() {
         return networkStats;
     }


### PR DESCRIPTION
Include `networks` in statistics (branch 2.x) 