### PR TITLE
Implement Node property in Inspect container response introduces by swarm

### DIFF
--- a/.travis/travis-before-install.sh
+++ b/.travis/travis-before-install.sh
@@ -61,6 +61,7 @@ DOCKER_OPTS="\
 -D \
 -H=unix:///var/run/docker.sock \
 -H=tcp://0.0.0.0:${HOST_PORT}  \
+--label=com.github.dockerjava.test=docker-java \
 "
 EOF
 

--- a/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
+++ b/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
@@ -1,13 +1,5 @@
 package com.github.dockerjava.api.command;
 
-import java.util.List;
-
-import javax.annotation.CheckForNull;
-
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -20,7 +12,14 @@ import com.github.dockerjava.api.model.VolumeBinds;
 import com.github.dockerjava.api.model.VolumeRW;
 import com.github.dockerjava.api.model.VolumesRW;
 import com.github.dockerjava.core.RemoteApiVersion;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
+
+import javax.annotation.CheckForNull;
+import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -104,6 +103,9 @@ public class InspectContainerResponse {
 
     @JsonProperty("VolumesRW")
     private VolumesRW volumesRW;
+
+    @JsonProperty("Node")
+    private Node node;
 
     @JsonProperty("Mounts")
     private List<Mount> mounts;
@@ -214,6 +216,15 @@ public class InspectContainerResponse {
 
     public List<String> getExecIds() {
         return execIds;
+    }
+
+    /**
+     * Get the underlying swarm node info. This property does only contains a value in swarm-classic
+     * @return The underlying swarm-classic node info
+     * @CheckForNull
+     */
+    public Node getNode() {
+        return node;
     }
 
     @Override
@@ -554,6 +565,64 @@ public class InspectContainerResponse {
         @Override
         public int hashCode() {
             return HashCodeBuilder.reflectionHashCode(this);
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class Node {
+
+        @JsonProperty("ID")
+        private String id;
+
+        @JsonProperty("IP")
+        private String ip;
+
+        @JsonProperty("Addr")
+        private String addr;
+
+        @JsonProperty("Name")
+        private String name;
+
+        @JsonProperty("Cpus")
+        private Integer cpus;
+
+        @JsonProperty("Memory")
+        private Long memory;
+
+        @JsonProperty("Labels")
+        private Map<String, String> labels;
+
+        public String getId() {
+            return id;
+        }
+
+        public String getIp() {
+            return ip;
+        }
+
+        public String getAddr() {
+            return addr;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Integer getCpus() {
+            return cpus;
+        }
+
+        public Long getMemory() {
+            return memory;
+        }
+
+        public Map<String, String> getLabels() {
+            return labels;
+        }
+
+        @Override
+        public String toString() {
+            return ToStringBuilder.reflectionToString(this);
         }
     }
 }


### PR DESCRIPTION
Implement the Node property returned by the docker swarm api
https://docs.docker.com/swarm/api/swarm-api/

I also like to implement the docker list command, wich respond with all available nodes in swarm, but the api is currently not implementation freindly as described in issue:
https://github.com/docker/swarm/issues/1214

So i delay the implementaion until the api is improved.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/383)

<!-- Reviewable:end -->
