### PR TITLE
Fix exec start stdin encoding

### DIFF
--- a/src/test/java/com/github/dockerjava/netty/exec/ExecStartCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/ExecStartCmdExecTest.java
@@ -109,16 +109,16 @@ public class ExecStartCmdExecTest extends AbstractNettyDockerClientTest {
 
         dockerClient.startContainerCmd(container.getId()).exec();
 
-        InputStream stdin = new ByteArrayInputStream("echo STDIN\n".getBytes());
+        InputStream stdin = new ByteArrayInputStream("STDIN\n".getBytes("UTF-8"));
 
         ByteArrayOutputStream stdout = new ByteArrayOutputStream();
 
         ExecCreateCmdResponse execCreateCmdResponse = dockerClient.execCreateCmd(container.getId())
-                .withAttachStdout(true).withAttachStdin(true).withCmd("/bin/sh").exec();
+                .withAttachStdout(true).withAttachStdin(true).withCmd("cat").exec();
         dockerClient.execStartCmd(execCreateCmdResponse.getId()).withDetach(false).withTty(true).withStdIn(stdin)
                 .exec(new ExecStartResultCallback(stdout, System.err)).awaitCompletion(5, TimeUnit.SECONDS);
 
-        assertEquals(stdout.toString(), "STDIN\n");
+        assertEquals(stdout.toString("UTF-8"), "STDIN\n");
     }
 
     @Test(groups = "ignoreInCircleCi")


### PR DESCRIPTION
stdin is now encoded like this: `abc` -> `\0\0\0a\0\0\0b\0\0\0c`. This works with `/bin/sh`, but doesn't work with other commands.

This pull request removes stream re-encoding and sends the InputStream directly to channel.