### PR TITLE
Se linux bind

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/Bind.java
+++ b/src/main/java/com/github/dockerjava/api/model/Bind.java
@@ -15,14 +15,20 @@ public class Bind {
 
     private AccessMode accessMode;
 
+    private SELContext secMode;
+
     public Bind(String path, Volume volume) {
-        this(path, volume, AccessMode.DEFAULT);
+        this(path, volume, AccessMode.DEFAULT, SELContext.DEFAULT);
     }
 
     public Bind(String path, Volume volume, AccessMode accessMode) {
+        this(path, volume, accessMode, SELContext.DEFAULT);
+    }
+    public Bind(String path, Volume volume, AccessMode accessMode, SELContext secMode) {
         this.path = path;
         this.volume = volume;
         this.accessMode = accessMode;
+        this.secMode = secMode;
     }
 
     public String getPath() {
@@ -35,6 +41,10 @@ public class Bind {
 
     public AccessMode getAccessMode() {
         return accessMode;
+    }
+
+    public SELContext getSecMode() {
+        return secMode;
     }
 
     /**
@@ -50,16 +60,26 @@ public class Bind {
         try {
             String[] parts = serialized.split(":");
             switch (parts.length) {
-                case 2: {
-                    return new Bind(parts[0], new Volume(parts[1]));
+            case 2: {
+                return new Bind(parts[0], new Volume(parts[1]));
+            }
+            case 3: {
+                parts = parts[2].split(",");
+                AccessMode accessMode = AccessMode.DEFAULT;
+                SELContext seMode = SELContext.DEFAULT;
+                for (String p : parts) {
+                    if (p.length() == 2) {
+                        accessMode = AccessMode.valueOf(p.toLowerCase());
+                    } else {
+                        seMode = SELContext.fromString(p);
+                    }
                 }
-                case 3: {
-                    AccessMode accessMode = AccessMode.valueOf(parts[2].toLowerCase());
-                    return new Bind(parts[0], new Volume(parts[1]), accessMode);
-                }
-                default: {
-                    throw new IllegalArgumentException();
-                }
+
+                return new Bind(parts[0], new Volume(parts[1]), accessMode, seMode);
+            }
+            default: {
+                throw new IllegalArgumentException();
+            }
             }
         } catch (Exception e) {
             throw new IllegalArgumentException("Error parsing Bind '" + serialized + "'");
@@ -90,7 +110,7 @@ public class Bind {
      */
     @Override
     public String toString() {
-        return path + ":" + volume.getPath() + ":" + accessMode.toString();
+        return path + ":" + volume.getPath() + ":" + accessMode.toString() + (secMode != SELContext.none ? "," + secMode.toString() : "");
     }
 
 }

--- a/src/main/java/com/github/dockerjava/api/model/Bind.java
+++ b/src/main/java/com/github/dockerjava/api/model/Bind.java
@@ -1,5 +1,7 @@
 package com.github.dockerjava.api.model;
 
+import java.util.regex.Pattern;
+
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
@@ -15,6 +17,9 @@ public class Bind {
 
     private AccessMode accessMode;
 
+    /**
+     * @since 1.17
+     */
     private SELContext secMode;
 
     public Bind(String path, Volume volume) {
@@ -24,6 +29,7 @@ public class Bind {
     public Bind(String path, Volume volume, AccessMode accessMode) {
         this(path, volume, accessMode, SELContext.DEFAULT);
     }
+    
     public Bind(String path, Volume volume, AccessMode accessMode, SELContext secMode) {
         this.path = path;
         this.volume = volume;
@@ -56,6 +62,36 @@ public class Bind {
      * @throws IllegalArgumentException
      *             if the specification cannot be parsed
      */
+    public static Bind parse(String serialized) {
+        try {
+            String[] parts = serialized.split(":");
+            switch (parts.length) {
+            case 2: {
+                return new Bind(parts[0], new Volume(parts[1]));
+            }
+            case 3: {
+                String[] flags = parts[2].split(",");
+                AccessMode accessMode = AccessMode.DEFAULT;
+                SELContext seMode = SELContext.DEFAULT;
+                for (String p : flags) {
+                    if (p.length() == 2) {
+                        accessMode = AccessMode.valueOf(p.toLowerCase());
+                    } else {
+                        seMode = SELContext.fromString(p);
+                    }
+                }
+
+                return new Bind(parts[0], new Volume(parts[1]), accessMode, seMode);
+            }
+            default: {
+                throw new IllegalArgumentException();
+            }
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Error parsing Bind '" + serialized + "'", e);
+        }
+    }
+
     public static Bind parse(String serialized) {
         try {
             String[] parts = serialized.split(":");

--- a/src/main/java/com/github/dockerjava/api/model/Bind.java
+++ b/src/main/java/com/github/dockerjava/api/model/Bind.java
@@ -1,7 +1,5 @@
 package com.github.dockerjava.api.model;
 
-import java.util.regex.Pattern;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
@@ -29,7 +27,7 @@ public class Bind {
     public Bind(String path, Volume volume, AccessMode accessMode) {
         this(path, volume, accessMode, SELContext.DEFAULT);
     }
-    
+
     public Bind(String path, Volume volume, AccessMode accessMode, SELContext secMode) {
         this.path = path;
         this.volume = volume;
@@ -62,36 +60,6 @@ public class Bind {
      * @throws IllegalArgumentException
      *             if the specification cannot be parsed
      */
-    public static Bind parse(String serialized) {
-        try {
-            String[] parts = serialized.split(":");
-            switch (parts.length) {
-            case 2: {
-                return new Bind(parts[0], new Volume(parts[1]));
-            }
-            case 3: {
-                String[] flags = parts[2].split(",");
-                AccessMode accessMode = AccessMode.DEFAULT;
-                SELContext seMode = SELContext.DEFAULT;
-                for (String p : flags) {
-                    if (p.length() == 2) {
-                        accessMode = AccessMode.valueOf(p.toLowerCase());
-                    } else {
-                        seMode = SELContext.fromString(p);
-                    }
-                }
-
-                return new Bind(parts[0], new Volume(parts[1]), accessMode, seMode);
-            }
-            default: {
-                throw new IllegalArgumentException();
-            }
-            }
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Error parsing Bind '" + serialized + "'", e);
-        }
-    }
-
     public static Bind parse(String serialized) {
         try {
             String[] parts = serialized.split(":");

--- a/src/main/java/com/github/dockerjava/api/model/Bind.java
+++ b/src/main/java/com/github/dockerjava/api/model/Bind.java
@@ -64,10 +64,10 @@ public class Bind {
                 return new Bind(parts[0], new Volume(parts[1]));
             }
             case 3: {
-                parts = parts[2].split(",");
+                String[] flags = parts[2].split(",");
                 AccessMode accessMode = AccessMode.DEFAULT;
                 SELContext seMode = SELContext.DEFAULT;
-                for (String p : parts) {
+                for (String p : flags) {
                     if (p.length() == 2) {
                         accessMode = AccessMode.valueOf(p.toLowerCase());
                     } else {
@@ -82,7 +82,7 @@ public class Bind {
             }
             }
         } catch (Exception e) {
-            throw new IllegalArgumentException("Error parsing Bind '" + serialized + "'");
+            throw new IllegalArgumentException("Error parsing Bind '" + serialized + "'", e);
         }
     }
 

--- a/src/main/java/com/github/dockerjava/api/model/SELContext.java
+++ b/src/main/java/com/github/dockerjava/api/model/SELContext.java
@@ -5,6 +5,7 @@ package com.github.dockerjava.api.model;
  * Host path <code>shared</code> - can be used by all containers, <code>private</code> - by only this container
  *
  * @see http://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/
+ * @since 1.17
  */
 public enum SELContext {
     /** no selinux */

--- a/src/main/java/com/github/dockerjava/api/model/SELContext.java
+++ b/src/main/java/com/github/dockerjava/api/model/SELContext.java
@@ -1,0 +1,44 @@
+package com.github.dockerjava.api.model;
+
+/**
+ * The context mode of bound volume in SELinux.
+ * Host path <code>shared</code> - can be used by all containers, <code>private</code> - by only this container
+ *
+ * @see http://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/
+ */
+public enum SELContext {
+    /** no selinux */
+    none(""),
+
+    /** z option */
+    shared("z"),
+
+    /** Z option */
+    single("Z");
+
+    /**
+     * The default {@link SELContext}: {@link #none}
+     */
+    public static final SELContext DEFAULT = none;
+
+    private String value;
+
+    SELContext(String v) {
+        this.value = v;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    public static SELContext fromString(String p) {
+        switch (p) {
+        case "z":
+            return shared;
+        case "Z":
+            return single;
+        }
+        return none;
+    }
+}

--- a/src/test/java/com/github/dockerjava/api/model/BindTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/BindTest.java
@@ -14,6 +14,7 @@ public class BindTest {
         assertEquals(bind.getPath(), "/host");
         assertEquals(bind.getVolume().getPath(), "/container");
         assertEquals(bind.getAccessMode(), AccessMode.DEFAULT);
+        assertEquals(bind.getSecMode(), SELContext.none);
     }
 
     @Test
@@ -22,6 +23,7 @@ public class BindTest {
         assertEquals(bind.getPath(), "/host");
         assertEquals(bind.getVolume().getPath(), "/container");
         assertEquals(bind.getAccessMode(), rw);
+        assertEquals(bind.getSecMode(), SELContext.none);
     }
 
     @Test
@@ -30,6 +32,40 @@ public class BindTest {
         assertEquals(bind.getPath(), "/host");
         assertEquals(bind.getVolume().getPath(), "/container");
         assertEquals(bind.getAccessMode(), ro);
+        assertEquals(bind.getSecMode(), SELContext.none);
+    }
+
+    @Test
+    public void parseSELOnly() {
+        Bind bind = Bind.parse("/host:/container:Z");
+        assertEquals(bind.getPath(), "/host");
+        assertEquals(bind.getVolume().getPath(), "/container");
+        assertEquals(bind.getAccessMode(), AccessMode.DEFAULT);
+        assertEquals(bind.getSecMode(), SELContext.single);
+        
+        bind = Bind.parse("/host:/container:z");
+        assertEquals(bind.getPath(), "/host");
+        assertEquals(bind.getVolume().getPath(), "/container");
+        assertEquals(bind.getAccessMode(), AccessMode.DEFAULT);
+        assertEquals(bind.getSecMode(), SELContext.shared);
+    }
+
+    @Test
+    public void parseReadWriteSEL() {
+        Bind bind = Bind.parse("/host:/container:rw,Z");
+        assertEquals(bind.getPath(), "/host");
+        assertEquals(bind.getVolume().getPath(), "/container");
+        assertEquals(bind.getAccessMode(), rw);
+        assertEquals(bind.getSecMode(), SELContext.single);
+    }
+
+    @Test
+    public void parseReadOnlySEL() {
+        Bind bind = Bind.parse("/host:/container:ro,z");
+        assertEquals(bind.getPath(), "/host");
+        assertEquals(bind.getVolume().getPath(), "/container");
+        assertEquals(bind.getAccessMode(), ro);
+        assertEquals(bind.getSecMode(), SELContext.shared);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Error parsing Bind.*")
@@ -60,6 +96,21 @@ public class BindTest {
     @Test
     public void toStringDefaultAccessMode() {
         assertEquals(Bind.parse("/host:/container").toString(), "/host:/container:rw");
+    }
+
+    @Test
+    public void toStringReadOnlySEL() {
+        assertEquals(Bind.parse("/host:/container:ro,Z").toString(), "/host:/container:ro,Z");
+    }
+
+    @Test
+    public void toStringReadWriteSEL() {
+        assertEquals(Bind.parse("/host:/container:rw,z").toString(), "/host:/container:rw,z");
+    }
+
+    @Test
+    public void toStringDefaultSEL() {
+        assertEquals(Bind.parse("/host:/container:Z").toString(), "/host:/container:rw,Z");
     }
 
 }


### PR DESCRIPTION
Project Atomic recently added z and Z flags to volume binding command. Without these no volume binds can be done for /var/* volumes under SE Linux.
This PR adds ability to pass these flags to docker daemon.

see http://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/
for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/503)
<!-- Reviewable:end -->
