### PR TITLE
Exec start command: detect end of STDIN stream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<!-- test dependencies -->
 		<logback.version>1.1.0</logback.version>
 		<testng.version>6.1.1</testng.version>
-		<netty.version>4.1.0.CR2</netty.version>
+		<netty.version>4.1.0.CR3</netty.version>
 		<hamcrest.library.version>1.3</hamcrest.library.version>
 		<hamcrest.jpa-matchers>1.6</hamcrest.jpa-matchers>
 		<lambdaj.version>2.3.3</lambdaj.version>

--- a/src/main/java/com/github/dockerjava/core/async/ResultCallbackTemplate.java
+++ b/src/main/java/com/github/dockerjava/core/async/ResultCallbackTemplate.java
@@ -95,11 +95,11 @@ public abstract class ResultCallbackTemplate<RC_T extends ResultCallback<A_RES_T
 
     /**
      * Blocks until {@link ResultCallback#onComplete()} was called or the given timeout occurs
+     * @return {@code true} if completed and {@code false} if the waiting time elapsed
+     *         before {@link ResultCallback#onComplete()} was called.
      */
-    @SuppressWarnings("unchecked")
-    public RC_T awaitCompletion(long timeout, TimeUnit timeUnit) throws InterruptedException {
-        completed.await(timeout, timeUnit);
-        return (RC_T) this;
+    public boolean awaitCompletion(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        return completed.await(timeout, timeUnit);
     }
 
     /**
@@ -115,11 +115,11 @@ public abstract class ResultCallbackTemplate<RC_T extends ResultCallback<A_RES_T
     /**
      * Blocks until {@link ResultCallback#onStart()} was called or the given timeout occurs. {@link ResultCallback#onStart()} is called when
      * the request was processed on the server side and the response is incoming.
+     * @return {@code true} if started and {@code false} if the waiting time elapsed
+     *         before {@link ResultCallback#onStart()} was called.
      */
-    @SuppressWarnings("unchecked")
-    public RC_T awaitStarted(long timeout, TimeUnit timeUnit) throws InterruptedException {
-        started.await(timeout, timeUnit);
-        return (RC_T) this;
+    public boolean awaitStarted(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        return started.await(timeout, timeUnit);
     }
 
     @CheckForNull

--- a/src/main/java/com/github/dockerjava/netty/ChannelProvider.java
+++ b/src/main/java/com/github/dockerjava/netty/ChannelProvider.java
@@ -1,7 +1,7 @@
 package com.github.dockerjava.netty;
 
-import io.netty.channel.Channel;
+import io.netty.channel.socket.DuplexChannel;
 
 public interface ChannelProvider {
-    Channel getChannel();
+    DuplexChannel getChannel();
 }

--- a/src/main/java/com/github/dockerjava/netty/InvocationBuilder.java
+++ b/src/main/java/com/github/dockerjava/netty/InvocationBuilder.java
@@ -151,7 +151,7 @@ public class InvocationBuilder {
         return;
     }
 
-    private Channel getChannel() {
+    private DuplexChannel getChannel() {
         return channelProvider.getChannel();
     }
 
@@ -216,7 +216,7 @@ public class InvocationBuilder {
 
         FramedResponseStreamHandler streamHandler = new FramedResponseStreamHandler(resultCallback);
 
-        final Channel channel = getChannel();
+        final DuplexChannel channel = getChannel();
 
         // result callback's close() method must be called when the servers closes the connection
         channel.closeFuture().addListener(new GenericFutureListener<Future<? super Void>>() {
@@ -264,9 +264,7 @@ public class InvocationBuilder {
                     }
 
                     // we close the writing side of the socket, but keep the read side open to transfer stdout/stderr
-                    if (channel instanceof DuplexChannel) {
-                        ((DuplexChannel) channel).shutdownOutput();
-                    }
+                    channel.shutdownOutput();
 
                 }
             }).start();

--- a/src/main/java/com/github/dockerjava/netty/InvocationBuilder.java
+++ b/src/main/java/com/github/dockerjava/netty/InvocationBuilder.java
@@ -4,6 +4,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.socket.DuplexChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -260,6 +261,11 @@ public class InvocationBuilder {
                     int read;
                     while ((read = read(stdin, buffer)) != -1) {
                         channel.writeAndFlush(Unpooled.copiedBuffer(buffer, 0, read));
+                    }
+
+                    // we close the writing side of the socket, but keep the read side open to transfer stdout/stderr
+                    if (channel instanceof DuplexChannel) {
+                        ((DuplexChannel) channel).shutdownOutput();
                     }
 
                 }

--- a/src/test/java/com/github/dockerjava/core/command/AttachContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/AttachContainerCmdImplTest.java
@@ -68,7 +68,8 @@ public class AttachContainerCmdImplTest extends AbstractDockerClientTest {
         };
 
         dockerClient.attachContainerCmd(container.getId()).withStdErr(true).withStdOut(true).withFollowStream(true)
-                .withLogs(true).exec(callback).awaitCompletion(30, TimeUnit.SECONDS).close();
+                .withLogs(true).exec(callback).awaitCompletion(30, TimeUnit.SECONDS);
+        callback.close();
 
         assertThat(callback.toString(), containsString(snippet));
     }
@@ -97,7 +98,8 @@ public class AttachContainerCmdImplTest extends AbstractDockerClientTest {
         };
 
         dockerClient.attachContainerCmd(container.getId()).withStdErr(true).withStdOut(true).withFollowStream(true)
-                .exec(callback).awaitCompletion(15, TimeUnit.SECONDS).close();
+                .exec(callback).awaitCompletion(15, TimeUnit.SECONDS);
+        callback.close();
 
         System.out.println("log: " + callback.toString());
 
@@ -130,7 +132,8 @@ public class AttachContainerCmdImplTest extends AbstractDockerClientTest {
         InputStream stdin = new ByteArrayInputStream("".getBytes());
 
         dockerClient.attachContainerCmd(container.getId()).withStdErr(true).withStdOut(true).withFollowStream(true)
-                .withLogs(true).withStdIn(stdin).exec(callback).awaitCompletion(30, TimeUnit.SECONDS).close();
+                .withLogs(true).withStdIn(stdin).exec(callback).awaitCompletion(30, TimeUnit.SECONDS);
+        callback.close();
     }
 
     public static class AttachContainerTestCallback extends AttachContainerResultCallback {

--- a/src/test/java/com/github/dockerjava/netty/exec/AttachContainerCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/AttachContainerCmdExecTest.java
@@ -70,7 +70,8 @@ public class AttachContainerCmdExecTest extends AbstractNettyDockerClientTest {
         };
 
         dockerClient.attachContainerCmd(container.getId()).withStdErr(true).withStdOut(true).withFollowStream(true)
-                .withLogs(true).exec(callback).awaitCompletion(10, TimeUnit.SECONDS).close();
+                .withLogs(true).exec(callback).awaitCompletion(10, TimeUnit.SECONDS);
+        callback.close();
 
         assertThat(callback.toString(), containsString(snippet));
     }
@@ -104,7 +105,8 @@ public class AttachContainerCmdExecTest extends AbstractNettyDockerClientTest {
         InputStream stdin = new ByteArrayInputStream((snippet + "\n").getBytes());
 
         dockerClient.attachContainerCmd(container.getId()).withStdErr(true).withStdOut(true).withFollowStream(true)
-                .withStdIn(stdin).exec(callback).awaitCompletion(2, TimeUnit.SECONDS).close();
+                .withStdIn(stdin).exec(callback).awaitCompletion(2, TimeUnit.SECONDS);
+        callback.close();
 
         assertThat(callback.toString(), containsString(snippet));
     }
@@ -133,7 +135,8 @@ public class AttachContainerCmdExecTest extends AbstractNettyDockerClientTest {
         };
 
         dockerClient.attachContainerCmd(container.getId()).withStdErr(true).withStdOut(true).withFollowStream(true)
-                .exec(callback).awaitCompletion(10, TimeUnit.SECONDS).close();
+                .exec(callback).awaitCompletion(10, TimeUnit.SECONDS);
+        callback.close();
 
         // HexDump.dump(collectFramesCallback.toString().getBytes(), 0, System.out, 0);
 

--- a/src/test/java/com/github/dockerjava/netty/exec/ExecStartCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/ExecStartCmdExecTest.java
@@ -115,9 +115,10 @@ public class ExecStartCmdExecTest extends AbstractNettyDockerClientTest {
 
         ExecCreateCmdResponse execCreateCmdResponse = dockerClient.execCreateCmd(container.getId())
                 .withAttachStdout(true).withAttachStdin(true).withCmd("cat").exec();
-        dockerClient.execStartCmd(execCreateCmdResponse.getId()).withDetach(false).withTty(true).withStdIn(stdin)
+        boolean completed = dockerClient.execStartCmd(execCreateCmdResponse.getId()).withDetach(false).withTty(true).withStdIn(stdin)
                 .exec(new ExecStartResultCallback(stdout, System.err)).awaitCompletion(5, TimeUnit.SECONDS);
 
+        assertTrue(completed, "The process was not finished.");
         assertEquals(stdout.toString("UTF-8"), "STDIN\n");
     }
 
@@ -138,9 +139,10 @@ public class ExecStartCmdExecTest extends AbstractNettyDockerClientTest {
 
         ExecCreateCmdResponse execCreateCmdResponse = dockerClient.execCreateCmd(container.getId())
                 .withAttachStdout(true).withAttachStdin(false).withCmd("/bin/sh").exec();
-        dockerClient.execStartCmd(execCreateCmdResponse.getId()).withDetach(false).withStdIn(stdin)
+        boolean completed = dockerClient.execStartCmd(execCreateCmdResponse.getId()).withDetach(false).withStdIn(stdin)
                 .exec(new ExecStartResultCallback(stdout, System.err)).awaitCompletion(5, TimeUnit.SECONDS);
 
+        assertTrue(completed, "The process was not finished.");
         assertEquals(stdout.toString(), "");
     }
 }


### PR DESCRIPTION
Fix for #471.

The fix itself is to close the write side of the socket to indicate the end of stream.
`shutdownOutput` is available for unix domain sockets since netty `4.1.0.CR3`.