### PR TITLE
Return null, instead of NullPointerException, should no exposedPorts be found

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/ContainerConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/ContainerConfig.java
@@ -84,7 +84,7 @@ public class ContainerConfig {
 
     @JsonIgnore
     public ExposedPort[] getExposedPorts() {
-        return exposedPorts.getExposedPorts();
+        return exposedPorts != null ? exposedPorts.getExposedPorts() : null;
     }
 
     public Boolean isNetworkDisabled() {


### PR DESCRIPTION
Instead of getting a NullPointerException when trying to call "ContainerConfig.getExposedPorts()" we'd like to instead return null. I'm preferring null over say an empty ExposedPort[] array as that is what dockers remote API returns. Thoughts?

```
"Config": {
        "Hostname": "92e5c83152bb",
        "Domainname": "",
        "User": "",
        "AttachStdin": false,
        "AttachStdout": false,
        "AttachStderr": false,
        "ExposedPorts": null,
        "PublishService": "",
        "Tty": false,
        "OpenStdin": false,
        "StdinOnce": false,
        "Env": null,
        "Cmd": [
            "/hello"
        ],
        "Image": "hello-world:latest",
        "Volumes": null,
        "VolumeDriver": "",
        "WorkingDir": "",
        "Entrypoint": null,
        "NetworkDisabled": false,
        "MacAddress": "",
        "OnBuild": null,
        "Labels": null
    }
```