### PR TITLE
Fix for SSL Servers if you are using a self-signed, wildcard certificate.

### DIFF
--- a/src/main/java/com/github/dockerjava/core/RemoteApiVersion.java
+++ b/src/main/java/com/github/dockerjava/core/RemoteApiVersion.java
@@ -15,7 +15,7 @@ import java.util.regex.Pattern;
  *
  * @author Marcus Thiesen
  */
-public class RemoteApiVersion {
+public class RemoteApiVersion implements java.io.Serializable {
 
     public static final RemoteApiVersion VERSION_1_19 = RemoteApiVersion.create(1, 19);
 

--- a/src/main/java/com/github/dockerjava/jaxrs/DockerCmdExecFactoryImpl.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/DockerCmdExecFactoryImpl.java
@@ -58,6 +58,7 @@ import org.glassfish.jersey.client.ClientProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -176,7 +177,8 @@ public class DockerCmdExecFactoryImpl implements DockerCmdExecFactory {
         if (sslContext != null) {
             clientBuilder.sslContext(sslContext);
         }
-
+        HostnameVerifier verifier = SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER;
+        clientBuilder.hostnameVerifier(verifier);
         client = clientBuilder.build();
 
         baseResource = client.target(sanitizeUrl(dockerClientConfig.getUri())).path(dockerClientConfig.getVersion().asWebPathPart());
@@ -218,7 +220,7 @@ public class DockerCmdExecFactoryImpl implements DockerCmdExecFactory {
         RegistryBuilder<ConnectionSocketFactory> registryBuilder = RegistryBuilder.create();
         registryBuilder.register("http", PlainConnectionSocketFactory.getSocketFactory());
         if (sslContext != null) {
-            registryBuilder.register("https", new SSLConnectionSocketFactory(sslContext));
+            registryBuilder.register("https", new SSLConnectionSocketFactory(sslContext,SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER));
         }
         registryBuilder.register("unix", new UnixConnectionSocketFactory(originalUri));
         return registryBuilder.build();


### PR DESCRIPTION
Using docker-java with (e.g) Joyent Triton causes SSL exceptions, because jersey won't match
a self-signed wildcard certificate (e.g: *.triton) with the hostname (e.g: my.triton).

Fix is to use all hostname verifiers when configuring the client builder.

FWIW, this is also an issue in 3.x/master - I am not currently using that however as there seems to be a
fair bit of API movement and I haven't the time to update to it. But I suspect a similar fix will work there, too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/610)
<!-- Reviewable:end -->
