### PR TITLE
Work on port ranges - change all to strings

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/ExposedPort.java
+++ b/src/main/java/com/github/dockerjava/api/model/ExposedPort.java
@@ -65,7 +65,7 @@ public class ExposedPort {
      * @param scheme
      *            the {@link #getScheme() scheme}, <code>tcp</code> or <code>udp</code>
      * @param port
-     *            the {@link #getPort() port number}
+     *            the {@link #getPort() port number or port range}
      * @deprecated use {@link #ExposedPort(int, InternetProtocol)}
      */
     @Deprecated
@@ -124,9 +124,9 @@ public class ExposedPort {
             String[] parts = serialized.split("/");
             switch (parts.length) {
                 case 1:
-                    return new ExposedPort(Integer.valueOf(parts[0]));
+                    return new ExposedPort(Integer.parseInt(parts[0]));
                 case 2:
-                    return new ExposedPort(Integer.valueOf(parts[0]), InternetProtocol.parse(parts[1]));
+                    return new ExposedPort(Integer.parseInt(parts[0]), InternetProtocol.parse(parts[1]));
                 default:
                     throw new IllegalArgumentException();
             }

--- a/src/test/java/com/github/dockerjava/api/command/InspectContainerResponseTest.java
+++ b/src/test/java/com/github/dockerjava/api/command/InspectContainerResponseTest.java
@@ -25,7 +25,9 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsNot.not;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Tests for {@link InspectContainerResponse}.

--- a/src/test/java/com/github/dockerjava/api/model/BindingTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/BindingTest.java
@@ -10,12 +10,12 @@ public class BindingTest {
 
     @Test
     public void parseIpAndPort() {
-        assertEquals(Binding.parse("127.0.0.1:80"), Ports.binding("127.0.0.1", 80));
+        assertEquals(Binding.parse("127.0.0.1:80"), Ports.binding("127.0.0.1", "80"));
     }
 
     @Test
     public void parsePortOnly() {
-        assertEquals(Binding.parse("80"), Ports.binding(null, 80));
+        assertEquals(Binding.parse("80"), Ports.binding(null, "80"));
     }
 
     @Test
@@ -28,7 +28,8 @@ public class BindingTest {
         assertEquals(Binding.parse(""), Ports.binding(null, null));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Error parsing Binding 'nonsense'")
+    // Strings can be used since it can be a range. Let the docker daemon do the validation.
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Error parsing Binding 'nonsense'", enabled = false)
     public void parseInvalidInput() {
         Binding.parse("nonsense");
     }

--- a/src/test/java/com/github/dockerjava/api/model/PortBindingTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/PortBindingTest.java
@@ -13,22 +13,22 @@ public class PortBindingTest {
     @Test
     public void fullDefinition() {
         assertEquals(PortBinding.parse("127.0.0.1:80:8080/tcp"),
-                new PortBinding(new Binding("127.0.0.1", 80), TCP_8080));
+                new PortBinding(new Binding("127.0.0.1", "80"), TCP_8080));
     }
 
     @Test
     public void noProtocol() {
-        assertEquals(PortBinding.parse("127.0.0.1:80:8080"), new PortBinding(new Binding("127.0.0.1", 80), TCP_8080));
+        assertEquals(PortBinding.parse("127.0.0.1:80:8080"), new PortBinding(new Binding("127.0.0.1", "80"), TCP_8080));
     }
 
     @Test
     public void noHostIp() {
-        assertEquals(PortBinding.parse("80:8080/tcp"), new PortBinding(new Binding(80), TCP_8080));
+        assertEquals(PortBinding.parse("80:8080/tcp"), new PortBinding(Binding.forPort("80"), TCP_8080));
     }
 
     @Test
     public void portsOnly() {
-        assertEquals(PortBinding.parse("80:8080"), new PortBinding(new Binding(80), TCP_8080));
+        assertEquals(PortBinding.parse("80:8080"), new PortBinding(Binding.forPort("80"), TCP_8080));
     }
 
     @Test
@@ -38,10 +38,10 @@ public class PortBindingTest {
 
     @Test
     public void dynamicHostPort() {
-        assertEquals(PortBinding.parse("127.0.0.1::8080"), new PortBinding(new Binding("127.0.0.1"), TCP_8080));
+        assertEquals(PortBinding.parse("127.0.0.1::8080"), new PortBinding(Binding.forIp("127.0.0.1"), TCP_8080));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Error parsing PortBinding 'nonsense'")
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Error parsing PortBinding 'nonsense'", enabled = false)
     public void parseInvalidInput() {
         PortBinding.parse("nonsense");
     }

--- a/src/test/java/com/github/dockerjava/api/model/Ports_SerializingTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/Ports_SerializingTest.java
@@ -1,13 +1,12 @@
 package com.github.dockerjava.api.model;
 
-import static org.testng.Assert.assertEquals;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dockerjava.api.model.Ports.Binding;
+import org.testng.annotations.Test;
 
 import java.util.Map;
 
-import org.testng.annotations.Test;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.dockerjava.api.model.Ports.Binding;
+import static org.testng.Assert.assertEquals;
 
 public class Ports_SerializingTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -24,15 +23,15 @@ public class Ports_SerializingTest {
 
         Binding[] bindings = map.get(ExposedPort.tcp(80));
         assertEquals(bindings.length, 2);
-        assertEquals(bindings[0], new Binding("10.0.0.1", 80));
-        assertEquals(bindings[1], new Binding("10.0.0.2", 80));
+        assertEquals(bindings[0], new Binding("10.0.0.1", "80"));
+        assertEquals(bindings[1], new Binding("10.0.0.2", "80"));
     }
 
     @Test
     public void serializingPortWithMultipleBindings() throws Exception {
         Ports ports = new Ports();
-        ports.bind(ExposedPort.tcp(80), new Binding("10.0.0.1", 80));
-        ports.bind(ExposedPort.tcp(80), new Binding("10.0.0.2", 80));
+        ports.bind(ExposedPort.tcp(80), new Binding("10.0.0.1", "80"));
+        ports.bind(ExposedPort.tcp(80), new Binding("10.0.0.2", "80"));
         assertEquals(objectMapper.writeValueAsString(ports), jsonWithDoubleBindingForOnePort);
     }
 

--- a/src/test/java/com/github/dockerjava/api/model/Ports_addBindingsTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/Ports_addBindingsTest.java
@@ -1,13 +1,12 @@
 package com.github.dockerjava.api.model;
 
-import static org.testng.Assert.assertEquals;
-
-import java.util.Map;
-
+import com.github.dockerjava.api.model.Ports.Binding;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.github.dockerjava.api.model.Ports.Binding;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
 
 /**
  * As there may be several {@link Binding}s per {@link ExposedPort}, it makes a difference if you add {@link PortBinding}s for the same or
@@ -18,9 +17,9 @@ public class Ports_addBindingsTest {
 
     private static final ExposedPort TCP_90 = ExposedPort.tcp(90);
 
-    private static final Binding BINDING_8080 = Ports.binding(8080);
+    private static final Binding BINDING_8080 = Ports.binding("8080");
 
-    private static final Binding BINDING_9090 = Ports.binding(9090);
+    private static final Binding BINDING_9090 = Ports.binding("9090");
 
     private Ports ports;
 

--- a/src/test/java/com/github/dockerjava/core/TestDockerCmdExecFactory.java
+++ b/src/test/java/com/github/dockerjava/core/TestDockerCmdExecFactory.java
@@ -1,16 +1,68 @@
 package com.github.dockerjava.core;
 
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.AttachContainerCmd;
+import com.github.dockerjava.api.command.AuthCmd.Exec;
+import com.github.dockerjava.api.command.BuildImageCmd;
+import com.github.dockerjava.api.command.CommitCmd;
+import com.github.dockerjava.api.command.ConnectToNetworkCmd;
+import com.github.dockerjava.api.command.ContainerDiffCmd;
+import com.github.dockerjava.api.command.CopyArchiveFromContainerCmd;
+import com.github.dockerjava.api.command.CopyArchiveToContainerCmd;
+import com.github.dockerjava.api.command.CopyFileFromContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.command.CreateImageCmd;
+import com.github.dockerjava.api.command.CreateImageResponse;
+import com.github.dockerjava.api.command.CreateNetworkCmd;
+import com.github.dockerjava.api.command.CreateNetworkResponse;
+import com.github.dockerjava.api.command.CreateVolumeCmd;
+import com.github.dockerjava.api.command.CreateVolumeResponse;
+import com.github.dockerjava.api.command.DisconnectFromNetworkCmd;
+import com.github.dockerjava.api.command.DockerCmdExecFactory;
+import com.github.dockerjava.api.command.EventsCmd;
+import com.github.dockerjava.api.command.ExecCreateCmd;
+import com.github.dockerjava.api.command.ExecStartCmd;
+import com.github.dockerjava.api.command.InfoCmd;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectExecCmd;
+import com.github.dockerjava.api.command.InspectImageCmd;
+import com.github.dockerjava.api.command.InspectNetworkCmd;
+import com.github.dockerjava.api.command.InspectVolumeCmd;
+import com.github.dockerjava.api.command.KillContainerCmd;
+import com.github.dockerjava.api.command.ListContainersCmd;
+import com.github.dockerjava.api.command.ListImagesCmd;
+import com.github.dockerjava.api.command.ListNetworksCmd;
+import com.github.dockerjava.api.command.ListVolumesCmd;
+import com.github.dockerjava.api.command.LogContainerCmd;
+import com.github.dockerjava.api.command.PauseContainerCmd;
+import com.github.dockerjava.api.command.PingCmd;
+import com.github.dockerjava.api.command.PullImageCmd;
+import com.github.dockerjava.api.command.PushImageCmd;
+import com.github.dockerjava.api.command.RemoveContainerCmd;
+import com.github.dockerjava.api.command.RemoveImageCmd;
+import com.github.dockerjava.api.command.RemoveNetworkCmd;
+import com.github.dockerjava.api.command.RemoveVolumeCmd;
+import com.github.dockerjava.api.command.RenameContainerCmd;
+import com.github.dockerjava.api.command.RestartContainerCmd;
+import com.github.dockerjava.api.command.SaveImageCmd;
+import com.github.dockerjava.api.command.SearchImagesCmd;
+import com.github.dockerjava.api.command.StartContainerCmd;
+import com.github.dockerjava.api.command.StatsCmd;
+import com.github.dockerjava.api.command.StopContainerCmd;
+import com.github.dockerjava.api.command.TagImageCmd;
+import com.github.dockerjava.api.command.TopContainerCmd;
+import com.github.dockerjava.api.command.UnpauseContainerCmd;
+import com.github.dockerjava.api.command.UpdateContainerCmd;
+import com.github.dockerjava.api.command.VersionCmd;
+import com.github.dockerjava.api.command.WaitContainerCmd;
+import com.github.dockerjava.api.model.BuildResponseItem;
+
+import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
-
-import javax.net.ssl.SSLContext;
-
-import com.github.dockerjava.api.async.ResultCallback;
-import com.github.dockerjava.api.command.*;
-import com.github.dockerjava.api.command.AuthCmd.Exec;
-import com.github.dockerjava.api.model.BuildResponseItem;
 
 /**
  * Special {@link DockerCmdExecFactory} implementation that collects container and image creations while test execution for the purpose of

--- a/src/test/java/com/github/dockerjava/core/command/BuildImageCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/BuildImageCmdImplTest.java
@@ -263,7 +263,7 @@ public class BuildImageCmdImplTest extends AbstractDockerClientTest {
         CreateContainerResponse testregistry = dockerClient
                 .createContainerCmd("testregistry:2")
                 .withName("registry")
-                .withPortBindings(new PortBinding(new Ports.Binding(5000), ExposedPort.tcp(5000)))
+                .withPortBindings(new PortBinding(Ports.Binding.forPort("5000"), ExposedPort.tcp(5000)))
                 .withEnv("REGISTRY_AUTH=htpasswd", "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm",
                         "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd", "REGISTRY_LOG_LEVEL=debug",
                         "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt", "REGISTRY_HTTP_TLS_KEY=/certs/domain.key")

--- a/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
@@ -361,9 +361,9 @@ public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
         ExposedPort tcp23 = ExposedPort.tcp(23);
 
         Ports portBindings = new Ports();
-        portBindings.bind(tcp22, Ports.binding(11022));
-        portBindings.bind(tcp23, Ports.binding(11023));
-        portBindings.bind(tcp23, Ports.binding(11024));
+        portBindings.bind(tcp22, Ports.binding("11022"));
+        portBindings.bind(tcp23, Ports.binding("11023"));
+        portBindings.bind(tcp23, Ports.binding("11024"));
 
         CreateContainerResponse container = dockerClient.createContainerCmd(BUSYBOX_IMAGE).withCmd("true")
                 .withExposedPorts(tcp22, tcp23).withPortBindings(portBindings).exec();
@@ -377,13 +377,13 @@ public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
         assertThat(Arrays.asList(inspectContainerResponse.getConfig().getExposedPorts()), contains(tcp22, tcp23));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp22)[0],
-                is(equalTo(Ports.binding(11022))));
+                is(equalTo(Ports.binding("11022"))));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23)[0],
-                is(equalTo(Ports.binding(11023))));
+                is(equalTo(Ports.binding("11023"))));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23)[1],
-                is(equalTo(Ports.binding(11024))));
+                is(equalTo(Ports.binding("11024"))));
 
     }
 

--- a/src/test/java/com/github/dockerjava/core/command/RenameContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/RenameContainerCmdImplTest.java
@@ -6,12 +6,17 @@ import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.client.AbstractDockerClientTest;
 import org.testng.ITestResult;
-import org.testng.annotations.*;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.not;
 
 @Test(groups = "integration")
 public class RenameContainerCmdImplTest extends AbstractDockerClientTest {

--- a/src/test/java/com/github/dockerjava/core/command/StartContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/StartContainerCmdImplTest.java
@@ -1,31 +1,5 @@
 package com.github.dockerjava.core.command;
 
-import static com.github.dockerjava.api.model.AccessMode.ro;
-import static com.github.dockerjava.api.model.Capability.MKNOD;
-import static com.github.dockerjava.api.model.Capability.NET_ADMIN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.startsWith;
-
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-
-import org.testng.ITestResult;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
@@ -42,6 +16,31 @@ import com.github.dockerjava.api.model.RestartPolicy;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.api.model.VolumesFrom;
 import com.github.dockerjava.client.AbstractDockerClientTest;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static com.github.dockerjava.api.model.AccessMode.ro;
+import static com.github.dockerjava.api.model.Capability.MKNOD;
+import static com.github.dockerjava.api.model.Capability.NET_ADMIN;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
 
 @Test(groups = "integration")
 public class StartContainerCmdImplTest extends AbstractDockerClientTest {
@@ -189,9 +188,9 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
         ExposedPort tcp23 = ExposedPort.tcp(23);
 
         Ports portBindings = new Ports();
-        portBindings.bind(tcp22, Ports.binding(11022));
-        portBindings.bind(tcp23, Ports.binding(11023));
-        portBindings.bind(tcp23, Ports.binding(11024));
+        portBindings.bind(tcp22, Ports.binding("11022"));
+        portBindings.bind(tcp23, Ports.binding("11023"));
+        portBindings.bind(tcp23, Ports.binding("11024"));
 
         CreateContainerResponse container = dockerClient.createContainerCmd("busybox").withCmd("true")
                 .withExposedPorts(tcp22, tcp23).withPortBindings(portBindings).exec();
@@ -209,13 +208,13 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
         assertThat(Arrays.asList(inspectContainerResponse.getConfig().getExposedPorts()), contains(tcp22, tcp23));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp22)[0],
-                is(equalTo(Ports.binding(11022))));
+                is(equalTo(Ports.binding("11022"))));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23)[0],
-                is(equalTo(Ports.binding(11023))));
+                is(equalTo(Ports.binding("11023"))));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23)[1],
-                is(equalTo(Ports.binding(11024))));
+                is(equalTo(Ports.binding("11024"))));
 
     }
 
@@ -243,10 +242,10 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
         assertThat(Arrays.asList(inspectContainerResponse.getConfig().getExposedPorts()), contains(tcp22, tcp23));
 
         assertThat(inspectContainerResponse.getNetworkSettings().getPorts().getBindings().get(tcp22)[0].getHostPort(),
-                is(not(equalTo(tcp22.getPort()))));
+                is(not(equalTo(String.valueOf(tcp22.getPort())))));
 
         assertThat(inspectContainerResponse.getNetworkSettings().getPorts().getBindings().get(tcp23)[0].getHostPort(),
-                is(not(equalTo(tcp23.getPort()))));
+                is(not(equalTo(String.valueOf(tcp23.getPort())))));
 
     }
 
@@ -257,8 +256,8 @@ public class StartContainerCmdImplTest extends AbstractDockerClientTest {
         ExposedPort tcp23 = ExposedPort.tcp(23);
 
         Ports portBindings = new Ports();
-        portBindings.bind(tcp22, Ports.binding(11022));
-        portBindings.bind(tcp23, Ports.binding(11022));
+        portBindings.bind(tcp22, Ports.binding("11022"));
+        portBindings.bind(tcp23, Ports.binding("11022"));
 
         CreateContainerResponse container = dockerClient.createContainerCmd("busybox").withCmd("true")
                 .withExposedPorts(tcp22, tcp23).withPortBindings(portBindings).exec();

--- a/src/test/java/com/github/dockerjava/core/util/FiltersBuilderTest.java
+++ b/src/test/java/com/github/dockerjava/core/util/FiltersBuilderTest.java
@@ -1,13 +1,12 @@
 package com.github.dockerjava.core.util;
 
-import com.github.dockerjava.core.util.FiltersBuilder;
 import com.google.common.collect.Maps;
-
 import org.testng.annotations.Test;
 
 import java.util.Map;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
 /**
  * @author Vincent Latombe <vincent@latombe.net>

--- a/src/test/java/com/github/dockerjava/netty/exec/BuildImageCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/BuildImageCmdExecTest.java
@@ -255,7 +255,7 @@ public class BuildImageCmdExecTest extends AbstractNettyDockerClientTest {
         CreateContainerResponse testregistry = dockerClient
                 .createContainerCmd("testregistry:2")
                 .withName("registry")
-                .withPortBindings(new PortBinding(new Ports.Binding(5000), ExposedPort.tcp(5000)))
+                .withPortBindings(new PortBinding(Ports.Binding.forPort("5000"), ExposedPort.tcp(5000)))
                 .withEnv("REGISTRY_AUTH=htpasswd", "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm",
                         "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd", "REGISTRY_LOG_LEVEL=debug",
                         "REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt", "REGISTRY_HTTP_TLS_KEY=/certs/domain.key")

--- a/src/test/java/com/github/dockerjava/netty/exec/CreateContainerCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/CreateContainerCmdExecTest.java
@@ -1,33 +1,5 @@
 package com.github.dockerjava.netty.exec;
 
-import static com.github.dockerjava.api.model.Capability.MKNOD;
-import static com.github.dockerjava.api.model.Capability.NET_ADMIN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItemInArray;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.startsWith;
-
-import java.lang.reflect.Method;
-import java.security.SecureRandom;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
-import org.testng.ITestResult;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.exception.ConflictException;
@@ -43,6 +15,33 @@ import com.github.dockerjava.api.model.Ulimit;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.api.model.VolumesFrom;
 import com.github.dockerjava.netty.AbstractNettyDockerClientTest;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.github.dockerjava.api.model.Capability.MKNOD;
+import static com.github.dockerjava.api.model.Capability.NET_ADMIN;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
 
 @Test(groups = "integration")
 public class CreateContainerCmdExecTest extends AbstractNettyDockerClientTest {
@@ -352,9 +351,9 @@ public class CreateContainerCmdExecTest extends AbstractNettyDockerClientTest {
         ExposedPort tcp23 = ExposedPort.tcp(23);
 
         Ports portBindings = new Ports();
-        portBindings.bind(tcp22, Ports.binding(11022));
-        portBindings.bind(tcp23, Ports.binding(11023));
-        portBindings.bind(tcp23, Ports.binding(11024));
+        portBindings.bind(tcp22, Ports.binding("11022"));
+        portBindings.bind(tcp23, Ports.binding("11023"));
+        portBindings.bind(tcp23, Ports.binding("11024"));
 
         CreateContainerResponse container = dockerClient.createContainerCmd("busybox").withCmd("true")
                 .withExposedPorts(tcp22, tcp23).withPortBindings(portBindings).exec();
@@ -368,13 +367,13 @@ public class CreateContainerCmdExecTest extends AbstractNettyDockerClientTest {
         assertThat(Arrays.asList(inspectContainerResponse.getConfig().getExposedPorts()), contains(tcp22, tcp23));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp22)[0],
-                is(equalTo(Ports.binding(11022))));
+                is(equalTo(Ports.binding("11022"))));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23)[0],
-                is(equalTo(Ports.binding(11023))));
+                is(equalTo(Ports.binding("11023"))));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23)[1],
-                is(equalTo(Ports.binding(11024))));
+                is(equalTo(Ports.binding("11024"))));
 
     }
 

--- a/src/test/java/com/github/dockerjava/netty/exec/RenameContainerCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/RenameContainerCmdExecTest.java
@@ -6,12 +6,17 @@ import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.netty.AbstractNettyDockerClientTest;
 import org.testng.ITestResult;
-import org.testng.annotations.*;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.not;
 
 @Test(groups = "integration")
 public class RenameContainerCmdExecTest extends AbstractNettyDockerClientTest {

--- a/src/test/java/com/github/dockerjava/netty/exec/StartContainerCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/StartContainerCmdExecTest.java
@@ -1,31 +1,5 @@
 package com.github.dockerjava.netty.exec;
 
-import static com.github.dockerjava.api.model.AccessMode.ro;
-import static com.github.dockerjava.api.model.Capability.MKNOD;
-import static com.github.dockerjava.api.model.Capability.NET_ADMIN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyString;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.startsWith;
-
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
-
-import org.testng.ITestResult;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
@@ -43,6 +17,31 @@ import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.api.model.VolumesFrom;
 import com.github.dockerjava.core.command.WaitContainerResultCallback;
 import com.github.dockerjava.netty.AbstractNettyDockerClientTest;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static com.github.dockerjava.api.model.AccessMode.ro;
+import static com.github.dockerjava.api.model.Capability.MKNOD;
+import static com.github.dockerjava.api.model.Capability.NET_ADMIN;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
 
 @Test(groups = "integration")
 public class StartContainerCmdExecTest extends AbstractNettyDockerClientTest {
@@ -192,9 +191,9 @@ public class StartContainerCmdExecTest extends AbstractNettyDockerClientTest {
         ExposedPort tcp23 = ExposedPort.tcp(23);
 
         Ports portBindings = new Ports();
-        portBindings.bind(tcp22, Ports.binding(11022));
-        portBindings.bind(tcp23, Ports.binding(11023));
-        portBindings.bind(tcp23, Ports.binding(11024));
+        portBindings.bind(tcp22, Ports.binding("11022"));
+        portBindings.bind(tcp23, Ports.binding("11023"));
+        portBindings.bind(tcp23, Ports.binding("11024"));
 
         CreateContainerResponse container = dockerClient.createContainerCmd("busybox").withCmd("true")
                 .withExposedPorts(tcp22, tcp23).withPortBindings(portBindings).exec();
@@ -212,13 +211,13 @@ public class StartContainerCmdExecTest extends AbstractNettyDockerClientTest {
         assertThat(Arrays.asList(inspectContainerResponse.getConfig().getExposedPorts()), contains(tcp22, tcp23));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp22)[0],
-                is(equalTo(Ports.binding(11022))));
+                is(equalTo(Ports.binding("11022"))));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23)[0],
-                is(equalTo(Ports.binding(11023))));
+                is(equalTo(Ports.binding("11023"))));
 
         assertThat(inspectContainerResponse.getHostConfig().getPortBindings().getBindings().get(tcp23)[1],
-                is(equalTo(Ports.binding(11024))));
+                is(equalTo(Ports.binding("11024"))));
 
     }
 
@@ -246,10 +245,10 @@ public class StartContainerCmdExecTest extends AbstractNettyDockerClientTest {
         assertThat(Arrays.asList(inspectContainerResponse.getConfig().getExposedPorts()), contains(tcp22, tcp23));
 
         assertThat(inspectContainerResponse.getNetworkSettings().getPorts().getBindings().get(tcp22)[0].getHostPort(),
-                is(not(equalTo(tcp22.getPort()))));
+                is(not(equalTo(String.valueOf(tcp22.getPort())))));
 
         assertThat(inspectContainerResponse.getNetworkSettings().getPorts().getBindings().get(tcp23)[0].getHostPort(),
-                is(not(equalTo(tcp23.getPort()))));
+                is(not(equalTo(String.valueOf(tcp23.getPort())))));
 
     }
 
@@ -260,8 +259,8 @@ public class StartContainerCmdExecTest extends AbstractNettyDockerClientTest {
         ExposedPort tcp23 = ExposedPort.tcp(23);
 
         Ports portBindings = new Ports();
-        portBindings.bind(tcp22, Ports.binding(11022));
-        portBindings.bind(tcp23, Ports.binding(11022));
+        portBindings.bind(tcp22, Ports.binding("11022"));
+        portBindings.bind(tcp23, Ports.binding("11022"));
 
         CreateContainerResponse container = dockerClient.createContainerCmd("busybox").withCmd("true")
                 .withExposedPorts(tcp22, tcp23).withPortBindings(portBindings).exec();


### PR DESCRIPTION
This is a fix for #556 allowing port ranges.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/566)
<!-- Reviewable:end -->
