### PR TITLE
Fix memory leak in netty implementation of DockerCmdExecFactory

### DIFF
--- a/src/main/java/com/github/dockerjava/netty/handler/FramedResponseStreamHandler.java
+++ b/src/main/java/com/github/dockerjava/netty/handler/FramedResponseStreamHandler.java
@@ -45,7 +45,7 @@ public class FramedResponseStreamHandler extends SimpleChannelInboundHandler<Byt
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) throws Exception {
 
-        rawBuffer.writeBytes(msg.copy(), 0, msg.readableBytes());
+        rawBuffer.writeBytes(msg, 0, msg.readableBytes());
 
         Frame frame = null;
 

--- a/src/main/java/com/github/dockerjava/netty/handler/HttpResponseHandler.java
+++ b/src/main/java/com/github/dockerjava/netty/handler/HttpResponseHandler.java
@@ -120,6 +120,9 @@ public class HttpResponseHandler extends SimpleChannelInboundHandler<HttpObject>
     }
 
     private String getBodyAsMessage(ByteBuf body) {
-        return body.readBytes(body.readableBytes()).toString(Charset.forName("UTF-8"));
+        String result = body.readBytes(body.readableBytes()).toString(Charset.forName("UTF-8"));
+        body.discardReadBytes();
+        body.release();
+        return result;
     }
 }

--- a/src/main/java/com/github/dockerjava/netty/handler/JsonResponseCallbackHandler.java
+++ b/src/main/java/com/github/dockerjava/netty/handler/JsonResponseCallbackHandler.java
@@ -30,6 +30,7 @@ public class JsonResponseCallbackHandler<T> extends SimpleChannelInboundHandler<
     protected void channelRead0(ChannelHandlerContext ctx, ByteBuf msg) throws Exception {
         byte[] buffer = new byte[msg.readableBytes()];
         msg.readBytes(buffer);
+        msg.discardReadBytes();
 
         T object = null;
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/563)
<!-- Reviewable:end -->
