### PR TITLE
Doc fix: Fixed a bad implimentation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ There are three ways to configure, in descending order of precedence:
 #### Programmatic:
 In your application, e.g.
 
-    DockerClientConfig config = DockerClientConfig.createDefaultConfigBuilder()
+    DockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder()
         .withDockerHost("tcp://my-docker-host.tld:2376")
         .withDockerTlsVerify(true)
         .withDockerCertPath("/home/user/.docker/certs")


### PR DESCRIPTION
DockerClientConfig is an interface and does not have a method called: DockerClientConfig.createDefaultConfigBuilder().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/655)
<!-- Reviewable:end -->
