### PR TITLE
Upgraded jackson-jaxrs-json-provider dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 		<jdk.target>1.7</jdk.target>
 
 		<jersey.version>2.11</jersey.version>
-		<jackson-jaxrs.version>2.1.2</jackson-jaxrs.version>
+		<jackson-jaxrs.version>2.6.4</jackson-jaxrs.version>
 		<httpclient.version>4.3.1</httpclient.version>
 		<commons-compress.version>1.5</commons-compress.version>
 		<commons-codec.version>1.8</commons-codec.version>


### PR DESCRIPTION
There is a version problem when using spring-boot-starter-web 1.3.0, as it needs a later version than the one that the transitive dependency brings.