### PR TITLE
Allow legacy registry message to indicate pull success

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/PullResponseItem.java
+++ b/src/main/java/com/github/dockerjava/api/model/PullResponseItem.java
@@ -10,6 +10,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class PullResponseItem extends ResponseItem {
 
     private static final long serialVersionUID = -2575482839766823293L;
+    private static final String LEGACY_REGISTRY = "this image was pulled from a legacy registry";
+    private static final String DOWNLOADED_NEWER_IMAGE = "Downloaded newer image";
+    private static final String IMAGE_UP_TO_DATE = "Image is up to date";
+    private static final String DOWNLOAD_COMPLETE = "Download complete";
 
     /**
      * Returns whether the status indicates a successful pull operation
@@ -22,8 +26,9 @@ public class PullResponseItem extends ResponseItem {
             return false;
         }
 
-        return (getStatus().contains("Download complete") || getStatus().contains("Image is up to date") || getStatus()
-                .contains("Downloaded newer image"));
+        return (getStatus().contains(DOWNLOAD_COMPLETE) || getStatus().contains(IMAGE_UP_TO_DATE)
+                || getStatus().contains(DOWNLOADED_NEWER_IMAGE)
+                || getStatus().contains(LEGACY_REGISTRY));
     }
 
 }

--- a/src/test/java/com/github/dockerjava/api/model/PullResponseItemTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/PullResponseItemTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015, Zach Marshall.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.dockerjava.api.model;
+
+import static com.github.dockerjava.test.serdes.JSONTestHelper.testRoundTrip;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.testng.annotations.Test;
+
+/**
+ * Tests logic of PullResponseItem's error/success handling by simulating a JSON response.
+ *
+ * @author Zach Marshall
+ */
+public class PullResponseItemTest {
+    @Test
+    public void pullNewerImage() throws IOException {
+        PullResponseItem response =
+                testRoundTrip(PullResponseJSONSamples.pullImageResponse_newerImage, PullResponseItem.class);
+        assertTrue(response.isPullSuccessIndicated());
+        assertFalse(response.isErrorIndicated());
+    }
+
+    @Test
+    public void pullUpToDate() throws IOException {
+        PullResponseItem response =
+                testRoundTrip(PullResponseJSONSamples.pullImageResponse_upToDate, PullResponseItem.class);
+        assertTrue(response.isPullSuccessIndicated());
+        assertFalse(response.isErrorIndicated());
+    }
+
+    @Test
+    public void pullLegacyRegistry() throws IOException {
+        PullResponseItem response =
+                testRoundTrip(PullResponseJSONSamples.pullImageResponse_legacy, PullResponseItem.class);
+        assertTrue(response.isPullSuccessIndicated());
+        assertFalse(response.isErrorIndicated());
+    }
+
+    @Test
+    public void pullAndEncounterError() throws IOException {
+        PullResponseItem response =
+                testRoundTrip(PullResponseJSONSamples.pullImageResponse_error, PullResponseItem.class);
+        assertFalse(response.isPullSuccessIndicated());
+        assertTrue(response.isErrorIndicated());
+    }
+}

--- a/src/test/java/com/github/dockerjava/api/model/PullResponseJSONSamples.java
+++ b/src/test/java/com/github/dockerjava/api/model/PullResponseJSONSamples.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015 Zach Marshall.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.dockerjava.api.model;
+
+import com.github.dockerjava.test.serdes.JSONResourceRef;
+
+/**
+ * Enumeration for the available pull response statuses.
+ *
+ * @author Zach Marshall
+ */
+public enum PullResponseJSONSamples implements JSONResourceRef
+{
+    pullImageResponse_legacy, pullImageResponse_error, pullImageResponse_newerImage, pullImageResponse_upToDate;
+
+    @Override
+    public String getFileName()
+    {
+        return this + ".json";
+    }
+
+    @Override
+    public Class<?> getResourceClass()
+    {
+        return PullResponseJSONSamples.class;
+    }
+}

--- a/src/test/java/com/github/dockerjava/test/serdes/JSONTestHelper.java
+++ b/src/test/java/com/github/dockerjava/test/serdes/JSONTestHelper.java
@@ -25,13 +25,14 @@ import org.apache.commons.io.IOUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.dockerjava.api.command.CommandJSONSamples;
 
 /**
- * Provides helper methods for serialization-deserialization tests
- * 
+ * Provides helper methods for serialization-deserialization tests.
+ *
+ * <p><b>TODO</b>: Create helper that loads json files from simple folder
+ * structure using a type, version number, and name.</p>
+ *
  * @author Oleg Nenashev
- * @since TODO
  */
 public class JSONTestHelper {
 
@@ -45,11 +46,12 @@ public class JSONTestHelper {
      *             JSON Conversion error
      */
     public static String readString(JSONResourceRef resource) throws IOException {
-        InputStream istream = CommandJSONSamples.class.getResourceAsStream(resource.getFileName());
-        if (istream == null) {
-            throw new IOException("Cannot retrieve resource " + resource.getFileName());
+        try (InputStream istream = resource.getResourceClass().getResourceAsStream(resource.getFileName())) {
+            if (istream == null) {
+                throw new IOException("Cannot retrieve resource " + resource.getFileName());
+            }
+            return IOUtils.toString(istream, "UTF-8");
         }
-        return IOUtils.toString(istream, "UTF-8");
     }
 
     /**

--- a/src/test/resources/com/github/dockerjava/api/model/pullImageResponse_error.json
+++ b/src/test/resources/com/github/dockerjava/api/model/pullImageResponse_error.json
@@ -1,0 +1,1 @@
+{"errorDetail":{"message":"Error: image cccxxx/xxxccc:latest not found"},"error":"Error: image cccxxx/xxxccc:latest not found"}

--- a/src/test/resources/com/github/dockerjava/api/model/pullImageResponse_legacy.json
+++ b/src/test/resources/com/github/dockerjava/api/model/pullImageResponse_legacy.json
@@ -1,0 +1,1 @@
+{"status":"docker.com/xxxxcv/ccccxx: this image was pulled from a legacy registry.  Important: This registry version will not be supported in future versions of docker."}

--- a/src/test/resources/com/github/dockerjava/api/model/pullImageResponse_newerImage.json
+++ b/src/test/resources/com/github/dockerjava/api/model/pullImageResponse_newerImage.json
@@ -1,0 +1,1 @@
+{"status":"Downloaded newer image for docker.com/xxxxcv/ccccxx"}

--- a/src/test/resources/com/github/dockerjava/api/model/pullImageResponse_upToDate.json
+++ b/src/test/resources/com/github/dockerjava/api/model/pullImageResponse_upToDate.json
@@ -1,0 +1,1 @@
+{"status":"Image is up to date for docker.com/xxxxcv/ccccxx"}


### PR DESCRIPTION
If build node is pulling from older registry and build node reports legacy registry message, docker java will treat this as a failure. This update allows this message to be treated as a success condition.

Fix for master/version 3.0.0.

Fixes #380