### PR TITLE
Always use HTTP to connect to proxy even when proxying HTTPS

### DIFF
--- a/src/main/java/com/github/dockerjava/jaxrs/DockerCmdExecFactoryImpl.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/DockerCmdExecFactoryImpl.java
@@ -231,7 +231,7 @@ public class DockerCmdExecFactoryImpl implements DockerCmdExecFactory {
                 String hostname = address.getHostName();
                 int port = address.getPort();
 
-                clientConfig.property(ClientProperties.PROXY_URI, protocol + "://" + hostname + ":" + port);
+                clientConfig.property(ClientProperties.PROXY_URI, "http://" + hostname + ":" + port);
 
                 String httpProxyUser = System.getProperty(protocol + ".proxyUser");
                 if (httpProxyUser != null) {


### PR DESCRIPTION
The intention of the current implementation seems to be to have the
normal proxy settings accomplish the same results with docker-java as
they would in java in general. I think the one accidental divergence
from that is that for the HTTPS case setting https.{proxy,port} would
normally still use HTTP but in this case the code is- I think
unintentionally- switching to the proxy connection to HTTPS.

This change makes it so it corresponds better with how the java proxy
properties work as well. Even when proxying HTTPS the connection to
the actually proxy is done over HTTP and it makes a CONNECT call to
stream the HTTPS over.

Most proxies are still used via HTTP and for better or worse this is
the assumption built into the java proxy configuration which
docker-java is using. The apache client is more flexible and perhaps
the docker-java configuration should be too but I'd like to argue that
until then that the docker-java match the behavior of java.

Also this allows me to use docker-java through the corporate proxy
when proxying HTTPS. Otherwise HTTP works but HTTPS fails since the
proxy is not configured with HTTPS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/586)
<!-- Reviewable:end -->
