### PR TITLE
Fixes execute permissions for files when copied to container.

### DIFF
--- a/src/main/java/com/github/dockerjava/core/util/CompressArchiveUtil.java
+++ b/src/main/java/com/github/dockerjava/core/util/CompressArchiveUtil.java
@@ -68,7 +68,7 @@ public class CompressArchiveUtil {
         try (TarArchiveOutputStream tarArchiveOutputStream = buildTarStream(outputPath, gZipped)) {
             if (!Files.isDirectory(inputPath)) {
                 TarArchiveEntry tarEntry = new TarArchiveEntry(inputPath.getFileName().toString());
-                if (filePath.toFile().canExecute()) {
+                if (inputPath.toFile().canExecute()) {
                     tarEntry.setMode(tarEntry.getMode() | 0755);
                 }
                 putTarEntry(tarArchiveOutputStream, tarEntry, inputPath);

--- a/src/main/java/com/github/dockerjava/core/util/CompressArchiveUtil.java
+++ b/src/main/java/com/github/dockerjava/core/util/CompressArchiveUtil.java
@@ -67,7 +67,11 @@ public class CompressArchiveUtil {
 
         try (TarArchiveOutputStream tarArchiveOutputStream = buildTarStream(outputPath, gZipped)) {
             if (!Files.isDirectory(inputPath)) {
-                putTarEntry(tarArchiveOutputStream, new TarArchiveEntry(inputPath.getFileName().toString()), inputPath);
+                TarArchiveEntry tarEntry = new TarArchiveEntry(inputPath.getFileName().toString());
+                if (filePath.toFile().canExecute()) {
+                    tarEntry.setMode(tarEntry.getMode() | 0755);
+                }
+                putTarEntry(tarArchiveOutputStream, tarEntry, inputPath);
             } else {
                 Path sourcePath = inputPath;
                 if (!childrenOnly) {

--- a/src/main/java/com/github/dockerjava/core/util/TarDirWalker.java
+++ b/src/main/java/com/github/dockerjava/core/util/TarDirWalker.java
@@ -33,8 +33,11 @@ public class TarDirWalker extends SimpleFileVisitor<Path> {
 
     @Override
     public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-        CompressArchiveUtil.putTarEntry(tarArchiveOutputStream,
-                new TarArchiveEntry(FilePathUtil.relativize(basePath, file)), file);
+        TarArchiveEntry tarEntry = new TarArchiveEntry(FilePathUtil.relativize(basePath, file));
+        if (filePath.toFile().canExecute()) {
+                tarEntry.setMode(tarEntry.getMode() | 0755);
+        }
+        CompressArchiveUtil.putTarEntry(tarArchiveOutputStream, tarEntry, file);
         return FileVisitResult.CONTINUE;
     }
 

--- a/src/main/java/com/github/dockerjava/core/util/TarDirWalker.java
+++ b/src/main/java/com/github/dockerjava/core/util/TarDirWalker.java
@@ -34,7 +34,7 @@ public class TarDirWalker extends SimpleFileVisitor<Path> {
     @Override
     public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
         TarArchiveEntry tarEntry = new TarArchiveEntry(FilePathUtil.relativize(basePath, file));
-        if (filePath.toFile().canExecute()) {
+        if (file.toFile().canExecute()) {
                 tarEntry.setMode(tarEntry.getMode() | 0755);
         }
         CompressArchiveUtil.putTarEntry(tarArchiveOutputStream, tarEntry, file);

--- a/src/test/java/com/github/dockerjava/core/command/CopyArchiveToContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/CopyArchiveToContainerCmdImplTest.java
@@ -134,19 +134,19 @@ public class CopyArchiveToContainerCmdImplTest extends AbstractDockerClientTest 
         // create a test container which starts and waits 3 seconds for the
         // script to be copied to the container's home dir and then executes it
         String containerCmd = "sleep 3; /home/" + scriptPath.getFileName().toString();
-        CreateContainerResponse container = docker.createContainerCmd("busybox")
+        CreateContainerResponse container = dockerClient.createContainerCmd("busybox")
                 .withName("test")
                 .withCmd("/bin/sh", "-c", containerCmd)
                 .exec();
         // start the container
-        docker.startContainerCmd(container.getId()).exec();
+        dockerClient.startContainerCmd(container.getId()).exec();
         // copy script to container home dir
-        docker.copyArchiveToContainerCmd(container.getId())
+        dockerClient.copyArchiveToContainerCmd(container.getId())
                 .withRemotePath("/home")
                 .withHostResource(scriptPath.toString())
                 .exec();
         // await exid code
-        int exitCode = docker.waitContainerCmd(container.getId())
+        int exitCode = dockerClient.waitContainerCmd(container.getId())
                 .exec(new WaitContainerResultCallback())
                 .awaitStatusCode();
         // check result

--- a/src/test/java/com/github/dockerjava/core/command/CopyArchiveToContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/CopyArchiveToContainerCmdImplTest.java
@@ -3,6 +3,7 @@ package com.github.dockerjava.core.command;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.equalTo;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -116,6 +117,40 @@ public class CopyArchiveToContainerCmdImplTest extends AbstractDockerClientTest 
         dockerClient.copyArchiveToContainerCmd(container.getId())
                 .withHostResource(localDir.toString())
                 .exec();
+    }
+    
+    @Test
+    public void copyFileWithExecutePermission() throws Exception {
+        // create script file, add permission to execute
+        scriptPath = Files.createTempFile("run", ".sh");
+        boolean executable = scriptPath.toFile().setExecutable(true, false);
+        if (!executable){
+            throw new Exception("Execute permission on file not set!");
+        }
+        String snippet = "Running script with execute permission.";
+        String scriptTextStr = "#!/bin/sh\necho \"" + snippet + "\"";
+        // write content for created script
+        Files.write(scriptPath, scriptTextStr.getBytes());
+        // create a test container which starts and waits 3 seconds for the
+        // script to be copied to the container's home dir and then executes it
+        String containerCmd = "sleep 3; /home/" + scriptPath.getFileName().toString();
+        CreateContainerResponse container = docker.createContainerCmd("busybox")
+                .withName("test")
+                .withCmd("/bin/sh", "-c", containerCmd)
+                .exec();
+        // start the container
+        docker.startContainerCmd(container.getId()).exec();
+        // copy script to container home dir
+        docker.copyArchiveToContainerCmd(container.getId())
+                .withRemotePath("/home")
+                .withHostResource(scriptPath.toString())
+                .exec();
+        // await exid code
+        int exitCode = docker.waitContainerCmd(container.getId())
+                .exec(new WaitContainerResultCallback())
+                .awaitStatusCode();
+        // check result
+        assertThat(exitCode, equalTo(0));
     }
 
 }

--- a/src/test/java/com/github/dockerjava/core/command/CopyArchiveToContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/CopyArchiveToContainerCmdImplTest.java
@@ -122,7 +122,7 @@ public class CopyArchiveToContainerCmdImplTest extends AbstractDockerClientTest 
     @Test
     public void copyFileWithExecutePermission() throws Exception {
         // create script file, add permission to execute
-        scriptPath = Files.createTempFile("run", ".sh");
+        Path scriptPath = Files.createTempFile("run", ".sh");
         boolean executable = scriptPath.toFile().setExecutable(true, false);
         if (!executable){
             throw new Exception("Execute permission on file not set!");


### PR DESCRIPTION
This pull request fixes the issue of **discarding execute permissions** of files when **copied to a container**.

For every file copied to a container, permissions **default to 644 mode**. As a result, execute permissions on files are lost and files **cannot execute**.

I created and added to copyArchiveToContainerCmdImplTest a **Test Case** that simulates such a scenario.

Also, I have written code to maintain permissions of a file copied to a container as in host's file system, but I do not know if this is going to be useful to be added. If anyone thinks it is, let me know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/580)
<!-- Reviewable:end -->


Sorry for any unnecessary commits. If you want I may create a new PR.