### PR TITLE
Issue 674: 3.0.x scheme switch for docker host breaks proxy configure

### DIFF
--- a/src/main/java/com/github/dockerjava/jaxrs/JerseyDockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/JerseyDockerCmdExecFactory.java
@@ -187,7 +187,7 @@ public class JerseyDockerCmdExecFactory implements DockerCmdExecFactory {
                 throw new RuntimeException(e);
             }
 
-            configureProxy(clientConfig, protocol);
+            configureProxy(clientConfig, originalUri, protocol);
         }
 
         connManager = new PoolingHttpClientConnectionManager(getSchemeRegistry(
@@ -237,9 +237,9 @@ public class JerseyDockerCmdExecFactory implements DockerCmdExecFactory {
         return originalUri;
     }
 
-    private void configureProxy(ClientConfig clientConfig, String protocol) {
+    private void configureProxy(ClientConfig clientConfig, URI originalUri, String protocol) {
 
-        List<Proxy> proxies = ProxySelector.getDefault().select(dockerClientConfig.getDockerHost());
+        List<Proxy> proxies = ProxySelector.getDefault().select(originalUri);
 
         for (Proxy proxy : proxies) {
             InetSocketAddress address = (InetSocketAddress) proxy.address();


### PR DESCRIPTION
Issue: https://github.com/docker-java/docker-java/issues/674

With the 3.0.x release, the code has been changed to use docker hosts of the format:

  tcp://host:port

Instead of:

  https://host:port

This breaks some of the logic in JerseyDockerCmdExecFactory that configures the proxy setting.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/675)

<!-- Reviewable:end -->
