### PR TITLE
Pr/372

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
+++ b/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
@@ -3,6 +3,7 @@ package com.github.dockerjava.api.command;
 import java.util.List;
 import java.util.Map;
 
+import com.github.dockerjava.core.RemoteApiVersion;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -15,6 +16,8 @@ import com.github.dockerjava.api.model.VolumeBind;
 import com.github.dockerjava.api.model.VolumeBinds;
 import com.github.dockerjava.api.model.VolumeRW;
 import com.github.dockerjava.api.model.VolumesRW;
+
+import javax.annotation.CheckForNull;
 
 /**
  *
@@ -225,44 +228,169 @@ public class InspectContainerResponse {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public class ContainerState {
 
+        /**
+         * @since {@link RemoteApiVersion#VERSION_1_20}
+         */
+        @CheckForNull
+        @JsonProperty("Status")
+        private String status;
+
+        /**
+         * @since < {@link RemoteApiVersion#VERSION_1_16}
+         */
+        @CheckForNull
         @JsonProperty("Running")
         private Boolean running;
 
+        /**
+         * @since {@link RemoteApiVersion#VERSION_1_17}
+         */
+        @CheckForNull
         @JsonProperty("Paused")
         private Boolean paused;
 
+        /**
+         * @since {@link RemoteApiVersion#VERSION_1_17}
+         */
+        @CheckForNull
+        @JsonProperty("Restarting")
+        private Boolean restarting;
+
+        /**
+         * @since {@link RemoteApiVersion#VERSION_1_17}
+         */
+        @CheckForNull
+        @JsonProperty("OOMKilled")
+        private Boolean oomKilled;
+
+        /**
+         * <a href="https://github.com/docker/docker/pull/18127">Unclear</a>
+         * @since {@link RemoteApiVersion#UNKNOWN_VERSION}
+         */
+        @CheckForNull
+        @JsonProperty("Dead")
+        private Boolean dead;
+
+        /**
+         * @since < {@link RemoteApiVersion#VERSION_1_16}
+         */
+        @CheckForNull
         @JsonProperty("Pid")
         private Integer pid;
 
+        /**
+         * @since < {@link RemoteApiVersion#VERSION_1_16}
+         */
+        @CheckForNull
         @JsonProperty("ExitCode")
         private Integer exitCode;
 
+        /**
+         * @since {@link RemoteApiVersion#VERSION_1_17}
+         */
+        @CheckForNull
+        @JsonProperty("Error")
+        private String error;
+
+        /**
+         * @since < {@link RemoteApiVersion#VERSION_1_16}
+         */
+        @CheckForNull
         @JsonProperty("StartedAt")
         private String startedAt;
 
+        /**
+         * @since {@link RemoteApiVersion#VERSION_1_17}
+         */
+        @CheckForNull
         @JsonProperty("FinishedAt")
         private String finishedAt;
 
-        public Boolean isRunning() {
+
+        /**
+         * See {@link #status}
+         */
+        @CheckForNull
+        public String getStatus() {
+            return status;
+        }
+
+        /**
+         * See {@link #running}
+         */
+        @CheckForNull
+        public Boolean getRunning() {
             return running;
         }
 
-        public Boolean isPaused() {
+        /**
+         * See {@link #paused}
+         */
+        @CheckForNull
+        public Boolean getPaused() {
             return paused;
         }
 
+        /**
+         * See {@link #restarting}
+         */
+        @CheckForNull
+        public Boolean getRestarting() {
+            return restarting;
+        }
+
+        /**
+         * See {@link #oomKilled}
+         */
+        @CheckForNull
+        public Boolean getOOMKilled() {
+            return oomKilled;
+        }
+
+        /**
+         * See {@link #dead}
+         */
+        @CheckForNull
+        public Boolean getDead() {
+            return dead;
+        }
+
+        /**
+         * See {@link #pid}
+         */
+        @CheckForNull
         public Integer getPid() {
             return pid;
         }
 
+        /**
+         * See {@link #exitCode}
+         */
+        @CheckForNull
         public Integer getExitCode() {
             return exitCode;
         }
 
+        /**
+         * See {@link #error}
+         */
+        @CheckForNull
+        public String getError() {
+            return error;
+        }
+
+        /**
+         * See {@link #startedAt}
+         */
+        @CheckForNull
         public String getStartedAt() {
             return startedAt;
         }
 
+        /**
+         * See {@link #finishedAt}
+         */
+        @CheckForNull
         public String getFinishedAt() {
             return finishedAt;
         }

--- a/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
+++ b/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 
 import com.github.dockerjava.core.RemoteApiVersion;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -393,6 +395,16 @@ public class InspectContainerResponse {
         @CheckForNull
         public String getFinishedAt() {
             return finishedAt;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return EqualsBuilder.reflectionEquals(this, o);
+        }
+
+        @Override
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this);
         }
 
         @Override

--- a/src/main/java/com/github/dockerjava/core/RemoteApiVersion.java
+++ b/src/main/java/com/github/dockerjava/core/RemoteApiVersion.java
@@ -10,7 +10,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Bean to encapsulate the version of the Docker Remote API (REST API)
+ * Bean to encapsulate the version of the
+ * <a href="http://docs.docker.com/engine/reference/api/docker_remote_api/">Docker Remote (REST) API</a>
  * <p>
  * Contains the minor and major version of the API as well as operations to compare API versions.
  *
@@ -19,10 +20,49 @@ import java.util.regex.Pattern;
 public class RemoteApiVersion implements Serializable {
     private static final long serialVersionUID = -5382212999262115459L;
 
-    public static final RemoteApiVersion VERSION_1_19 = RemoteApiVersion.create(1, 19);
-
     private static final Pattern VERSION_REGEX = Pattern.compile("v?(\\d+)\\.(\\d+)");
 
+    /**
+     * @see <a href="http://docs.docker.com/engine/reference/api/docker_remote_api_v1.16/">Docker API 1.16</a>
+     */
+    public static final RemoteApiVersion VERSION_1_16 = RemoteApiVersion.create(1, 16);
+
+    /**
+     * @see <a href="http://docs.docker.com/engine/reference/api/docker_remote_api_v1.17/">Docker API 1.17</a>
+     */
+    public static final RemoteApiVersion VERSION_1_17 = RemoteApiVersion.create(1, 17);
+
+    /**
+     * @see <a href="http://docs.docker.com/engine/reference/api/docker_remote_api_v1.18/">Docker API 1.18</a>
+     */
+    public static final RemoteApiVersion VERSION_1_18 = RemoteApiVersion.create(1, 18);
+
+    /**
+     * @see <a href="http://docs.docker.com/engine/reference/api/docker_remote_api_v1.19/">Docker API 1.19</a>
+     */
+    public static final RemoteApiVersion VERSION_1_19 = RemoteApiVersion.create(1, 19);
+
+    /**
+     * @see <a href="http://docs.docker.com/engine/reference/api/docker_remote_api_v1.20/">Docker API 1.20</a>
+     */
+    public static final RemoteApiVersion VERSION_1_20 = RemoteApiVersion.create(1, 20);
+
+
+    /**
+     * @see <a href="http://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/">Docker API 1.21</a>
+     */
+    public static final RemoteApiVersion VERSION_1_21 = RemoteApiVersion.create(1, 21);
+
+    /**
+     * @see <a href="https://github.com/docker/docker/blob/master/docs/reference/api/docker_remote_api_v1.22.md">Docker API 1.22</a>
+     */
+    public static final RemoteApiVersion VERSION_1_22 = RemoteApiVersion.create(1, 22);
+
+
+    /**
+     * Unknown, docker doesn't reflect reality.
+     * I.e. we implemented method, but for javadoc it not clear when it was added.
+     */
     private static final RemoteApiVersion UNKNOWN_VERSION = new RemoteApiVersion(0, 0) {
 
         @Override

--- a/src/test/java/com/github/dockerjava/api/command/CommandJSONSamples.java
+++ b/src/test/java/com/github/dockerjava/api/command/CommandJSONSamples.java
@@ -24,7 +24,9 @@ import com.github.dockerjava.test.serdes.JSONResourceRef;
  */
 public enum CommandJSONSamples implements JSONResourceRef {
 
-    inspectContainerResponse_full, inspectContainerResponse_empty;
+    inspectContainerResponse_full,
+    inspectContainerResponse_full_1_21,
+    inspectContainerResponse_empty;
 
     @Override
     public String getFileName() {

--- a/src/test/java/com/github/dockerjava/api/command/InspectContainerResponseTest.java
+++ b/src/test/java/com/github/dockerjava/api/command/InspectContainerResponseTest.java
@@ -15,18 +15,21 @@
  */
 package com.github.dockerjava.api.command;
 
-import static com.github.dockerjava.test.serdes.JSONTestHelper.testRoundTrip;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import org.testng.annotations.Test;
 
 import java.io.IOException;
 
-import org.testng.annotations.Test;
+import static com.github.dockerjava.test.serdes.JSONTestHelper.testRoundTrip;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.IsNot.not;
+import static org.testng.Assert.*;
 
 /**
  * Tests for {@link InspectContainerResponse}.
- * 
+ *
  * @author Oleg Nenashev
  */
 public class InspectContainerResponseTest {
@@ -46,6 +49,22 @@ public class InspectContainerResponseTest {
         assertEquals(response.getVolumesRW()[1].getVolume().getPath(), "/bar/foo/myvol2");
         assertFalse(response.getVolumesRW()[1].getAccessMode().toBoolean());
         assertTrue(response.getVolumesRW()[0].getAccessMode().toBoolean());
+    }
+
+    @Test
+    public void roundTrip_1_21_full() throws IOException {
+        InspectContainerResponse[] responses = testRoundTrip(CommandJSONSamples.inspectContainerResponse_full_1_21,
+                InspectContainerResponse[].class);
+        assertEquals(1, responses.length);
+        final InspectContainerResponse response = responses[0];
+        final InspectContainerResponse.ContainerState state = response.getState();
+        assertThat(state, not(nullValue()));
+
+        assertFalse(state.getDead());
+        assertThat(state.getStatus(), containsString("running"));
+        assertFalse(state.getRestarting());
+        assertFalse(state.getOOMKilled());
+        assertThat(state.getError(), isEmptyString());
     }
 
     @Test

--- a/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
@@ -253,7 +253,7 @@ public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
         InspectContainerResponse inspectContainerResponse1 = dockerClient.inspectContainerCmd(container1.getId())
                 .exec();
         LOG.info("Container1 Inspect: {}", inspectContainerResponse1.toString());
-        assertThat(inspectContainerResponse1.getState().isRunning(), is(true));
+        assertThat(inspectContainerResponse1.getState().getRunning(), is(true));
 
         CreateContainerResponse container2 = dockerClient.createContainerCmd("busybox").withName("container2")
                 .withCmd("env").withLinks(new Link("container1", "container1Link")).exec();
@@ -406,9 +406,9 @@ public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
         assertThat(inspectContainerResponse1.getName(), equalTo("/container1"));
         assertThat(inspectContainerResponse1.getImageId(), not(isEmptyString()));
         assertThat(inspectContainerResponse1.getState(), is(notNullValue()));
-        assertThat(inspectContainerResponse1.getState().isRunning(), is(true));
+        assertThat(inspectContainerResponse1.getState().getRunning(), is(true));
 
-        if (!inspectContainerResponse1.getState().isRunning()) {
+        if (!inspectContainerResponse1.getState().getRunning()) {
             assertThat(inspectContainerResponse1.getState().getExitCode(), is(equalTo(0)));
         }
 

--- a/src/test/java/com/github/dockerjava/core/command/KillContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/KillContainerCmdImplTest.java
@@ -62,7 +62,7 @@ public class KillContainerCmdImplTest extends AbstractDockerClientTest {
         InspectContainerResponse inspectContainerResponse = dockerClient.inspectContainerCmd(container.getId()).exec();
         LOG.info("Container Inspect: {}", inspectContainerResponse.toString());
 
-        assertThat(inspectContainerResponse.getState().isRunning(), is(equalTo(false)));
+        assertThat(inspectContainerResponse.getState().getRunning(), is(equalTo(false)));
         assertThat(inspectContainerResponse.getState().getExitCode(), not(equalTo(0)));
 
     }

--- a/src/test/java/com/github/dockerjava/core/command/RestartContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/RestartContainerCmdImplTest.java
@@ -66,7 +66,7 @@ public class RestartContainerCmdImplTest extends AbstractDockerClientTest {
 
         assertThat(startTime, not(equalTo(startTime2)));
 
-        assertThat(inspectContainerResponse.getState().isRunning(), is(equalTo(true)));
+        assertThat(inspectContainerResponse.getState().getRunning(), is(equalTo(true)));
 
         dockerClient.killContainerCmd(container.getId()).exec();
     }

--- a/src/test/java/com/github/dockerjava/core/command/StartContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/StartContainerCmdImplTest.java
@@ -289,9 +289,9 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
         assertThat(inspectContainerResponse1.getName(), equalTo("/container1"));
         assertThat(inspectContainerResponse1.getImageId(), not(isEmptyString()));
         assertThat(inspectContainerResponse1.getState(), is(notNullValue()));
-        assertThat(inspectContainerResponse1.getState().isRunning(), is(true));
+        assertThat(inspectContainerResponse1.getState().getRunning(), is(true));
 
-        if (!inspectContainerResponse1.getState().isRunning()) {
+        if (!inspectContainerResponse1.getState().getRunning()) {
             assertThat(inspectContainerResponse1.getState().getExitCode(), is(equalTo(0)));
         }
 
@@ -317,7 +317,7 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
         assertThat(inspectContainerResponse2.getName(), equalTo("/container2"));
         assertThat(inspectContainerResponse2.getImageId(), not(isEmptyString()));
         assertThat(inspectContainerResponse2.getState(), is(notNullValue()));
-        assertThat(inspectContainerResponse2.getState().isRunning(), is(true));
+        assertThat(inspectContainerResponse2.getState().getRunning(), is(true));
 
     }
 
@@ -342,9 +342,9 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
         assertThat(inspectContainerResponse1.getName(), equalTo("/container1"));
         assertThat(inspectContainerResponse1.getImageId(), not(isEmptyString()));
         assertThat(inspectContainerResponse1.getState(), is(notNullValue()));
-        assertThat(inspectContainerResponse1.getState().isRunning(), is(true));
+        assertThat(inspectContainerResponse1.getState().getRunning(), is(true));
 
-        if (!inspectContainerResponse1.getState().isRunning()) {
+        if (!inspectContainerResponse1.getState().getRunning()) {
             assertThat(inspectContainerResponse1.getState().getExitCode(), is(equalTo(0)));
         }
 
@@ -370,7 +370,7 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
         assertThat(inspectContainerResponse2.getName(), equalTo("/container2"));
         assertThat(inspectContainerResponse2.getImageId(), not(isEmptyString()));
         assertThat(inspectContainerResponse2.getState(), is(notNullValue()));
-        assertThat(inspectContainerResponse2.getState().isRunning(), is(true));
+        assertThat(inspectContainerResponse2.getState().getRunning(), is(true));
 
     }
 
@@ -396,9 +396,9 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
         assertThat(inspectContainerResponse.getImageId(), not(isEmptyString()));
         assertThat(inspectContainerResponse.getState(), is(notNullValue()));
 
-        assertThat(inspectContainerResponse.getState().isRunning(), is(true));
+        assertThat(inspectContainerResponse.getState().getRunning(), is(true));
 
-        if (!inspectContainerResponse.getState().isRunning()) {
+        if (!inspectContainerResponse.getState().getRunning()) {
             assertThat(inspectContainerResponse.getState().getExitCode(), is(equalTo(0)));
         }
     }
@@ -452,7 +452,7 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
 
         InspectContainerResponse inspectContainerResponse = dockerClient.inspectContainerCmd(container.getId()).exec();
 
-        assertThat(inspectContainerResponse.getState().isRunning(), is(true));
+        assertThat(inspectContainerResponse.getState().getRunning(), is(true));
 
         assertThat(Arrays.asList(inspectContainerResponse.getHostConfig().getCapAdd()), contains(NET_ADMIN));
 
@@ -473,7 +473,7 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
 
         InspectContainerResponse inspectContainerResponse = dockerClient.inspectContainerCmd(container.getId()).exec();
 
-        assertThat(inspectContainerResponse.getState().isRunning(), is(true));
+        assertThat(inspectContainerResponse.getState().getRunning(), is(true));
 
         assertThat(Arrays.asList(inspectContainerResponse.getHostConfig().getDevices()), contains(new Device("rwm",
                 "/dev/nulo", "/dev/zero")));
@@ -493,7 +493,7 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
 
         InspectContainerResponse inspectContainerResponse = dockerClient.inspectContainerCmd(container.getId()).exec();
 
-        assertThat(inspectContainerResponse.getState().isRunning(), is(true));
+        assertThat(inspectContainerResponse.getState().getRunning(), is(true));
 
         assertThat(Arrays.asList(inspectContainerResponse.getHostConfig().getExtraHosts()),
                 contains("dockerhost:127.0.0.1"));
@@ -515,7 +515,7 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
 
         InspectContainerResponse inspectContainerResponse = dockerClient.inspectContainerCmd(container.getId()).exec();
 
-        assertThat(inspectContainerResponse.getState().isRunning(), is(true));
+        assertThat(inspectContainerResponse.getState().getRunning(), is(true));
 
         assertThat(inspectContainerResponse.getHostConfig().getRestartPolicy(), is(equalTo(restartPolicy)));
     }

--- a/src/test/java/com/github/dockerjava/core/command/StopContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/StopContainerCmdImplTest.java
@@ -62,7 +62,7 @@ public class StopContainerCmdImplTest extends AbstractDockerClientTest {
         InspectContainerResponse inspectContainerResponse = dockerClient.inspectContainerCmd(container.getId()).exec();
         LOG.info("Container Inspect: {}", inspectContainerResponse.toString());
 
-        assertThat(inspectContainerResponse.getState().isRunning(), is(equalTo(false)));
+        assertThat(inspectContainerResponse.getState().getRunning(), is(equalTo(false)));
         assertThat(inspectContainerResponse.getState().getExitCode(), not(equalTo(0)));
     }
 

--- a/src/test/java/com/github/dockerjava/core/command/WaitContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/WaitContainerCmdImplTest.java
@@ -64,7 +64,7 @@ public class WaitContainerCmdImplTest extends AbstractDockerClientTest {
         InspectContainerResponse inspectContainerResponse = dockerClient.inspectContainerCmd(container.getId()).exec();
         LOG.info("Container Inspect: {}", inspectContainerResponse.toString());
 
-        assertThat(inspectContainerResponse.getState().isRunning(), is(equalTo(false)));
+        assertThat(inspectContainerResponse.getState().getRunning(), is(equalTo(false)));
         assertThat(inspectContainerResponse.getState().getExitCode(), is(equalTo(exitCode)));
     }
 
@@ -102,6 +102,6 @@ public class WaitContainerCmdImplTest extends AbstractDockerClientTest {
         InspectContainerResponse inspectContainerResponse = dockerClient.inspectContainerCmd(container.getId()).exec();
         LOG.info("Container Inspect: {}", inspectContainerResponse.toString());
 
-        assertThat(inspectContainerResponse.getState().isRunning(), is(equalTo(false)));
+        assertThat(inspectContainerResponse.getState().getRunning(), is(equalTo(false)));
     }
 }

--- a/src/test/resources/com/github/dockerjava/api/command/inspectContainerResponse_full_1_21.json
+++ b/src/test/resources/com/github/dockerjava/api/command/inspectContainerResponse_full_1_21.json
@@ -1,0 +1,143 @@
+[
+  {
+    "Id": "fc1243c01bbb791d9eca64204d76f72fc47fbebbca892d7dd0a5cd0e4e346045",
+    "Created": "2015-11-20T21:10:34.775649753Z",
+    "Path": "cat",
+    "Args": [],
+    "State": {
+      "Status": "running",
+      "Running": true,
+      "Paused": false,
+      "Restarting": false,
+      "OOMKilled": false,
+      "Dead": false,
+      "Pid": 10912,
+      "ExitCode": 0,
+      "Error": "",
+      "StartedAt": "2015-11-20T21:10:34.845546358Z",
+      "FinishedAt": "0001-01-01T00:00:00Z"
+    },
+    "Image": "c51f86c283408d1749d066333f7acd5d33b053b003a61ff6a7b36819ddcbc7b7",
+    "ResolvConfPath": "/mnt/sda1/var/lib/docker/containers/fc1243c01bbb791d9eca64204d76f72fc47fbebbca892d7dd0a5cd0e4e346045/resolv.conf",
+    "HostnamePath": "/mnt/sda1/var/lib/docker/containers/fc1243c01bbb791d9eca64204d76f72fc47fbebbca892d7dd0a5cd0e4e346045/hostname",
+    "HostsPath": "/mnt/sda1/var/lib/docker/containers/fc1243c01bbb791d9eca64204d76f72fc47fbebbca892d7dd0a5cd0e4e346045/hosts",
+    "LogPath": "/mnt/sda1/var/lib/docker/containers/fc1243c01bbb791d9eca64204d76f72fc47fbebbca892d7dd0a5cd0e4e346045/fc1243c01bbb791d9eca64204d76f72fc47fbebbca892d7dd0a5cd0e4e346045-json.log",
+    "Name": "/small_hodgkin",
+    "RestartCount": 0,
+    "Driver": "aufs",
+    "ExecDriver": "native-0.2",
+    "MountLabel": "",
+    "ProcessLabel": "",
+    "AppArmorProfile": "",
+    "ExecIDs": null,
+    "HostConfig": {
+      "Binds": null,
+      "ContainerIDFile": "",
+      "LxcConf": [],
+      "Memory": 0,
+      "MemoryReservation": 0,
+      "MemorySwap": 0,
+      "KernelMemory": 0,
+      "CpuShares": 0,
+      "CpuPeriod": 0,
+      "CpusetCpus": "",
+      "CpusetMems": "",
+      "CpuQuota": 0,
+      "BlkioWeight": 0,
+      "OomKillDisable": false,
+      "MemorySwappiness": -1,
+      "Privileged": false,
+      "PortBindings": {},
+      "Links": null,
+      "PublishAllPorts": false,
+      "Dns": null,
+      "DnsOptions": null,
+      "DnsSearch": null,
+      "ExtraHosts": null,
+      "VolumesFrom": null,
+      "Devices": [],
+      "NetworkMode": "default",
+      "IpcMode": "",
+      "PidMode": "",
+      "UTSMode": "",
+      "CapAdd": null,
+      "CapDrop": null,
+      "GroupAdd": null,
+      "RestartPolicy": {
+        "Name": "no",
+        "MaximumRetryCount": 0
+      },
+      "SecurityOpt": null,
+      "ReadonlyRootfs": false,
+      "Ulimits": null,
+      "LogConfig": {
+        "Type": "json-file",
+        "Config": {}
+      },
+      "CgroupParent": "",
+      "ConsoleSize": [
+        0,
+        0
+      ],
+      "VolumeDriver": ""
+    },
+    "GraphDriver": {
+      "Name": "aufs",
+      "Data": null
+    },
+    "Mounts": [],
+    "Config": {
+      "Hostname": "fc1243c01bbb",
+      "Domainname": "",
+      "User": "",
+      "AttachStdin": false,
+      "AttachStdout": false,
+      "AttachStderr": false,
+      "Tty": false,
+      "OpenStdin": true,
+      "StdinOnce": false,
+      "Env": null,
+      "Cmd": [
+        "cat"
+      ],
+      "Image": "busybox",
+      "Volumes": null,
+      "WorkingDir": "",
+      "Entrypoint": null,
+      "OnBuild": null,
+      "Labels": {},
+      "StopSignal": "SIGTERM"
+    },
+    "NetworkSettings": {
+      "Bridge": "",
+      "SandboxID": "5a6ded01bf23cc180e8ba6a059449ac832f28fa1d8367127e316607f92d3228c",
+      "HairpinMode": false,
+      "LinkLocalIPv6Address": "",
+      "LinkLocalIPv6PrefixLen": 0,
+      "Ports": {},
+      "SandboxKey": "/var/run/docker/netns/5a6ded01bf23",
+      "SecondaryIPAddresses": null,
+      "SecondaryIPv6Addresses": null,
+      "EndpointID": "6b4bb2aff9981d6e132cf37ebbfd370069061fab848ae56247b154717a99aba7",
+      "Gateway": "172.17.0.1",
+      "GlobalIPv6Address": "",
+      "GlobalIPv6PrefixLen": 0,
+      "IPAddress": "172.17.0.2",
+      "IPPrefixLen": 16,
+      "IPv6Gateway": "",
+      "MacAddress": "02:42:ac:11:00:02",
+      "Networks": {
+        "bridge": {
+          "EndpointID": "6b4bb2aff9981d6e132cf37ebbfd370069061fab848ae56247b154717a99aba7",
+          "Gateway": "172.17.0.1",
+          "IPAddress": "172.17.0.2",
+          "IPPrefixLen": 16,
+          "IPv6Gateway": "",
+          "GlobalIPv6Address": "",
+          "GlobalIPv6PrefixLen": 0,
+          "MacAddress": "02:42:ac:11:00:02"
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
More reworked #372 

@marcuslinke for review

@marcuslinke we should define what to do with javadocs, annotating only field sounds logical, but getter/setter should also provide docs. Didn't found way inherit field javadoc to methods.
Probably it makes sense annotate field and provide link to it from getter WDYT?