### PR TITLE
Adds name filter to netty's image listing

### DIFF
--- a/src/main/java/com/github/dockerjava/netty/exec/ListImagesCmdExec.java
+++ b/src/main/java/com/github/dockerjava/netty/exec/ListImagesCmdExec.java
@@ -33,6 +33,10 @@ public class ListImagesCmdExec extends AbstrSyncDockerCmdExec<ListImagesCmd, Lis
             webTarget = webTarget.queryParam("filters", urlPathSegmentEscaper().escape(FiltersEncoder.jsonEncode(command.getFilters())));
         }
 
+       if (command.getImageNameFilter() != null) {
+            webTarget = webTarget.queryParam("filter", urlPathSegmentEscaper().escape(command.getImageNameFilter()));
+       }
+
         LOGGER.trace("GET: {}", webTarget);
 
         List<Image> images = webTarget.request().accept(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/github/dockerjava/netty/exec/ListImagesCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/ListImagesCmdExecTest.java
@@ -75,6 +75,18 @@ public class ListImagesCmdExecTest extends AbstractNettyDockerClientTest {
         assertTrue(imageInFilteredList);
     }
 
+    @Test
+    public void listImagesWithNameFilter() throws DockerException {
+        String imageId = createDanglingImage();
+        dockerClient.tagImageCmd(imageId, "test_repository", "latest").exec();
+        List<Image> images = dockerClient.listImagesCmd().withImageNameFilter("test_repository:latest").exec();
+        assertThat(images, notNullValue());
+        LOG.info("Images List: {}", images);
+        assertThat(images.size(), is(equalTo(1)));
+        Boolean imageInFilteredList = isImageInFilteredList(images, imageId);
+        assertTrue(imageInFilteredList);
+    }
+
     private boolean isImageInFilteredList(List<Image> images, String expectedImageId) {
         for (Image image : images) {
             if (expectedImageId.equals(image.getId())) {


### PR DESCRIPTION
Hi,  

previously just `jaxrs` had implemented the feature of filtering by image name. Even though the `withFilter` was exposed, netty's implementation didn't checked for its presence, thus, it didn't include it in the request.

The PR adds a test for such feature and the correction to the mentioned problem.

Let me know if there are any issues with it,

Thx!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/579)
<!-- Reviewable:end -->
