### PR TITLE
add state and mounts fields to list container response

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/Container.java
+++ b/src/main/java/com/github/dockerjava/api/model/Container.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.command.ListContainersCmd;
 import com.github.dockerjava.core.RemoteApiVersion;
 import org.apache.commons.lang.builder.EqualsBuilder;
@@ -12,6 +13,7 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 
 import javax.annotation.CheckForNull;
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -51,6 +53,13 @@ public class Container implements Serializable {
     @JsonProperty("Labels")
     public Map<String, String> labels;
 
+    /**
+     * The containers status state can be one of created, restarting, running, paused, exited or dead
+     * @since ~{@link RemoteApiVersion#VERSION_1_23}
+     */
+    @JsonProperty("State")
+    private String state;
+
     @JsonProperty("Status")
     private String status;
 
@@ -73,6 +82,12 @@ public class Container implements Serializable {
      */
     @JsonProperty("HostConfig")
     private ContainerHostConfig hostConfig;
+
+    /**
+     * @since ~{@link RemoteApiVersion#VERSION_1_23}
+     */
+    @JsonProperty("Mounts")
+    private List<InspectContainerResponse.Mount> mounts;
 
     /**
      * Docker API docs says "list of networks", but json names `networkSettings`.
@@ -102,6 +117,11 @@ public class Container implements Serializable {
 
     public Long getCreated() {
         return created;
+    }
+
+    @CheckForNull
+    public String getState() {
+        return state;
     }
 
     public String getStatus() {
@@ -150,6 +170,11 @@ public class Container implements Serializable {
     @CheckForNull
     public ContainerHostConfig getHostConfig() {
         return hostConfig;
+    }
+
+    @CheckForNull
+    public List<InspectContainerResponse.Mount> getMounts() {
+        return mounts;
     }
 
     @Override


### PR DESCRIPTION
add state and mounts fields to list container response introduced with API version 1.23

API changes are documented here:
https://docs.docker.com/engine/reference/api/docker_remote_api/#v123-api-changes

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/733)
<!-- Reviewable:end -->
