### PR TITLE
Docker inspect command now shows sizes if request.

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/InspectContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/InspectContainerCmd.java
@@ -12,6 +12,10 @@ public interface InspectContainerCmd extends SyncDockerCmd<InspectContainerRespo
 
     InspectContainerCmd withContainerId(@Nonnull String containerId);
 
+    InspectContainerCmd withSize(Boolean showSize);
+
+    boolean getSize();
+
     /**
      * @throws NotFoundException
      *             No such container

--- a/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
+++ b/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
@@ -56,6 +56,9 @@ public class InspectContainerResponse {
     @JsonProperty("Id")
     private String id;
 
+    @JsonProperty("SizeRootFs")
+    private Integer sizeRootFs;
+
     @JsonProperty("Image")
     private String imageId;
 
@@ -100,6 +103,10 @@ public class InspectContainerResponse {
 
     public String getId() {
         return id;
+    }
+
+    public Integer getSizeRootFs() {
+        return  sizeRootFs;
     }
 
     public String getCreated() {

--- a/src/main/java/com/github/dockerjava/core/command/InspectContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/InspectContainerCmdImpl.java
@@ -13,6 +13,7 @@ public class InspectContainerCmdImpl extends AbstrDockerCmd<InspectContainerCmd,
         InspectContainerCmd {
 
     private String containerId;
+    private boolean size;
 
     public InspectContainerCmdImpl(InspectContainerCmd.Exec exec, String containerId) {
         super(exec);
@@ -29,6 +30,17 @@ public class InspectContainerCmdImpl extends AbstrDockerCmd<InspectContainerCmd,
         checkNotNull(containerId, "containerId was not specified");
         this.containerId = containerId;
         return this;
+    }
+
+    @Override
+    public InspectContainerCmd withSize(Boolean showSize) {
+        this.size = showSize;
+        return this;
+    }
+
+    @Override
+    public boolean getSize() {
+        return size;
     }
 
     /**

--- a/src/main/java/com/github/dockerjava/jaxrs/InspectContainerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/InspectContainerCmdExec.java
@@ -21,8 +21,9 @@ public class InspectContainerCmdExec extends AbstrSyncDockerCmdExec<InspectConta
 
     @Override
     protected InspectContainerResponse execute(InspectContainerCmd command) {
-        WebTarget webResource = getBaseResource().path("/containers/{id}/json").resolveTemplate("id",
-                command.getContainerId());
+        WebTarget webResource = getBaseResource().path("/containers/{id}/json")
+                                                 .queryParam("size", command.getSize())
+                                                 .resolveTemplate("id", command.getContainerId());
 
         LOGGER.debug("GET: {}", webResource);
         return webResource.request().accept(MediaType.APPLICATION_JSON).get(InspectContainerResponse.class);

--- a/src/test/java/com/github/dockerjava/core/command/InspectContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/InspectContainerCmdImplTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.not;
 import java.lang.reflect.Method;
 import java.security.SecureRandom;
 
+import com.github.dockerjava.api.command.InspectContainerCmd;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.ITestResult;
@@ -73,11 +74,12 @@ public class InspectContainerCmdImplTest extends AbstractDockerClientTest {
         LOG.info("Created container {}", container.toString());
         assertThat(container.getId(), not(isEmptyString()));
 
-        InspectContainerResponse containerInfo = dockerClient.inspectContainerCmd(container.getId())
-                                                             .withSize(true)
-                                                             .exec();
-        assertNotNull(containerInfo.getSizeRootFs());
+        InspectContainerCmd command = dockerClient.inspectContainerCmd(container.getId()).withSize(true);
+        assertTrue(command.getSize());
+        InspectContainerResponse containerInfo  = command.exec();
         assertEquals(containerInfo.getId(), container.getId());
+        assertNotNull(containerInfo.getSizeRootFs());
+        assertTrue(containerInfo.getSizeRootFs().intValue() > 0 );
     }
 
     @Test(expectedExceptions = NotFoundException.class)

--- a/src/test/java/com/github/dockerjava/core/command/InspectContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/InspectContainerCmdImplTest.java
@@ -63,6 +63,23 @@ public class InspectContainerCmdImplTest extends AbstractDockerClientTest {
 
     }
 
+    @Test()
+    public void inspectContainerWithSize() throws DockerException {
+
+        String containerName = "generated_" + new SecureRandom().nextInt();
+
+        CreateContainerResponse container = dockerClient.createContainerCmd("busybox").withCmd("top")
+                .withName(containerName).exec();
+        LOG.info("Created container {}", container.toString());
+        assertThat(container.getId(), not(isEmptyString()));
+
+        InspectContainerResponse containerInfo = dockerClient.inspectContainerCmd(container.getId())
+                                                             .withSize(true)
+                                                             .exec();
+        assertNotNull(containerInfo.getSizeRootFs());
+        assertEquals(containerInfo.getId(), container.getId());
+    }
+
     @Test(expectedExceptions = NotFoundException.class)
     public void inspectNonExistingContainer() throws DockerException {
         dockerClient.inspectContainerCmd("non-existing").exec();

--- a/src/test/java/com/github/dockerjava/netty/exec/InspectContainerCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/InspectContainerCmdExecTest.java
@@ -63,6 +63,21 @@ public class InspectContainerCmdExecTest extends AbstractNettyDockerClientTest {
 
     }
 
+    @Test()
+    public void inspectContainerWithSize() throws DockerException {
+
+        String containerName = "generated_" + new SecureRandom().nextInt();
+
+        CreateContainerResponse container = dockerClient.createContainerCmd("busybox").withCmd("top")
+                .withName(containerName).exec();
+        LOG.info("Created container {}", container.toString());
+        assertThat(container.getId(), not(isEmptyString()));
+
+        InspectContainerResponse containerInfo = dockerClient.inspectContainerCmd(container.getId()).exec();
+        assertEquals(containerInfo.getId(), container.getId());
+        assertNotNull(containerInfo.getSizeRootFs());
+    }
+
     @Test(expectedExceptions = NotFoundException.class)
     public void inspectNonExistingContainer() throws DockerException {
         dockerClient.inspectContainerCmd("non-existing").exec();

--- a/src/test/java/com/github/dockerjava/netty/exec/InspectContainerCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/InspectContainerCmdExecTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.not;
 import java.lang.reflect.Method;
 import java.security.SecureRandom;
 
+import com.github.dockerjava.api.command.InspectContainerCmd;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.ITestResult;
@@ -73,9 +74,13 @@ public class InspectContainerCmdExecTest extends AbstractNettyDockerClientTest {
         LOG.info("Created container {}", container.toString());
         assertThat(container.getId(), not(isEmptyString()));
 
-        InspectContainerResponse containerInfo = dockerClient.inspectContainerCmd(container.getId()).exec();
+        InspectContainerCmd command = dockerClient.inspectContainerCmd(container.getId())
+                                                      .withSize(true);
+        assertTrue(command.getSize());
+        InspectContainerResponse containerInfo  = command.exec();
         assertEquals(containerInfo.getId(), container.getId());
         assertNotNull(containerInfo.getSizeRootFs());
+        assertTrue(containerInfo.getSizeRootFs().intValue() > 0 );
     }
 
     @Test(expectedExceptions = NotFoundException.class)


### PR DESCRIPTION
As I understand the docker command line interface, you can request the current size of an Image. I did not see this functionality in your API, but needed it for a project and have added it myself. Please feel free to copy it & thanks for your hard work :-)

Best wishes, 

AE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/572)
<!-- Reviewable:end -->
