### PR TITLE
Added getter for previous cpu stats

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/Statistics.java
+++ b/src/main/java/com/github/dockerjava/api/model/Statistics.java
@@ -50,7 +50,7 @@ public class Statistics implements Serializable {
      * @since Docker Remote API 1.19
      */
     @JsonProperty("precpu_stats")
-    private Map<String, Object> precpuStats;
+    private Map<String, Object> preCpuStats;
 
     /**
      * @since Docker Remote API 1.21
@@ -76,8 +76,8 @@ public class Statistics implements Serializable {
      * The cpu statistic of last read, which is used for calculating the cpu usage percent.
      * It is not the exact copy of the {@link #getCpuStats()}.
      */
-    public Map<String, Object> getPrecpuStats() {
-        return precpuStats;
+    public Map<String, Object> getPreCpuStats() {
+        return preCpuStats;
     }
 
     public Map<String, Object> getMemoryStats() {

--- a/src/main/java/com/github/dockerjava/api/model/Statistics.java
+++ b/src/main/java/com/github/dockerjava/api/model/Statistics.java
@@ -76,7 +76,7 @@ public class Statistics implements Serializable {
      * The cpu statistic of last read, which is used for calculating the cpu usage percent.
      * It is not the exact copy of the {@link #getCpuStats()}.
      */
-    public Map<String, Object> getPreviousCpuStats() {
+    public Map<String, Object> getPrecpuStats() {
         return precpuStats;
     }
 

--- a/src/main/java/com/github/dockerjava/api/model/Statistics.java
+++ b/src/main/java/com/github/dockerjava/api/model/Statistics.java
@@ -47,6 +47,12 @@ public class Statistics implements Serializable {
     private Map<String, Object> cpuStats;
 
     /**
+     * @since Docker Remote API 1.19
+     */
+    @JsonProperty("precpu_stats")
+    private Map<String, Object> precpuStats;
+
+    /**
      * @since Docker Remote API 1.21
      */
     @CheckForNull
@@ -64,6 +70,14 @@ public class Statistics implements Serializable {
 
     public Map<String, Object> getCpuStats() {
         return cpuStats;
+    }
+
+    /**
+     * The cpu statistic of last read, which is used for calculating the cpu usage percent.
+     * It is not the exact copy of the {@link #getCpuStats()}.
+     */
+    public Map<String, Object> getPreviousCpuStats() {
+        return precpuStats;
     }
 
     public Map<String, Object> getMemoryStats() {


### PR DESCRIPTION
This PR adds a getter to the existing field `precpu_stats` that has existed since remote API v1.19 (https://docs.docker.com/engine/reference/api/docker_remote_api_v1.19/#/get-container-stats-based-on-resource-usage and https://github.com/docker/docker/pull/13320). This field is used to calculate the CPU usage without keeping state, using formula: `(cpu_stats.cpu_usage.total_usage - precpu_stats.cpu_usage.total_usage) / (cpu_stats.system_cpu_usage - precpu_stats.system_cpu_usage)`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/724)

<!-- Reviewable:end -->
