### PR TITLE
Implement missing network api options for v1.22

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/ConnectToNetworkCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/ConnectToNetworkCmd.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.api.command;
 
+import com.github.dockerjava.api.model.ContainerNetwork;
 import com.github.dockerjava.core.RemoteApiVersion;
 
 import javax.annotation.CheckForNull;
@@ -18,9 +19,14 @@ public interface ConnectToNetworkCmd extends SyncDockerCmd<Void> {
     @CheckForNull
     String getContainerId();
 
+    @CheckForNull
+    ContainerNetwork getContainerConfig();
+
     ConnectToNetworkCmd withNetworkId(@Nonnull String networkId);
 
     ConnectToNetworkCmd withContainerId(@Nonnull String containerId);
+
+    ConnectToNetworkCmd withContainerNetwork(@Nonnull ContainerNetwork endpointConfig);
 
     interface Exec extends DockerCmdSyncExec<ConnectToNetworkCmd, Void> {
     }

--- a/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
@@ -1,10 +1,5 @@
 package com.github.dockerjava.api.command;
 
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.CheckForNull;
-
 import com.github.dockerjava.api.exception.ConflictException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Bind;
@@ -21,7 +16,14 @@ import com.github.dockerjava.api.model.Ulimit;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.api.model.VolumesFrom;
 
+import javax.annotation.CheckForNull;
+import java.util.List;
+import java.util.Map;
+
 public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerResponse> {
+
+    @CheckForNull
+    List<String> getAliases();
 
     @CheckForNull
     Bind[] getBinds();
@@ -91,6 +93,12 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
 
     @CheckForNull
     String getImage();
+
+    @CheckForNull
+    String getIpv4Address();
+
+    @CheckForNull
+    String getIpv6Address();
 
     @CheckForNull
     Map<String, String> getLabels();
@@ -184,6 +192,18 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
 
     @CheckForNull
     Boolean isTty();
+
+    /**
+     * Add network-scoped alias for the container
+     * @param aliases on ore more aliases
+     */
+    CreateContainerCmd withAliases(String... aliases);
+
+    /**
+     * Add network-scoped alias for the container
+     * @param aliases on ore more aliases
+     */
+    CreateContainerCmd withAliases(List<String> aliases);
 
     CreateContainerCmd withAttachStderr(Boolean attachStderr);
 
@@ -303,6 +323,10 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
     CreateContainerCmd withHostName(String hostName);
 
     CreateContainerCmd withImage(String image);
+
+    CreateContainerCmd withIpv4Address(String ipv4Address);
+
+    CreateContainerCmd withIpv6Address(String ipv6Address);
 
     CreateContainerCmd withLabels(Map<String, String> labels);
 

--- a/src/main/java/com/github/dockerjava/api/command/CreateNetworkCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/CreateNetworkCmd.java
@@ -1,13 +1,12 @@
 package com.github.dockerjava.api.command;
 
-import java.util.Map;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-
 import com.github.dockerjava.api.model.Network;
 import com.github.dockerjava.api.model.Network.Ipam;
 import com.github.dockerjava.core.RemoteApiVersion;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.util.Map;
 
 /**
  * Create a network.
@@ -25,17 +24,35 @@ public interface CreateNetworkCmd extends SyncDockerCmd<CreateNetworkResponse> {
     @CheckForNull
     Network.Ipam getIpam();
 
+    @CheckForNull
+    Map<String, String> getOptions();
+
+    @CheckForNull
+    Boolean getCheckDuplicate();
+
+    @CheckForNull
+    Boolean getInternal();
+
+    @CheckForNull
+    Boolean getEnableIPv6();
+
     /** The new network's name. Required. */
     CreateNetworkCmd withName(@Nonnull String name);
-
-    /** Optional custom IP scheme for the network. */
-    CreateNetworkCmd withIpamConfig(Ipam.Config config);
 
     /** Name of the network driver to use. Defaults to <code>bridge</code>. */
     CreateNetworkCmd withDriver(String driver);
 
+    /** Ipam config, such es subnet, gateway and ip range of the network */
+    CreateNetworkCmd withIpam(Ipam ipam);
+
     /** Driver specific options */
     CreateNetworkCmd withOptions(Map<String, String> options);
+
+    CreateNetworkCmd withCheckDuplicate(boolean checkForDuplicate);
+
+    CreateNetworkCmd withInternal(boolean internal);
+
+    CreateNetworkCmd withEnableIpv6(boolean enableIpv6);
 
     interface Exec extends DockerCmdSyncExec<CreateNetworkCmd, CreateNetworkResponse> {
     }

--- a/src/main/java/com/github/dockerjava/api/command/DisconnectFromNetworkCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/DisconnectFromNetworkCmd.java
@@ -18,9 +18,14 @@ public interface DisconnectFromNetworkCmd extends SyncDockerCmd<Void> {
     @CheckForNull
     String getContainerId();
 
+    @CheckForNull
+    Boolean getForce();
+
     DisconnectFromNetworkCmd withNetworkId(@Nonnull String networkId);
 
     DisconnectFromNetworkCmd withContainerId(@Nonnull String containerId);
+
+    DisconnectFromNetworkCmd withForce(@Nonnull Boolean force);
 
     interface Exec extends DockerCmdSyncExec<DisconnectFromNetworkCmd, Void> {
     }

--- a/src/main/java/com/github/dockerjava/api/model/ContainerNetwork.java
+++ b/src/main/java/com/github/dockerjava/api/model/ContainerNetwork.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.dockerjava.core.RemoteApiVersion;
@@ -8,9 +9,14 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 import javax.annotation.CheckForNull;
+import java.util.Arrays;
 import java.util.List;
 
 /**
+ * Types taken form
+ * {@see https://github.com/docker/engine-api/blob/release/1.10/types/network/network.go}
+ * Docker named it EndpointSettings
+ *
  * @see ContainerNetworkSettings
  * @author Kanstantsin Shautsou
  */
@@ -20,16 +26,16 @@ public class ContainerNetwork {
      * FIXME verify
      */
     @JsonProperty("IPAMConfig")
-    private Network.Ipam.Config ipamConfig;
+    private Ipam ipamConfig;
 
     /**
      * FIXME verify
      */
     @JsonProperty("Links")
-    private List<String> links;
+    private Links links;
 
     /**
-     * FIXME no docs, unknown field.
+     * Add network-scoped alias for the container
      * Type picked from `docker/vendor/src/github.com/docker/engine-api/types/network/network.go`
      *
      * @since {@link RemoteApiVersion#VERSION_1_22}
@@ -77,6 +83,14 @@ public class ContainerNetwork {
      */
     public ContainerNetwork withAliases(List<String> aliases) {
         this.aliases = aliases;
+        return this;
+    }
+
+    /**
+     * @see #aliases
+     */
+    public ContainerNetwork withAliases(String... aliases) {
+        this.aliases = Arrays.asList(aliases);
         return this;
     }
 
@@ -155,7 +169,7 @@ public class ContainerNetwork {
     /**
      * @see #ipAddress
      */
-    public ContainerNetwork withIpAddress(String ipAddress) {
+    public ContainerNetwork withIpv4Address(String ipAddress) {
         this.ipAddress = ipAddress;
         return this;
     }
@@ -164,14 +178,14 @@ public class ContainerNetwork {
      * @see #ipamConfig
      */
     @CheckForNull
-    public Network.Ipam.Config getIpamConfig() {
+    public Ipam getIpamConfig() {
         return ipamConfig;
     }
 
     /**
      * @see #ipamConfig
      */
-    public ContainerNetwork withIpamConfig(Network.Ipam.Config ipamConfig) {
+    public ContainerNetwork withIpamConfig(Ipam ipamConfig) {
         this.ipamConfig = ipamConfig;
         return this;
     }
@@ -212,15 +226,24 @@ public class ContainerNetwork {
      * @see #links
      */
     @CheckForNull
-    public List<String> getLinks() {
-        return links;
+    @JsonIgnore
+    public Link[] getLinks() {
+        return links == null ? new Link[0] : links.getLinks();
     }
 
     /**
      * @see #links
      */
-    public ContainerNetwork withLinks(List<String> links) {
-        this.links = links;
+    public ContainerNetwork withLinks(List<Link> links) {
+        this.links = new Links(links);
+        return this;
+    }
+
+    /**
+     * @see #links
+     */
+    public ContainerNetwork withLinks(Link... links) {
+        this.links = new Links(links);
         return this;
     }
 
@@ -269,5 +292,35 @@ public class ContainerNetwork {
     @Override
     public int hashCode() {
         return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    /**
+     * Docker named it EndpointIPAMConfig
+     */
+    public static class Ipam {
+
+        @JsonProperty("IPv4Address")
+        private String ipv4Address;
+
+        @JsonProperty("IPv6Address")
+        private String ipv6Address;
+
+        public String getIpv4Address() {
+            return ipv4Address;
+        }
+
+        public String getIpv6Address() {
+            return ipv6Address;
+        }
+
+        public Ipam withIpv4Address(String ipv4Address) {
+            this.ipv4Address = ipv4Address;
+            return this;
+        }
+
+        public Ipam withIpv6Address(String ipv6Address) {
+            this.ipv6Address = ipv6Address;
+            return this;
+        }
     }
 }

--- a/src/main/java/com/github/dockerjava/api/model/HostConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/HostConfig.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 import javax.annotation.CheckForNull;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -20,6 +21,8 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_NULL)
 public class HostConfig {
+
+    private static final List<String> PREDEFINED_NETWORKS = Arrays.asList("bridge", "host", "none");
 
     @JsonProperty("Binds")
     private Binds binds;
@@ -408,6 +411,15 @@ public class HostConfig {
     @CheckForNull
     public String getVolumeDriver() {
         return volumeDriver;
+    }
+
+    /**
+     * Parse the network mode as specified at
+     * {@see https://github.com/docker/engine-api/blob/master/types/container/hostconfig_unix.go}
+     */
+    @JsonIgnore
+    public boolean isUserDefinedNetwork() {
+        return networkMode != null && !PREDEFINED_NETWORKS.contains(networkMode) && !networkMode.startsWith("container:");
     }
 
     @JsonIgnore

--- a/src/main/java/com/github/dockerjava/api/model/Network.java
+++ b/src/main/java/com/github/dockerjava/api/model/Network.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -111,14 +112,31 @@ public class Network {
         private String driver;
 
         @JsonProperty("Config")
-        List<Config> config = new ArrayList<>();
+        private List<Config> config = new ArrayList<>();
+
+        @JsonProperty("Options")
+        private Map<String, String> options = null;
 
         public String getDriver() {
             return driver;
         }
 
+        public Map<String, String> getOptions() {
+            return options;
+        }
+
         public List<Config> getConfig() {
             return config;
+        }
+
+        public Ipam withConfig(List<Config> ipamConfigs) {
+            config = ipamConfigs;
+            return this;
+        }
+
+        public Ipam withConfig(Config... ipamConfigs) {
+            config = Arrays.asList(ipamConfigs);
+            return this;
         }
 
         @Override
@@ -148,6 +166,21 @@ public class Network {
 
             public String getGateway() {
                 return gateway;
+            }
+
+            public Config withSubnet(String subnet) {
+                this.subnet = subnet;
+                return this;
+            }
+
+            public Config withIpRange(String ipRange) {
+                this.ipRange = ipRange;
+                return this;
+            }
+
+            public Config withGateway(String gateway) {
+                this.gateway = gateway;
+                return this;
             }
         }
     }

--- a/src/main/java/com/github/dockerjava/api/model/NetworkSettings.java
+++ b/src/main/java/com/github/dockerjava/api/model/NetworkSettings.java
@@ -3,15 +3,12 @@
  */
 package com.github.dockerjava.api.model;
 
-import java.util.Map;
-
-import org.apache.commons.lang.builder.ToStringBuilder;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.dockerjava.core.RemoteApiVersion;
+import org.apache.commons.lang.builder.ToStringBuilder;
 
-import javax.annotation.CheckForNull;
+import java.util.Map;
 
 /**
  *
@@ -76,7 +73,7 @@ public class NetworkSettings {
     private String macAddress;
 
     @JsonProperty("Networks")
-    private Map<String, Network> networks;
+    private Map<String, ContainerNetwork> networks;
 
     /**
      * @deprecated since {@link RemoteApiVersion#VERSION_1_21}
@@ -135,7 +132,7 @@ public class NetworkSettings {
     /**
      * @since {@link RemoteApiVersion#VERSION_1_21}
      */
-    public Map<String, Network> getNetworks() {
+    public Map<String, ContainerNetwork> getNetworks() {
         return networks;
     }
 
@@ -205,84 +202,5 @@ public class NetworkSettings {
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class Network {
-
-        @JsonProperty("IPAMConfig")
-        private String ipamConfig;
-
-        /**
-         * @since {@link RemoteApiVersion#VERSION_1_22}
-         */
-        @JsonProperty("NetworkID")
-        private String networkID;
-
-        @JsonProperty("EndpointID")
-        private String endpointId;
-
-        @JsonProperty("Gateway")
-        private String gateway;
-
-        @JsonProperty("IPAddress")
-        private String ipAddress;
-
-        @JsonProperty("IPPrefixLen")
-        private Integer ipPrefixLen;
-
-        @JsonProperty("IPv6Gateway")
-        private String ipV6Gateway;
-
-        @JsonProperty("GlobalIPv6Address")
-        private String globalIPv6Address;
-
-        @JsonProperty("GlobalIPv6PrefixLen")
-        private Integer globalIPv6PrefixLen;
-
-        @JsonProperty("MacAddress")
-        private String macAddress;
-
-        @CheckForNull
-        public String getNetworkID() {
-            return networkID;
-        }
-
-        public String getEndpointId() {
-            return endpointId;
-        }
-
-        public String getGateway() {
-            return gateway;
-        }
-
-        public String getIpAddress() {
-            return ipAddress;
-        }
-
-        public Integer getIpPrefixLen() {
-            return ipPrefixLen;
-        }
-
-        public String getIpV6Gateway() {
-            return ipV6Gateway;
-        }
-
-        public String getGlobalIPv6Address() {
-            return globalIPv6Address;
-        }
-
-        public Integer getGlobalIPv6PrefixLen() {
-            return globalIPv6PrefixLen;
-        }
-
-        public String getMacAddress() {
-            return macAddress;
-        }
-
-        @Override
-        public String toString() {
-            return ToStringBuilder.reflectionToString(this);
-        }
     }
 }

--- a/src/main/java/com/github/dockerjava/core/command/ConnectToNetworkCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ConnectToNetworkCmdImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.dockerjava.api.command.ConnectToNetworkCmd;
 import com.github.dockerjava.api.command.DockerCmdSyncExec;
+import com.github.dockerjava.api.model.ContainerNetwork;
 
 public class ConnectToNetworkCmdImpl extends AbstrDockerCmd<ConnectToNetworkCmd, Void> implements ConnectToNetworkCmd {
 
@@ -12,6 +13,9 @@ public class ConnectToNetworkCmdImpl extends AbstrDockerCmd<ConnectToNetworkCmd,
 
     @JsonProperty("Container")
     private String containerId;
+
+    @JsonProperty("EndpointConfig")
+    private ContainerNetwork endpointConfig;
 
     public ConnectToNetworkCmdImpl(DockerCmdSyncExec<ConnectToNetworkCmd, Void> execution) {
         super(execution);
@@ -28,6 +32,11 @@ public class ConnectToNetworkCmdImpl extends AbstrDockerCmd<ConnectToNetworkCmd,
     }
 
     @Override
+    public ContainerNetwork getContainerConfig() {
+        return endpointConfig;
+    }
+
+    @Override
     public ConnectToNetworkCmd withNetworkId(String networkId) {
         this.networkId = networkId;
         return this;
@@ -36,6 +45,12 @@ public class ConnectToNetworkCmdImpl extends AbstrDockerCmd<ConnectToNetworkCmd,
     @Override
     public ConnectToNetworkCmd withContainerId(String containerId) {
         this.containerId = containerId;
+        return this;
+    }
+
+    @Override
+    public ConnectToNetworkCmd withContainerNetwork(ContainerNetwork endpointConfig) {
+        this.endpointConfig = endpointConfig;
         return this;
     }
 }

--- a/src/main/java/com/github/dockerjava/core/command/CreateNetworkCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CreateNetworkCmdImpl.java
@@ -25,6 +25,15 @@ public class CreateNetworkCmdImpl extends AbstrDockerCmd<CreateNetworkCmd, Creat
     @JsonProperty("Options")
     private Map<String, String> options = new HashMap<>();
 
+    @JsonProperty("CheckDuplicate")
+    private Boolean checkDuplicate;
+
+    @JsonProperty("Internal")
+    private Boolean internal;
+
+    @JsonProperty("EnableIPv6")
+    private Boolean enableIpv6;
+
     public CreateNetworkCmdImpl(DockerCmdSyncExec<CreateNetworkCmd, CreateNetworkResponse> execution) {
         super(execution);
     }
@@ -45,6 +54,26 @@ public class CreateNetworkCmdImpl extends AbstrDockerCmd<CreateNetworkCmd, Creat
     }
 
     @Override
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    @Override
+    public Boolean getCheckDuplicate() {
+        return checkDuplicate;
+    }
+
+    @Override
+    public Boolean getInternal() {
+        return internal;
+    }
+
+    @Override
+    public Boolean getEnableIPv6() {
+        return enableIpv6;
+    }
+
+    @Override
     public CreateNetworkCmd withName(String name) {
         this.name = name;
         return this;
@@ -57,14 +86,32 @@ public class CreateNetworkCmdImpl extends AbstrDockerCmd<CreateNetworkCmd, Creat
     }
 
     @Override
-    public CreateNetworkCmd withIpamConfig(Ipam.Config config) {
-        this.ipam.getConfig().add(config);
+    public CreateNetworkCmd withIpam(Ipam ipam) {
+        this.ipam = ipam;
         return this;
     }
 
     @Override
     public CreateNetworkCmd withOptions(Map<String, String> options) {
         this.options = options;
+        return this;
+    }
+
+    @Override
+    public CreateNetworkCmd withCheckDuplicate(boolean checkDuplicate) {
+        this.checkDuplicate = checkDuplicate;
+        return this;
+    }
+
+    @Override
+    public CreateNetworkCmd withInternal(boolean internal) {
+        this.internal = internal;
+        return this;
+    }
+
+    @Override
+    public CreateNetworkCmd withEnableIpv6(boolean enableIpv6) {
+        this.enableIpv6 = enableIpv6;
         return this;
     }
 }

--- a/src/main/java/com/github/dockerjava/core/command/DisconnectFromNetworkCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/DisconnectFromNetworkCmdImpl.java
@@ -14,6 +14,9 @@ public class DisconnectFromNetworkCmdImpl extends AbstrDockerCmd<DisconnectFromN
     @JsonProperty("Container")
     private String containerId;
 
+    @JsonProperty("Force")
+    private Boolean force;
+
     public DisconnectFromNetworkCmdImpl(DockerCmdSyncExec<DisconnectFromNetworkCmd, Void> execution) {
         super(execution);
     }
@@ -29,6 +32,11 @@ public class DisconnectFromNetworkCmdImpl extends AbstrDockerCmd<DisconnectFromN
     }
 
     @Override
+    public Boolean getForce() {
+        return force;
+    }
+
+    @Override
     public DisconnectFromNetworkCmd withNetworkId(String networkId) {
         this.networkId = networkId;
         return this;
@@ -37,6 +45,12 @@ public class DisconnectFromNetworkCmdImpl extends AbstrDockerCmd<DisconnectFromN
     @Override
     public DisconnectFromNetworkCmd withContainerId(String containerId) {
         this.containerId = containerId;
+        return this;
+    }
+
+    @Override
+    public DisconnectFromNetworkCmd withForce(Boolean force) {
+        this.force = force;
         return this;
     }
 }

--- a/src/main/java/com/github/dockerjava/core/command/RemoveNetworkCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/RemoveNetworkCmdImpl.java
@@ -14,7 +14,6 @@ public class RemoveNetworkCmdImpl extends AbstrDockerCmd<RemoveNetworkCmd, Void>
 
     @Override
     public String getNetworkId() {
-
         return networkId;
     }
 

--- a/src/test/java/com/github/dockerjava/core/command/ConnectToNetworkCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/ConnectToNetworkCmdImplTest.java
@@ -1,7 +1,11 @@
 package com.github.dockerjava.core.command;
 
-import java.lang.reflect.Method;
-
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.command.CreateNetworkResponse;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.ContainerNetwork;
+import com.github.dockerjava.api.model.Network;
+import com.github.dockerjava.client.AbstractDockerClientTest;
 import org.testng.ITestResult;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterTest;
@@ -9,11 +13,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.github.dockerjava.api.command.CreateContainerResponse;
-import com.github.dockerjava.api.command.CreateNetworkResponse;
-import com.github.dockerjava.api.command.InspectContainerResponse;
-import com.github.dockerjava.api.model.Network;
-import com.github.dockerjava.client.AbstractDockerClientTest;
+import java.lang.reflect.Method;
+import java.util.Collections;
 
 @Test(groups = "integration")
 public class ConnectToNetworkCmdImplTest extends AbstractDockerClientTest {
@@ -55,5 +56,42 @@ public class ConnectToNetworkCmdImplTest extends AbstractDockerClientTest {
         InspectContainerResponse inspectContainerResponse = dockerClient.inspectContainerCmd(container.getId()).exec();
 
         assertNotNull(inspectContainerResponse.getNetworkSettings().getNetworks().get("testNetwork"));
+    }
+
+    @Test
+    public void connectToNetworkWithContainerNetwork() throws InterruptedException {
+
+        CreateContainerResponse container = dockerClient.createContainerCmd("busybox").withCmd("sleep", "9999").exec();
+        dockerClient.startContainerCmd(container.getId()).exec();
+
+        CreateNetworkResponse network = dockerClient.createNetworkCmd()
+                .withName("testNetwork")
+                .withIpam(new Network.Ipam()
+                    .withConfig(new Network.Ipam.Config()
+                        .withSubnet("10.100.100.0/24")))
+                .exec();
+
+        dockerClient.connectToNetworkCmd()
+                .withNetworkId(network.getId())
+                .withContainerId(container.getId())
+                .withContainerNetwork(new ContainerNetwork()
+                    .withAliases("testing")
+                    .withIpamConfig(new ContainerNetwork.Ipam()
+                        .withIpv4Address("10.100.100.100")))
+                .exec();
+
+        Network updatedNetwork = dockerClient.inspectNetworkCmd().withNetworkId(network.getId()).exec();
+
+        Network.ContainerNetworkConfig containerNetworkConfig = updatedNetwork.getContainers().get(container.getId());
+        assertNotNull(containerNetworkConfig);
+        assertEquals("10.100.100.100", containerNetworkConfig.getIpv4Address());
+
+        InspectContainerResponse inspectContainerResponse = dockerClient.inspectContainerCmd(container.getId()).exec();
+
+        ContainerNetwork testNetwork = inspectContainerResponse.getNetworkSettings().getNetworks().get("testNetwork");
+        assertNotNull(testNetwork);
+        assertEquals(Collections.singletonList("testing"), testNetwork.getAliases());
+        assertEquals("10.100.100.0", testNetwork.getGateway());
+        assertEquals("10.100.100.100", testNetwork.getIpAddress());
     }
 }

--- a/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
@@ -1,15 +1,18 @@
 package com.github.dockerjava.core.command;
 
 import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.command.CreateNetworkResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.exception.ConflictException;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.ContainerNetwork;
 import com.github.dockerjava.api.model.Device;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.Link;
 import com.github.dockerjava.api.model.LogConfig;
+import com.github.dockerjava.api.model.Network;
 import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.RestartPolicy;
 import com.github.dockerjava.api.model.Ulimit;
@@ -22,10 +25,12 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
+import org.testng.internal.junit.ArrayAsserts;
 
 import java.lang.reflect.Method;
 import java.security.SecureRandom;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -266,6 +271,107 @@ public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
                 .exec();
         assertThat(inspectContainerResponse2.getHostConfig().getLinks(), equalTo(new Link[]{new Link("container1",
                 "container1Link")}));
+    }
+
+    @Test
+    public void createContainerWithLinkInCustomNetwork() throws DockerException {
+
+        CreateNetworkResponse createNetworkResponse = dockerClient.createNetworkCmd()
+                .withName("linkNet")
+                .exec();
+
+        assertNotNull(createNetworkResponse.getId());
+
+        CreateContainerResponse container1 = dockerClient.createContainerCmd(BUSYBOX_IMAGE)
+                .withNetworkMode("linkNet")
+                .withCmd("sleep", "9999")
+                .withName("container1")
+                .exec();
+
+        assertThat(container1.getId(), not(isEmptyString()));
+
+        dockerClient.startContainerCmd(container1.getId()).exec();
+
+        InspectContainerResponse inspectContainerResponse1 = dockerClient.inspectContainerCmd(container1.getId())
+                .exec();
+        LOG.info("Container1 Inspect: {}", inspectContainerResponse1.toString());
+        assertThat(inspectContainerResponse1.getState().getRunning(), is(true));
+
+        CreateContainerResponse container2 = dockerClient.createContainerCmd(BUSYBOX_IMAGE)
+                .withNetworkMode("linkNet")
+                .withName("container2")
+                .withCmd("env")
+                .withLinks(new Link("container1", "container1Link"))
+                .exec();
+
+        LOG.info("Created container {}", container2.toString());
+        assertThat(container2.getId(), not(isEmptyString()));
+
+        InspectContainerResponse inspectContainerResponse2 = dockerClient.inspectContainerCmd(container2.getId())
+                .exec();
+
+        ContainerNetwork linkNet = inspectContainerResponse2.getNetworkSettings().getNetworks().get("linkNet");
+        assertNotNull(linkNet);
+        ArrayAsserts.assertArrayEquals(new Link[]{ new Link("container1", "container1Link")}, linkNet.getLinks());
+    }
+
+    @Test
+    public void createContainerWithCustomIp() throws DockerException {
+
+        CreateNetworkResponse createNetworkResponse = dockerClient.createNetworkCmd()
+                .withIpam(new Network.Ipam()
+                        .withConfig(new Network.Ipam.Config()
+                                .withSubnet("10.100.101.0/24")))
+                .withName("customIpNet")
+                .exec();
+
+        assertNotNull(createNetworkResponse.getId());
+
+        CreateContainerResponse container = dockerClient.createContainerCmd(BUSYBOX_IMAGE)
+                .withNetworkMode("customIpNet")
+                .withCmd("sleep", "9999")
+                .withName("container")
+                .withIpv4Address("10.100.101.100")
+                .exec();
+
+        assertThat(container.getId(), not(isEmptyString()));
+
+        dockerClient.startContainerCmd(container.getId()).exec();
+
+        InspectContainerResponse inspectContainerResponse = dockerClient.inspectContainerCmd(container.getId())
+                .exec();
+
+        ContainerNetwork customIpNet = inspectContainerResponse.getNetworkSettings().getNetworks().get("customIpNet");
+        assertNotNull(customIpNet);
+        assertEquals("10.100.101.0", customIpNet.getGateway());
+        assertEquals("10.100.101.100", customIpNet.getIpAddress());
+    }
+
+    @Test
+    public void createContainerWithAlias() throws DockerException {
+
+        CreateNetworkResponse createNetworkResponse = dockerClient.createNetworkCmd()
+                .withName("aliasNet")
+                .exec();
+
+        assertNotNull(createNetworkResponse.getId());
+
+        CreateContainerResponse container = dockerClient.createContainerCmd(BUSYBOX_IMAGE)
+                .withNetworkMode("aliasNet")
+                .withCmd("sleep", "9999")
+                .withName("container")
+                .withAliases("server")
+                .exec();
+
+        assertThat(container.getId(), not(isEmptyString()));
+
+        dockerClient.startContainerCmd(container.getId()).exec();
+
+        InspectContainerResponse inspectContainerResponse = dockerClient.inspectContainerCmd(container.getId())
+                .exec();
+
+        ContainerNetwork aliasNet = inspectContainerResponse.getNetworkSettings().getNetworks().get("aliasNet");
+        assertEquals(Collections.singletonList("server"), aliasNet.getAliases());
     }
 
     @Test

--- a/src/test/java/com/github/dockerjava/core/command/DisconnectFromNetworkCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/DisconnectFromNetworkCmdImplTest.java
@@ -56,4 +56,26 @@ public class DisconnectFromNetworkCmdImplTest extends AbstractDockerClientTest {
 
         assertFalse(updatedNetwork.getContainers().containsKey(container.getId()));
     }
+
+    @Test
+    public void forceDisconnectFromNetwork() throws InterruptedException {
+
+        CreateNetworkResponse network = dockerClient.createNetworkCmd().withName("testNetwork").exec();
+
+        CreateContainerResponse container = dockerClient.createContainerCmd("busybox")
+                .withNetworkMode("testNetwork")
+                .withCmd("sleep", "9999")
+                .exec();
+
+        dockerClient.startContainerCmd(container.getId()).exec();
+
+        dockerClient.disconnectFromNetworkCmd()
+                .withNetworkId(network.getId())
+                .withContainerId(container.getId())
+                .withForce(true)
+                .exec();
+
+        Network updatedNetwork = dockerClient.inspectNetworkCmd().withNetworkId(network.getId()).exec();
+        assertFalse(updatedNetwork.getContainers().containsKey(container.getId()));
+    }
 }


### PR DESCRIPTION
This pull request is based on your wip pull request #469 
I needed the additional networks options, while we are migrating to docker 1.10
I would like to give the outcome of my research back to you, since the complicated part was that docker handle links differently for the default network and user defined networks. 
The most interesting part is in the CreateContainerCmdImpl#exec() method.
I do not know if it is the best place to put this specific code there. If i can help you with further tasks, please let me now it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/484)
<!-- Reviewable:end -->
