### PR TITLE
This handles both unix and windows directories...

### DIFF
--- a/src/main/java/com/github/dockerjava/core/GoLangFileMatch.java
+++ b/src/main/java/com/github/dockerjava/core/GoLangFileMatch.java
@@ -86,7 +86,7 @@ public class GoLangFileMatch {
                 patternStringBuilder.append(quote(File.separatorChar));
             }
         }
-        patternStringBuilder.append("(").append(quote(File.separatorChar)).append(".*").append(")?");
+        patternStringBuilder.append("(").append("[\\|/]").append(".*").append(")?");
         return Pattern.compile(patternStringBuilder.toString());
     }
 


### PR DESCRIPTION
The windows directory file seperator wants to put out a windows slash to match against. This will handle both situations.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/722)

<!-- Reviewable:end -->
