### PR TITLE
Fixes broken Docker documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ client also uses UNIX domain sockets to connect to the docker daemon by default.
 
     DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock"
     
-More details about setting up Docker server can be found in official documentation: http://docs.docker.io/en/latest/use/basics/
+More details about setting up Docker Engine can be found in the official documentation: https://docs.docker.com/engine/admin/
 
 To force docker-java to use TCP (http) configure the following (see [Configuration](https://github.com/docker-java/docker-java#configuration) for details):
 


### PR DESCRIPTION
The official Docker documentation has moved around a bit and the link for how to configure the Docker Engine needed to be updated. The previous link pointed to a page that no longer exists.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/735)
<!-- Reviewable:end -->
