### PR TITLE
Make API Version transitions easier

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/BuildResponseItem.java
+++ b/src/main/java/com/github/dockerjava/api/model/BuildResponseItem.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 /**
  * Represents a build response stream item
  */
-@JsonIgnoreProperties(ignoreUnknown = false)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class BuildResponseItem extends ResponseItem {
 
     private static final long serialVersionUID = -1252904184236343612L;

--- a/src/main/java/com/github/dockerjava/api/model/PullResponseItem.java
+++ b/src/main/java/com/github/dockerjava/api/model/PullResponseItem.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 /**
  * Represents a pull response stream item
  */
-@JsonIgnoreProperties(ignoreUnknown = false)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PullResponseItem extends ResponseItem {
 
     private static final long serialVersionUID = -2575482839766823293L;

--- a/src/main/java/com/github/dockerjava/api/model/PushResponseItem.java
+++ b/src/main/java/com/github/dockerjava/api/model/PushResponseItem.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 /**
  * Represents a push response stream item
  */
-@JsonIgnoreProperties(ignoreUnknown = false)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PushResponseItem extends ResponseItem {
 
     private static final long serialVersionUID = 8256977108011295857L;

--- a/src/main/java/com/github/dockerjava/api/model/ResponseItem.java
+++ b/src/main/java/com/github/dockerjava/api/model/ResponseItem.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * Represents a pull response stream item
  */
-@JsonIgnoreProperties(ignoreUnknown = false)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ResponseItem implements Serializable {
 
     private static final long serialVersionUID = -5187169652557467828L;
@@ -105,7 +105,7 @@ public class ResponseItem implements Serializable {
         return getError() != null || getErrorDetail() != null;
     }
 
-    @JsonIgnoreProperties(ignoreUnknown = false)
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ProgressDetail implements Serializable {
         private static final long serialVersionUID = -1954994695645715264L;
 
@@ -139,7 +139,7 @@ public class ResponseItem implements Serializable {
         }
     }
 
-    @JsonIgnoreProperties(ignoreUnknown = false)
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ErrorDetail implements Serializable {
         private static final long serialVersionUID = -9136704865403084083L;
 

--- a/src/main/java/com/github/dockerjava/api/model/WaitResponse.java
+++ b/src/main/java/com/github/dockerjava/api/model/WaitResponse.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * Represents a wait container command response
  */
-@JsonIgnoreProperties(ignoreUnknown = false)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class WaitResponse {
 
     @JsonProperty("StatusCode")


### PR DESCRIPTION
IMHO there is no reason to be that strict about the JSON models, because it
leads to things like e.g. Issue #437 .

Be more lenient with changes in the data.