### PR TITLE
Docker Swarm Inspect Container Info Support

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
+++ b/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.dockerjava.api.model.ContainerConfig;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.NetworkSettings;
+import com.github.dockerjava.api.model.Node;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.api.model.VolumeBind;
 import com.github.dockerjava.api.model.VolumeBinds;
@@ -97,6 +98,9 @@ public class InspectContainerResponse {
 
     @JsonProperty("Mounts")
     private List<Mount> mounts;
+
+    @JsonProperty("Node")
+    private Node node;
 
     public String getId() {
         return id;
@@ -200,6 +204,10 @@ public class InspectContainerResponse {
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);
+    }
+
+    public Node getNode() {
+        return node;
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/github/dockerjava/api/model/Labels.java
+++ b/src/main/java/com/github/dockerjava/api/model/Labels.java
@@ -1,0 +1,67 @@
+package com.github.dockerjava.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Labels {
+
+    @JsonProperty("executiondriver")
+    private String executiondriver;
+
+    @JsonProperty("kernelversion")
+    private String kernelversion;
+
+    @JsonProperty("operatingsystem")
+    private String operatingsystem;
+
+    @JsonProperty("provider")
+    private String provider;
+
+    @JsonProperty("storagedriver")
+    private String storagedriver;
+
+    public String getExecutiondriver() {
+        return executiondriver;
+    }
+
+    public void setExecutiondriver(String executiondriver) {
+        this.executiondriver = executiondriver;
+    }
+
+    public String getKernelversion() {
+        return kernelversion;
+    }
+
+    public void setKernelversion(String kernelversion) {
+        this.kernelversion = kernelversion;
+    }
+
+    public String getOperatingsystem() {
+        return operatingsystem;
+    }
+
+    public void setOperatingsystem(String operatingsystem) {
+        this.operatingsystem = operatingsystem;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    public String getStoragedriver() {
+        return storagedriver;
+    }
+
+    public void setStoragedriver(String storagedriver) {
+        this.storagedriver = storagedriver;
+    }
+
+}

--- a/src/main/java/com/github/dockerjava/api/model/Node.java
+++ b/src/main/java/com/github/dockerjava/api/model/Node.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -8,19 +9,29 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * A node as returned by the /events API, for instance, when Swarm is used.
  */
 @JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Node {
 
     @JsonProperty("Name")
     private String name;
 
-    @JsonProperty("Id")
+    @JsonProperty("ID")
     private String id;
 
     @JsonProperty("Addr")
     private String addr;
 
-    @JsonProperty("Ip")
+    @JsonProperty("IP")
     private String ip;
+
+    @JsonProperty("Cpus")
+    private String cpus;
+
+    @JsonProperty("Memory")
+    private String memory;
+
+    @JsonProperty("Labels")
+    private Labels labels;
 
     public String getName() {
         return name;
@@ -37,4 +48,9 @@ public class Node {
     public String getIp() {
         return ip;
     }
+
+    public Labels getLabels() {
+        return labels;
+    }
+
 }


### PR DESCRIPTION
Fixes #458 .

When using Docker Swarm, containers/{id}/json does not contains Node information. This reqeust adds Node related information to the InspectContainerResponse.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/459)
<!-- Reviewable:end -->
