### PR TITLE
Triton/SDC, which supports Docker, gives itself by default a self-signed

### DIFF
--- a/src/main/java/com/github/dockerjava/jaxrs/JerseyDockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/JerseyDockerCmdExecFactory.java
@@ -23,6 +23,7 @@ import com.github.dockerjava.core.SSLConfig;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.glassfish.jersey.CommonProperties;
@@ -266,7 +267,7 @@ public class JerseyDockerCmdExecFactory implements DockerCmdExecFactory {
         RegistryBuilder<ConnectionSocketFactory> registryBuilder = RegistryBuilder.create();
         registryBuilder.register("http", PlainConnectionSocketFactory.getSocketFactory());
         if (sslContext != null) {
-            registryBuilder.register("https", new SSLConnectionSocketFactory(sslContext));
+            registryBuilder.register("https", new SSLConnectionSocketFactory(sslContext, new DefaultHostnameVerifier()));
         }
         registryBuilder.register("unix", new UnixConnectionSocketFactory(originalUri));
         return registryBuilder.build();


### PR DESCRIPTION
wildcard certificate of *.triton.

The Host name verifier will fail this, causing any connections to SDC to
fail.

Set the SSL connection factory to use the DefaultHostnameVerifier which
fixes this behaviour.

Signed-off-by: Nigel Magnay nigel.magnay@gmail.com

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/660)

<!-- Reviewable:end -->
