### PR TITLE
Use BufferedInputStream to read from a tar file

### DIFF
--- a/src/main/java/com/github/dockerjava/core/dockerfile/Dockerfile.java
+++ b/src/main/java/com/github/dockerjava/core/dockerfile/Dockerfile.java
@@ -16,6 +16,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -133,7 +134,7 @@ public class Dockerfile {
                 dockerFolderTar = CompressArchiveUtil.archiveTARFiles(directory, filesToAdd,
                         archiveNameWithOutExtension);
 
-                final InputStream tarInputStream = FileUtils.openInputStream(dockerFolderTar);
+                final InputStream tarInputStream = new BufferedInputStream(FileUtils.openInputStream(dockerFolderTar));
                 final File tarFile = dockerFolderTar;
 
                 return new InputStream() {


### PR DESCRIPTION
During my testing I've found that building an image with a fairly big context took a lot of time (several minutes) with docker-java. On the other hand, `docker` CLI was able to upload the very same context with the very same Dockerfile in 10-20 seconds.

After some profiling I've found out that we spent most time trying to read from a context's tar file, and it turned out we didn't use `BufferedInputStream` around `FileInputStream`.

Without the fix it took ~5 min to upload a ~153Mb context:
```
time="2015-12-14T20:27:45.165799084Z" level=info msg="POST /build?dockerfile=/Users/mikhail/.ahub/test_local/Dockerfile.sor.local&t=athena/sor:local"
time="2015-12-14T20:32:51.945725887Z" level=debug msg="[BUILDER] Use cached version: &{[/bin/sh -c #(nop) ENV JAVA_HOME=/usr/lib/jvm/jre/]}"
```
And with the fix it takes ~20 sec:
```
time="2015-12-14T20:34:52.298037218Z" level=info msg="POST /build?dockerfile=/Users/mikhail/.ahub/test_local/Dockerfile.sor.local&t=athena/sor:local"
time="2015-12-14T20:35:13.645568956Z" level=debug msg="[BUILDER] Use cached version: &{[/bin/sh -c #(nop) ENV JAVA_HOME=/usr/lib/jvm/jre/]}"
```