### PR TITLE
Added shmsize build option

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
@@ -95,8 +95,11 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
     @CheckForNull
     Map<String, String> getBuildArgs();
 
+    /**
+     *@since {@link RemoteApiVersion#VERSION_1_22}
+     */
     @CheckForNull
-    long getShmsize();
+    Long getShmsize();
 
     // setters
 
@@ -137,7 +140,10 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
 
     BuildImageCmd withTarInputStream(@Nonnull InputStream tarInputStream);
 
-    BuildImageCmd withShmsize(long shmsize);
+    /**
+    *@since {@link RemoteApiVersion#VERSION_1_22}
+    */
+    BuildImageCmd withShmsize(Long shmsize);
 
     interface Exec extends DockerCmdAsyncExec<BuildImageCmd, BuildResponseItem> {
     }

--- a/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
@@ -95,6 +95,9 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
     @CheckForNull
     Map<String, String> getBuildArgs();
 
+    @CheckForNull
+    long getShmsize();
+
     // setters
 
     BuildImageCmd withTag(String tag);
@@ -133,6 +136,8 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
     BuildImageCmd withBuildAuthConfigs(AuthConfigurations authConfig);
 
     BuildImageCmd withTarInputStream(@Nonnull InputStream tarInputStream);
+
+    BuildImageCmd withShmsize(long shmsize);
 
     interface Exec extends DockerCmdAsyncExec<BuildImageCmd, BuildResponseItem> {
     }

--- a/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
@@ -50,7 +50,7 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
 
     private Long memswap;
 
-    private long shmsize;
+    private Long shmsize;
 
     private URI remote;
 
@@ -161,8 +161,11 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
         return tarInputStream;
     }
 
+    /**
+     * @see #shmsize
+     */
     @Override
-    public long getShmsize() {
+    public Long getShmsize() {
         return shmsize;
     }
 
@@ -291,8 +294,11 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
         return this;
     }
 
+    /**
+     * @see #shmsize
+     */
     @Override
-    public BuildImageCmd withShmsize(long shmsize) {
+    public BuildImageCmd withShmsize(Long shmsize) {
         this.shmsize = shmsize;
         return this;
     }

--- a/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
@@ -50,6 +50,8 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
 
     private Long memswap;
 
+    private long shmsize;
+
     private URI remote;
 
     private Map<String, String> buildArgs;
@@ -157,6 +159,11 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
     @Override
     public InputStream getTarInputStream() {
         return tarInputStream;
+    }
+
+    @Override
+    public long getShmsize() {
+        return shmsize;
     }
 
     // setters
@@ -285,6 +292,12 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
     }
 
     @Override
+    public BuildImageCmd withShmsize(long shmsize) {
+        this.shmsize = shmsize;
+        return this;
+    }
+
+    @Override
     public void close() {
         super.close();
 
@@ -294,4 +307,5 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
             throw new RuntimeException(e);
         }
     }
+
 }

--- a/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
@@ -108,7 +108,7 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
             }
         }
 
-        if (command.getShmsize() != 0) {
+        if (command.getShmsize() != null) {
             webTarget = webTarget.queryParam("shmsize", command.getShmsize());
         }
 

--- a/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
@@ -108,6 +108,10 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
             }
         }
 
+        if (command.getShmsize() != 0) {
+            webTarget = webTarget.queryParam("shmsize", command.getShmsize());
+        }
+
         webTarget.property(ClientProperties.REQUEST_ENTITY_PROCESSING, RequestEntityProcessing.CHUNKED);
         webTarget.property(ClientProperties.CHUNKED_ENCODING_SIZE, 1024 * 1024);
 

--- a/src/main/java/com/github/dockerjava/netty/exec/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/netty/exec/BuildImageCmdExec.java
@@ -93,7 +93,7 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
             }
         }
 
-        if (command.getShmsize() != 0) {
+        if (command.getShmsize() != null) {
             webTarget = webTarget.queryParam("shmsize", command.getShmsize());
         }
 

--- a/src/main/java/com/github/dockerjava/netty/exec/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/netty/exec/BuildImageCmdExec.java
@@ -93,6 +93,10 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
             }
         }
 
+        if (command.getShmsize() != 0) {
+            webTarget = webTarget.queryParam("shmsize", command.getShmsize());
+        }
+
         LOGGER.trace("POST: {}", webTarget);
 
         InvocationBuilder builder = resourceWithOptionalAuthConfig(command, webTarget.request())


### PR DESCRIPTION
Added shmsize (Size of /dev/shm in bytes) on imagebuild as described in Docker API 1.22

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/533)
<!-- Reviewable:end -->
