### PR TITLE
Support no authentication on registry

### DIFF
--- a/src/main/java/com/github/dockerjava/jaxrs/AbstrDockerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/AbstrDockerCmdExec.java
@@ -19,6 +19,8 @@ import com.github.dockerjava.core.RemoteApiVersion;
 
 public abstract class AbstrDockerCmdExec {
 
+    public static final String EMPTY_JSON = "{}";
+
     private final DockerClientConfig dockerClientConfig;
 
     private final WebTarget baseResource;
@@ -40,7 +42,7 @@ public abstract class AbstrDockerCmdExec {
 
     protected String registryAuth(AuthConfig authConfig) {
         try {
-            String json = authConfig == null ? "{}" : new ObjectMapper().writeValueAsString(authConfig);
+            String json = authConfig == null ? EMPTY_JSON : new ObjectMapper().writeValueAsString(authConfig);
             return Base64.encodeBase64String(json.getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/github/dockerjava/jaxrs/AbstrDockerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/AbstrDockerCmdExec.java
@@ -40,7 +40,8 @@ public abstract class AbstrDockerCmdExec {
 
     protected String registryAuth(AuthConfig authConfig) {
         try {
-            return Base64.encodeBase64String(new ObjectMapper().writeValueAsString(authConfig).getBytes());
+            String json = authConfig == null ? "{}" : new ObjectMapper().writeValueAsString(authConfig);
+            return Base64.encodeBase64String(json.getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/github/dockerjava/netty/exec/AbstrDockerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/netty/exec/AbstrDockerCmdExec.java
@@ -39,7 +39,8 @@ public abstract class AbstrDockerCmdExec {
 
     protected String registryAuth(AuthConfig authConfig) {
         try {
-            return Base64.encodeBase64String(new ObjectMapper().writeValueAsString(authConfig).getBytes());
+            String json = authConfig == null ? "{}" : new ObjectMapper().writeValueAsString(authConfig);
+            return Base64.encodeBase64String(json.getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
I'm not sure if it's possible with the newer version of the Docker registry, but with the old version that we're running, we don't have authentication on our registry. This led to some obscure error messages when trying to publish Docker images to our registry from a Jenkins build. The attached pull request supports no authentication when pushing to a registry.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/693)

<!-- Reviewable:end -->
