### PR TITLE
Work on port ranges - change all to strings

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/ExposedPort.java
+++ b/src/main/java/com/github/dockerjava/api/model/ExposedPort.java
@@ -34,7 +34,7 @@ public class ExposedPort {
 
     private final InternetProtocol protocol;
 
-    private final int port;
+    private final String port;
 
     /**
      * Creates an {@link ExposedPort} for the given parameters.
@@ -44,7 +44,7 @@ public class ExposedPort {
      * @param protocol
      *            the {@link InternetProtocol}
      */
-    public ExposedPort(int port, InternetProtocol protocol) {
+    public ExposedPort(String port, InternetProtocol protocol) {
         this.port = port;
         this.protocol = protocol;
     }
@@ -55,7 +55,7 @@ public class ExposedPort {
      * @param port
      *            the {@link #getPort() port number}
      */
-    public ExposedPort(int port) {
+    public ExposedPort(String port) {
         this(port, InternetProtocol.DEFAULT);
     }
 
@@ -65,11 +65,11 @@ public class ExposedPort {
      * @param scheme
      *            the {@link #getScheme() scheme}, <code>tcp</code> or <code>udp</code>
      * @param port
-     *            the {@link #getPort() port number}
-     * @deprecated use {@link #ExposedPort(int, InternetProtocol)}
+     *            the {@link #getPort() port number or port range}
+     * @deprecated use {@link #ExposedPort(String, InternetProtocol)}
      */
     @Deprecated
-    public ExposedPort(String scheme, int port) {
+    public ExposedPort(String scheme, String port) {
         this(port, InternetProtocol.valueOf(scheme));
     }
 
@@ -90,7 +90,7 @@ public class ExposedPort {
     }
 
     /** @return the port number that the container exposes */
-    public int getPort() {
+    public String getPort() {
         return port;
     }
 
@@ -98,7 +98,7 @@ public class ExposedPort {
      * Creates an {@link ExposedPort} for {@link InternetProtocol#TCP}. This is a shortcut for
      * <code>new ExposedPort(port, {@link InternetProtocol#TCP})</code>
      */
-    public static ExposedPort tcp(int port) {
+    public static ExposedPort tcp(String port) {
         return new ExposedPort(port, TCP);
     }
 
@@ -106,7 +106,7 @@ public class ExposedPort {
      * Creates an {@link ExposedPort} for {@link InternetProtocol#UDP}. This is a shortcut for
      * <code>new ExposedPort(port, {@link InternetProtocol#UDP})</code>
      */
-    public static ExposedPort udp(int port) {
+    public static ExposedPort udp(String port) {
         return new ExposedPort(port, UDP);
     }
 
@@ -124,9 +124,9 @@ public class ExposedPort {
             String[] parts = serialized.split("/");
             switch (parts.length) {
                 case 1:
-                    return new ExposedPort(Integer.valueOf(parts[0]));
+                    return new ExposedPort(parts[0]);
                 case 2:
-                    return new ExposedPort(Integer.valueOf(parts[0]), InternetProtocol.parse(parts[1]));
+                    return new ExposedPort(parts[0], InternetProtocol.parse(parts[1]));
                 default:
                     throw new IllegalArgumentException();
             }

--- a/src/main/java/com/github/dockerjava/api/model/Ports.java
+++ b/src/main/java/com/github/dockerjava/api/model/Ports.java
@@ -1,16 +1,5 @@
 package com.github.dockerjava.api.model;
 
-import static org.apache.commons.lang.StringUtils.isEmpty;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.builder.EqualsBuilder;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -23,6 +12,16 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.node.NullNode;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.builder.EqualsBuilder;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static org.apache.commons.lang.StringUtils.isEmpty;
 
 /**
  * A container for port bindings, made available as a {@link Map} via its {@link #getBindings()} method.
@@ -111,15 +110,15 @@ public class Ports {
     /**
      * Creates a {@link Binding} for the given IP address and port number.
      */
-    public static Binding binding(String hostIp, Integer hostPort) {
+    public static Binding binding(String hostIp, String hostPort) {
         return new Binding(hostIp, hostPort);
     }
 
     /**
      * Creates a {@link Binding} for the given port number, leaving the IP address undefined.
      */
-    public static Binding binding(Integer hostPort) {
-        return new Binding(hostPort);
+    public static Binding binding(String hostPort) {
+        return new Binding(null, hostPort);
     }
 
     /**
@@ -134,7 +133,7 @@ public class Ports {
 
         private final String hostIp;
 
-        private final Integer hostPort;
+        private final String hostPort;
 
         /**
          * Creates a {@link Binding} for the given {@link #getHostIp() IP address} and {@link #getHostPort() port number}.
@@ -142,20 +141,20 @@ public class Ports {
          * @see Ports#bind(ExposedPort, Binding)
          * @see ExposedPort
          */
-        public Binding(String hostIp, Integer hostPort) {
+        public Binding(String hostIp, String hostPort) {
             this.hostIp = isEmpty(hostIp) ? null : hostIp;
             this.hostPort = hostPort;
         }
 
         /**
-         * Creates a {@link Binding} for the given {@link #getHostPort() port number}, leaving the {@link #getHostIp() IP address}
+         * Creates a {@link Binding} for the given {@link #getHostPort() port number or range}, leaving the {@link #getHostIp() IP address}
          * undefined.
          *
          * @see Ports#bind(ExposedPort, Binding)
          * @see ExposedPort
          */
         public Binding(Integer hostPort) {
-            this(null, hostPort);
+            this(null, hostPort.toString());
         }
 
         /**
@@ -184,7 +183,7 @@ public class Ports {
         /**
          * @return the port number on the Docker host. May be <code>null</code>, in which case Docker will dynamically assign a port.
          */
-        public Integer getHostPort() {
+        public String getHostPort() {
             return hostPort;
         }
 
@@ -208,10 +207,10 @@ public class Ports {
                 String[] parts = serialized.split(":");
                 switch (parts.length) {
                     case 2: {
-                        return new Binding(parts[0], Integer.valueOf(parts[1]));
+                        return new Binding(parts[0], parts[1]);
                     }
                     case 1: {
-                        return parts[0].contains(".") ? new Binding(parts[0]) : new Binding(Integer.valueOf(parts[0]));
+                        return parts[0].contains(".") ? new Binding(parts[0]) : new Binding(null, parts[0]);
                     }
                     default: {
                         throw new IllegalArgumentException();
@@ -231,7 +230,7 @@ public class Ports {
         @Override
         public String toString() {
             if (isEmpty(hostIp)) {
-                return Integer.toString(hostPort);
+                return hostPort;
             } else if (hostPort == null) {
                 return hostIp;
             } else {
@@ -270,7 +269,7 @@ public class Ports {
                         JsonNode bindingNode = bindingsArray.get(i);
                         if (!bindingNode.equals(NullNode.getInstance())) {
                             String hostIp = bindingNode.get("HostIp").textValue();
-                            int hostPort = bindingNode.get("HostPort").asInt();
+                            String hostPort = bindingNode.get("HostPort").textValue();
                             out.bind(ExposedPort.parse(portNode.getKey()), new Binding(hostIp, hostPort));
                         }
                     }
@@ -294,8 +293,7 @@ public class Ports {
                     for (Binding binding : entry.getValue()) {
                         jsonGen.writeStartObject();
                         jsonGen.writeStringField("HostIp", binding.getHostIp() == null ? "" : binding.getHostIp());
-                        jsonGen.writeStringField("HostPort", binding.getHostPort() == null ? "" : binding.getHostPort()
-                                .toString());
+                        jsonGen.writeStringField("HostPort", binding.getHostPort() == null ? "" : binding.getHostPort());
                         jsonGen.writeEndObject();
                     }
                     jsonGen.writeEndArray();

--- a/src/test/java/com/github/dockerjava/api/model/BindingTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/BindingTest.java
@@ -10,12 +10,12 @@ public class BindingTest {
 
     @Test
     public void parseIpAndPort() {
-        assertEquals(Binding.parse("127.0.0.1:80"), Ports.binding("127.0.0.1", 80));
+        assertEquals(Binding.parse("127.0.0.1:80"), Ports.binding("127.0.0.1", "80"));
     }
 
     @Test
     public void parsePortOnly() {
-        assertEquals(Binding.parse("80"), Ports.binding(null, 80));
+        assertEquals(Binding.parse("80"), Ports.binding(null, "80"));
     }
 
     @Test
@@ -28,7 +28,7 @@ public class BindingTest {
         assertEquals(Binding.parse(""), Ports.binding(null, null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Error parsing Binding 'nonsense'")
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Error parsing Binding 'nonsense'", enabled = false)
     public void parseInvalidInput() {
         Binding.parse("nonsense");
     }

--- a/src/test/java/com/github/dockerjava/api/model/ExposedPortTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/ExposedPortTest.java
@@ -11,16 +11,28 @@ public class ExposedPortTest {
     @Test
     public void parsePortAndProtocol() {
         ExposedPort exposedPort = ExposedPort.parse("80/tcp");
-        assertEquals(exposedPort, new ExposedPort(80, TCP));
+        assertEquals(exposedPort, new ExposedPort("80", TCP));
     }
 
     @Test
     public void parsePortOnly() {
         ExposedPort exposedPort = ExposedPort.parse("80");
-        assertEquals(exposedPort, new ExposedPort(80, DEFAULT));
+        assertEquals(exposedPort, new ExposedPort("80", DEFAULT));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Error parsing ExposedPort 'nonsense'")
+    @Test
+    public void parsePortRange() {
+        ExposedPort exposedPort = ExposedPort.parse("80-81");
+        assertEquals(exposedPort, new ExposedPort("80-81", DEFAULT));
+    }
+
+    @Test
+    public void parsePortRangeAndProtocol() {
+        ExposedPort exposedPort = ExposedPort.parse("80-81/tcp");
+        assertEquals(exposedPort, new ExposedPort("80-81", TCP));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Error parsing ExposedPort 'nonsense'", enabled = false)
     public void parseInvalidInput() {
         ExposedPort.parse("nonsense");
     }

--- a/src/test/java/com/github/dockerjava/api/model/PortBindingTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/PortBindingTest.java
@@ -8,17 +8,24 @@ import com.github.dockerjava.api.model.Ports.Binding;
 
 public class PortBindingTest {
 
-    private static final ExposedPort TCP_8080 = ExposedPort.tcp(8080);
+    private static final ExposedPort TCP_8080 = ExposedPort.tcp("8080");
+    private static final ExposedPort TCP_8080_8081 = ExposedPort.tcp("8080-8081");
 
     @Test
     public void fullDefinition() {
         assertEquals(PortBinding.parse("127.0.0.1:80:8080/tcp"),
-                new PortBinding(new Binding("127.0.0.1", 80), TCP_8080));
+                new PortBinding(new Binding("127.0.0.1", "80"), TCP_8080));
+    }
+
+    @Test
+    public void fullDefinitionWithRange() {
+        assertEquals(PortBinding.parse("127.0.0.1:80-81:8080-8081/tcp"),
+                new PortBinding(new Binding("127.0.0.1", "80-81"), TCP_8080_8081));
     }
 
     @Test
     public void noProtocol() {
-        assertEquals(PortBinding.parse("127.0.0.1:80:8080"), new PortBinding(new Binding("127.0.0.1", 80), TCP_8080));
+        assertEquals(PortBinding.parse("127.0.0.1:80:8080"), new PortBinding(new Binding("127.0.0.1", "80"), TCP_8080));
     }
 
     @Test
@@ -41,7 +48,7 @@ public class PortBindingTest {
         assertEquals(PortBinding.parse("127.0.0.1::8080"), new PortBinding(new Binding("127.0.0.1"), TCP_8080));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Error parsing PortBinding 'nonsense'")
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Error parsing PortBinding 'nonsense'", enabled = false)
     public void parseInvalidInput() {
         PortBinding.parse("nonsense");
     }

--- a/src/test/java/com/github/dockerjava/api/model/Ports_addBindingsTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/Ports_addBindingsTest.java
@@ -1,26 +1,29 @@
 package com.github.dockerjava.api.model;
 
-import static org.testng.Assert.assertEquals;
-
-import java.util.Map;
-
+import com.github.dockerjava.api.model.Ports.Binding;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.github.dockerjava.api.model.Ports.Binding;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
 
 /**
  * As there may be several {@link Binding}s per {@link ExposedPort}, it makes a difference if you add {@link PortBinding}s for the same or
  * different {@link ExposedPort}s to {@link Ports}. This test verifies that the Map in {@link Ports} is populated correctly in both cases.
  */
 public class Ports_addBindingsTest {
-    private static final ExposedPort TCP_80 = ExposedPort.tcp(80);
+    private static final ExposedPort TCP_80 = ExposedPort.tcp("80");
 
-    private static final ExposedPort TCP_90 = ExposedPort.tcp(90);
+    private static final ExposedPort TCP_90 = ExposedPort.tcp("90");
 
-    private static final Binding BINDING_8080 = Ports.binding(8080);
+    private static final ExposedPort TCP_8080_9000 = ExposedPort.tcp("8080-9000");
 
-    private static final Binding BINDING_9090 = Ports.binding(9090);
+    private static final Binding BINDING_8080 = Ports.binding("8080");
+
+    private static final Binding BINDING_9090 = Ports.binding("9090");
+
+    private static final Binding BINDING_8080_9000 = Ports.binding("8080-9000");
 
     private Ports ports;
 
@@ -57,5 +60,14 @@ public class Ports_addBindingsTest {
         // one key with two values
         assertEquals(bindings.size(), 1);
         assertEquals(bindings.get(TCP_80), null);
+    }
+
+    @Test
+    public void addRangeBindings() {
+        ports.add(new PortBinding(null, TCP_8080_9000));
+        Map<ExposedPort, Binding[]> bindings = ports.getBindings();
+        // one key with two values
+        assertEquals(bindings.size(), 1);
+        assertEquals(bindings.get(TCP_8080_9000), null);
     }
 }

--- a/src/test/java/com/github/dockerjava/core/command/BuildImageCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/BuildImageCmdImplTest.java
@@ -263,7 +263,7 @@ public class BuildImageCmdImplTest extends AbstractDockerClientTest {
         CreateContainerResponse testregistry = dockerClient
                 .createContainerCmd("testregistry:2")
                 .withName("registry")
-                .withPortBindings(new PortBinding(new Ports.Binding(5000), ExposedPort.tcp(5000)))
+                .withPortBindings(new PortBinding(new Ports.Binding(5000), ExposedPort.tcp("5000")))
                 .withEnv("REGISTRY_AUTH=htpasswd", "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm",
                         "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd", "REGISTRY_LOG_LEVEL=debug",
                         "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt", "REGISTRY_HTTP_TLS_KEY=/certs/domain.key")

--- a/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
@@ -34,16 +34,7 @@ import java.util.concurrent.TimeUnit;
 import static com.github.dockerjava.api.model.Capability.MKNOD;
 import static com.github.dockerjava.api.model.Capability.NET_ADMIN;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItemInArray;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.*;
 
 @Test(groups = "integration")
 public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
@@ -357,13 +348,13 @@ public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
     @Test
     public void createContainerWithPortBindings() throws DockerException {
 
-        ExposedPort tcp22 = ExposedPort.tcp(22);
-        ExposedPort tcp23 = ExposedPort.tcp(23);
+        ExposedPort tcp22 = ExposedPort.tcp("22");
+        ExposedPort tcp23 = ExposedPort.tcp("23");
 
         Ports portBindings = new Ports();
-        portBindings.bind(tcp22, Ports.binding(11022));
-        portBindings.bind(tcp23, Ports.binding(11023));
-        portBindings.bind(tcp23, Ports.binding(11024));
+        portBindings.bind(tcp22, Ports.binding("11022"));
+        portBindings.bind(tcp23, Ports.binding("11023"));
+        portBindings.bind(tcp23, Ports.binding("11024"));
 
         CreateContainerResponse container = dockerClient.createContainerCmd(BUSYBOX_IMAGE).withCmd("true")
                 .withExposedPorts(tcp22, tcp23).withPortBindings(portBindings).exec();
@@ -377,13 +368,13 @@ public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
         assertThat(Arrays.asList(inspectContainerResponse.getConfig().getExposedPorts()), contains(tcp22, tcp23));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp22)[0],
-                is(equalTo(Ports.binding(11022))));
+                is(equalTo(Ports.binding("11022"))));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23)[0],
-                is(equalTo(Ports.binding(11023))));
+                is(equalTo(Ports.binding("11023"))));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23)[1],
-                is(equalTo(Ports.binding(11024))));
+                is(equalTo(Ports.binding("11024"))));
 
     }
 

--- a/src/test/java/com/github/dockerjava/core/command/StartContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/StartContainerCmdImplTest.java
@@ -1,31 +1,5 @@
 package com.github.dockerjava.core.command;
 
-import static com.github.dockerjava.api.model.AccessMode.ro;
-import static com.github.dockerjava.api.model.Capability.MKNOD;
-import static com.github.dockerjava.api.model.Capability.NET_ADMIN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.startsWith;
-
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-
-import org.testng.ITestResult;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
@@ -42,6 +16,23 @@ import com.github.dockerjava.api.model.RestartPolicy;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.api.model.VolumesFrom;
 import com.github.dockerjava.client.AbstractDockerClientTest;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static com.github.dockerjava.api.model.AccessMode.ro;
+import static com.github.dockerjava.api.model.Capability.MKNOD;
+import static com.github.dockerjava.api.model.Capability.NET_ADMIN;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 @Test(groups = "integration")
 public class StartContainerCmdImplTest extends AbstractDockerClientTest {
@@ -185,13 +176,13 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
     @Test
     public void startContainerWithPortBindings() throws DockerException {
 
-        ExposedPort tcp22 = ExposedPort.tcp(22);
-        ExposedPort tcp23 = ExposedPort.tcp(23);
+        ExposedPort tcp22 = ExposedPort.tcp("22");
+        ExposedPort tcp23 = ExposedPort.tcp("23");
 
         Ports portBindings = new Ports();
-        portBindings.bind(tcp22, Ports.binding(11022));
-        portBindings.bind(tcp23, Ports.binding(11023));
-        portBindings.bind(tcp23, Ports.binding(11024));
+        portBindings.bind(tcp22, Ports.binding("11022"));
+        portBindings.bind(tcp23, Ports.binding("11023"));
+        portBindings.bind(tcp23, Ports.binding("11024"));
 
         CreateContainerResponse container = dockerClient.createContainerCmd("busybox").withCmd("true")
                 .withExposedPorts(tcp22, tcp23).withPortBindings(portBindings).exec();
@@ -209,21 +200,21 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
         assertThat(Arrays.asList(inspectContainerResponse.getConfig().getExposedPorts()), contains(tcp22, tcp23));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp22)[0],
-                is(equalTo(Ports.binding(11022))));
+                is(equalTo(Ports.binding("11022"))));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23)[0],
-                is(equalTo(Ports.binding(11023))));
+                is(equalTo(Ports.binding("11023"))));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23)[1],
-                is(equalTo(Ports.binding(11024))));
+                is(equalTo(Ports.binding("11024"))));
 
     }
 
     @Test
     public void startContainerWithRandomPortBindings() throws DockerException {
 
-        ExposedPort tcp22 = ExposedPort.tcp(22);
-        ExposedPort tcp23 = ExposedPort.tcp(23);
+        ExposedPort tcp22 = ExposedPort.tcp("22");
+        ExposedPort tcp23 = ExposedPort.tcp("23");
 
         Ports portBindings = new Ports();
         portBindings.bind(tcp22, Ports.binding(null));
@@ -253,12 +244,12 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
     @Test
     public void startContainerWithConflictingPortBindings() throws DockerException {
 
-        ExposedPort tcp22 = ExposedPort.tcp(22);
-        ExposedPort tcp23 = ExposedPort.tcp(23);
+        ExposedPort tcp22 = ExposedPort.tcp("22");
+        ExposedPort tcp23 = ExposedPort.tcp("23");
 
         Ports portBindings = new Ports();
-        portBindings.bind(tcp22, Ports.binding(11022));
-        portBindings.bind(tcp23, Ports.binding(11022));
+        portBindings.bind(tcp22, Ports.binding("11022"));
+        portBindings.bind(tcp23, Ports.binding("11022"));
 
         CreateContainerResponse container = dockerClient.createContainerCmd("busybox").withCmd("true")
                 .withExposedPorts(tcp22, tcp23).withPortBindings(portBindings).exec();

--- a/src/test/java/com/github/dockerjava/netty/exec/BuildImageCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/BuildImageCmdExecTest.java
@@ -255,7 +255,7 @@ public class BuildImageCmdExecTest extends AbstractNettyDockerClientTest {
         CreateContainerResponse testregistry = dockerClient
                 .createContainerCmd("testregistry:2")
                 .withName("registry")
-                .withPortBindings(new PortBinding(new Ports.Binding(5000), ExposedPort.tcp(5000)))
+                .withPortBindings(new PortBinding(new Ports.Binding(5000), ExposedPort.tcp("5000")))
                 .withEnv("REGISTRY_AUTH=htpasswd", "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm",
                         "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd", "REGISTRY_LOG_LEVEL=debug",
                         "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt", "REGISTRY_HTTP_TLS_KEY=/certs/domain.key")

--- a/src/test/java/com/github/dockerjava/netty/exec/CreateContainerCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/CreateContainerCmdExecTest.java
@@ -1,33 +1,5 @@
 package com.github.dockerjava.netty.exec;
 
-import static com.github.dockerjava.api.model.Capability.MKNOD;
-import static com.github.dockerjava.api.model.Capability.NET_ADMIN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItemInArray;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.startsWith;
-
-import java.lang.reflect.Method;
-import java.security.SecureRandom;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
-import org.testng.ITestResult;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.exception.ConflictException;
@@ -43,6 +15,24 @@ import com.github.dockerjava.api.model.Ulimit;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.api.model.VolumesFrom;
 import com.github.dockerjava.netty.AbstractNettyDockerClientTest;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.github.dockerjava.api.model.Capability.MKNOD;
+import static com.github.dockerjava.api.model.Capability.NET_ADMIN;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 @Test(groups = "integration")
 public class CreateContainerCmdExecTest extends AbstractNettyDockerClientTest {
@@ -348,13 +338,13 @@ public class CreateContainerCmdExecTest extends AbstractNettyDockerClientTest {
     @Test
     public void createContainerWithPortBindings() throws DockerException {
 
-        ExposedPort tcp22 = ExposedPort.tcp(22);
-        ExposedPort tcp23 = ExposedPort.tcp(23);
+        ExposedPort tcp22 = ExposedPort.tcp("22");
+        ExposedPort tcp23 = ExposedPort.tcp("23");
 
         Ports portBindings = new Ports();
-        portBindings.bind(tcp22, Ports.binding(11022));
-        portBindings.bind(tcp23, Ports.binding(11023));
-        portBindings.bind(tcp23, Ports.binding(11024));
+        portBindings.bind(tcp22, Ports.binding("11022"));
+        portBindings.bind(tcp23, Ports.binding("11023"));
+        portBindings.bind(tcp23, Ports.binding("11024"));
 
         CreateContainerResponse container = dockerClient.createContainerCmd("busybox").withCmd("true")
                 .withExposedPorts(tcp22, tcp23).withPortBindings(portBindings).exec();
@@ -368,13 +358,13 @@ public class CreateContainerCmdExecTest extends AbstractNettyDockerClientTest {
         assertThat(Arrays.asList(inspectContainerResponse.getConfig().getExposedPorts()), contains(tcp22, tcp23));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp22)[0],
-                is(equalTo(Ports.binding(11022))));
+                is(equalTo(Ports.binding("11022"))));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23)[0],
-                is(equalTo(Ports.binding(11023))));
+                is(equalTo(Ports.binding("11023"))));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23)[1],
-                is(equalTo(Ports.binding(11024))));
+                is(equalTo(Ports.binding("11024"))));
 
     }
 


### PR DESCRIPTION
This is a fix for #556 allowing port ranges.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/565)
<!-- Reviewable:end -->
