### PR TITLE
Fix for #625

### DIFF
--- a/src/main/java/com/github/dockerjava/netty/WebTarget.java
+++ b/src/main/java/com/github/dockerjava/netty/WebTarget.java
@@ -82,16 +82,22 @@ public class WebTarget {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         WebTarget webTarget = (WebTarget) o;
 
-        if (channelProvider != null ? !channelProvider.equals(webTarget.channelProvider) : webTarget.channelProvider != null)
+        if (channelProvider != null ? !channelProvider.equals(webTarget.channelProvider) : webTarget.channelProvider != null) {
             return false;
-        if (path != null ? !path.equals(webTarget.path) : webTarget.path != null) return false;
+        }
+        if (path != null ? !path.equals(webTarget.path) : webTarget.path != null) {
+            return false;
+        }
         return queryParams != null ? queryParams.equals(webTarget.queryParams) : webTarget.queryParams == null;
-
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/netty/WebTarget.java
+++ b/src/main/java/com/github/dockerjava/netty/WebTarget.java
@@ -2,11 +2,13 @@ package com.github.dockerjava.netty;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * This class is basically a replacement of javax.ws.rs.client.WebTarget to allow simpler migration of JAX-RS code to a netty based
@@ -16,32 +18,40 @@ import org.apache.commons.lang.StringUtils;
  */
 public class WebTarget {
 
-    private ChannelProvider channelProvider;
+    private final ChannelProvider channelProvider;
 
-    private List<String> path = new ArrayList<String>();
+    private final ImmutableList<String> path;
 
-    private Map<String, String> queryParams = new HashMap<String, String>();
+    private final ImmutableMap<String, String> queryParams;
 
     private static final String PATH_SEPARATOR = "/";
 
     public WebTarget(ChannelProvider channelProvider) {
+        this(channelProvider, ImmutableList.<String>of(), ImmutableMap.<String, String>of());
+    }
+
+    private WebTarget(ChannelProvider channelProvider,
+                      ImmutableList<String> path,
+                      ImmutableMap<String, String> queryParams) {
         this.channelProvider = channelProvider;
+        this.path = path;
+        this.queryParams = queryParams;
     }
 
     public WebTarget path(String... components) {
+        ImmutableList.Builder<String> newPath = ImmutableList.<String>builder().addAll(this.path);
 
         for (String component : components) {
-
-            path.addAll(Arrays.asList(StringUtils.split(component, PATH_SEPARATOR)));
+            newPath.addAll(Arrays.asList(StringUtils.split(component, PATH_SEPARATOR)));
         }
 
-        return this;
+        return new WebTarget(channelProvider, newPath.build(), queryParams);
     }
 
     public InvocationBuilder request() {
         String resource = PATH_SEPARATOR + StringUtils.join(path, PATH_SEPARATOR);
 
-        List<String> params = new ArrayList<String>();
+        List<String> params = new ArrayList<>();
         for (Map.Entry<String, String> entry : queryParams.entrySet()) {
             params.add(entry.getKey() + "=" + entry.getValue());
         }
@@ -54,20 +64,41 @@ public class WebTarget {
     }
 
     public WebTarget resolveTemplate(String name, Object value) {
-        List<String> newPath = new ArrayList<String>();
+        ImmutableList.Builder<String> newPath = ImmutableList.builder();
         for (String component : path) {
             component = component.replaceAll("\\{" + name + "\\}", value.toString());
             newPath.add(component);
         }
-        path = newPath;
-        return this;
+        return new WebTarget(channelProvider, newPath.build(), queryParams);
     }
 
     public WebTarget queryParam(String name, Object value) {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String>builder().putAll(queryParams);
         if (value != null) {
-            queryParams.put(name, value.toString());
+            builder.put(name, value.toString());
         }
-        return this;
+        return new WebTarget(channelProvider, path, builder.build());
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        WebTarget webTarget = (WebTarget) o;
+
+        if (channelProvider != null ? !channelProvider.equals(webTarget.channelProvider) : webTarget.channelProvider != null)
+            return false;
+        if (path != null ? !path.equals(webTarget.path) : webTarget.path != null) return false;
+        return queryParams != null ? queryParams.equals(webTarget.queryParams) : webTarget.queryParams == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = channelProvider != null ? channelProvider.hashCode() : 0;
+        result = 31 * result + (path != null ? path.hashCode() : 0);
+        result = 31 * result + (queryParams != null ? queryParams.hashCode() : 0);
+        return result;
+    }
 }

--- a/src/test/java/com/github/dockerjava/netty/WebTargetTest.java
+++ b/src/test/java/com/github/dockerjava/netty/WebTargetTest.java
@@ -1,0 +1,39 @@
+package com.github.dockerjava.netty;
+
+import static org.testng.Assert.assertEquals;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * @author Alexander Koshevoy
+ */
+public class WebTargetTest {
+    @Mock private ChannelProvider channelProvider;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void verifyImmutability() throws Exception {
+        WebTarget emptyWebTarget = new WebTarget(channelProvider);
+
+        WebTarget initWebTarget = emptyWebTarget.path("/containers/{id}/attach").resolveTemplate("id", "d03da378b592")
+                .queryParam("logs", "true");
+
+        WebTarget anotherWebTarget = emptyWebTarget.path("/containers/{id}/attach")
+                .resolveTemplate("id", "2cfada4e3c07").queryParam("stdin", "true");
+
+        assertEquals(new WebTarget(channelProvider), emptyWebTarget);
+
+        assertEquals(new WebTarget(channelProvider).path("/containers/d03da378b592/attach")
+                .queryParam("logs", "true"), initWebTarget);
+
+        assertEquals(new WebTarget(channelProvider).path("/containers/2cfada4e3c07/attach")
+                .queryParam("stdin", "true"), anotherWebTarget);
+    }
+}


### PR DESCRIPTION
Unable to setup a valuable integration test because `TestDockerCmdExecFactory` changes default `DockerCmdExecFactoryImpl` behavior in the way it becomes pointless. It creates `WebTarget` on every `exec()` invocation:
```
"main@1" prio=5 tid=0x1 nid=NA runnable
  java.lang.Thread.State: RUNNABLE
	  at com.github.dockerjava.netty.WebTarget.<init>(WebTarget.java:28)
	  at com.github.dockerjava.netty.DockerCmdExecFactoryImpl.getBaseResource(DockerCmdExecFactoryImpl.java:577)
	  at com.github.dockerjava.netty.DockerCmdExecFactoryImpl.createCreateContainerCmdExec(DockerCmdExecFactoryImpl.java:396)
	  at com.github.dockerjava.core.TestDockerCmdExecFactory$1.exec(TestDockerCmdExecFactory.java:103)
	  at com.github.dockerjava.core.TestDockerCmdExecFactory$1.exec(TestDockerCmdExecFactory.java:100)
	  at com.github.dockerjava.core.command.AbstrDockerCmd.exec(AbstrDockerCmd.java:35)
	  at com.github.dockerjava.core.command.CreateContainerCmdImpl.exec(CreateContainerCmdImpl.java:177)
	  ...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/630)
<!-- Reviewable:end -->
