### PR TITLE
Allow multiple tags in build image command

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
@@ -38,7 +38,7 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
      * @deprecated since docker API version 1.21 there can be multiple tags
      * specified so use {@link #getTags()}
      */
-    @Deprecated()
+    @Deprecated
     @CheckForNull
     String getTag();
 
@@ -119,7 +119,16 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
 
     // setters
 
+    /**
+     * @deprecated since docker API version 1.21 there can be multiple tags
+     * specified so use {@link #withTags(Set<String>)}
+     * @param tag
+     * @return
+     */
+    @Deprecated
     BuildImageCmd withTag(String tag);
+
+    BuildImageCmd withTags(Set<String> tags);
 
     BuildImageCmd withRemote(URI remote);
 

--- a/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
@@ -1,16 +1,16 @@
 package com.github.dockerjava.api.command;
 
+import com.github.dockerjava.api.model.AuthConfigurations;
+import com.github.dockerjava.api.model.BuildResponseItem;
+import com.github.dockerjava.core.RemoteApiVersion;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Map;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-
-import com.github.dockerjava.api.model.AuthConfigurations;
-import com.github.dockerjava.api.model.BuildResponseItem;
-import com.github.dockerjava.core.RemoteApiVersion;
+import java.util.Set;
 
 /**
  * Build an image from Dockerfile.
@@ -34,7 +34,11 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
 
     /**
      * "t" in API
+     *
+     * @deprecated since docker API version 1.21 there can be multiple tags
+     * specified so use {@link #getTags()}
      */
+    @Deprecated()
     @CheckForNull
     String getTag();
 
@@ -106,6 +110,12 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
      */
     @CheckForNull
     Map<String, String> getLabels();
+
+    /**
+     * @since {@link RemoteApiVersion#VERSION_1_21}
+     */
+    @CheckForNull
+    Set<String> getTags();
 
     // setters
 

--- a/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -23,6 +22,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildResponseItem> implements BuildImageCmd {
 
     private InputStream tarInputStream;
+
+    private String tag;
 
     private Set<String> tags;
 
@@ -84,11 +85,7 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
 
     @Override
     public String getTag() {
-        if (tags == null || tags.isEmpty()) {
-            return null;
-        }
-        // return first tag to be backward compatible
-        return tags.iterator().next();
+        return tag;
     }
 
     @Override
@@ -190,10 +187,13 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
     @Override
     public BuildImageCmdImpl withTag(String tag) {
         checkNotNull(tag, "Tag is null");
-        if (this.tags == null) {
-            this.tags = new HashSet<>(4);
-        }
-        this.tags.add(tag);
+        this.tag = tag;
+        return this;
+    }
+
+    @Override
+    public BuildImageCmd withTags(Set<String> tags) {
+        this.tags = tags;
         return this;
     }
 

--- a/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
@@ -1,30 +1,30 @@
 package com.github.dockerjava.core.command;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
-
 import com.github.dockerjava.api.command.BuildImageCmd;
 import com.github.dockerjava.api.model.AuthConfigurations;
 import com.github.dockerjava.api.model.BuildResponseItem;
 import com.github.dockerjava.core.dockerfile.Dockerfile;
 import com.github.dockerjava.core.util.FilePathUtil;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
- *
  * Build an image from Dockerfile.
- *
  */
 public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildResponseItem> implements BuildImageCmd {
 
     private InputStream tarInputStream;
 
-    private String tag;
+    private Set<String> tags;
 
     private Boolean noCache;
 
@@ -84,7 +84,11 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
 
     @Override
     public String getTag() {
-        return tag;
+        if (tags == null || tags.isEmpty()) {
+            return null;
+        }
+        // return first tag to be backward compatible
+        return tags.iterator().next();
     }
 
     @Override
@@ -156,6 +160,11 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
         return labels;
     }
 
+    @Override
+    public Set<String> getTags() {
+        return tags;
+    }
+
     // getter lib specific
 
     @Override
@@ -181,7 +190,10 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
     @Override
     public BuildImageCmdImpl withTag(String tag) {
         checkNotNull(tag, "Tag is null");
-        this.tag = tag;
+        if (this.tags == null) {
+            this.tags = new HashSet<>(4);
+        }
+        this.tags.add(tag);
         return this;
     }
 

--- a/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
@@ -69,7 +69,10 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
             for (String t : command.getTags()) {
                 webTarget = webTarget.queryParam("t", t);
             }
+        } else if (command.getTag() != null) {
+            webTarget = webTarget.queryParam("t", command.getTag());
         }
+
         if (command.getRemote() != null) {
             webTarget = webTarget.queryParam("remote", command.getRemote().toString());
         }

--- a/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
@@ -65,8 +65,10 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
         if (dockerFilePath != null && command.getRemote() == null && !"Dockerfile".equals(dockerFilePath)) {
             webTarget = webTarget.queryParam("dockerfile", dockerFilePath);
         }
-        if (command.getTag() != null) {
-            webTarget = webTarget.queryParam("t", command.getTag());
+        if (command.getTags() != null && !command.getTags().isEmpty()) {
+            for (String t : command.getTags()) {
+                webTarget = webTarget.queryParam("t", t);
+            }
         }
         if (command.getRemote() != null) {
             webTarget = webTarget.queryParam("remote", command.getRemote().toString());

--- a/src/main/java/com/github/dockerjava/netty/WebTarget.java
+++ b/src/main/java/com/github/dockerjava/netty/WebTarget.java
@@ -22,17 +22,17 @@ public class WebTarget {
 
     private final ImmutableList<String> path;
 
-    private final ImmutableMap<String, String> queryParams;
+    private final ImmutableMap<String, Object> queryParams;
 
     private static final String PATH_SEPARATOR = "/";
 
     public WebTarget(ChannelProvider channelProvider) {
-        this(channelProvider, ImmutableList.<String>of(), ImmutableMap.<String, String>of());
+        this(channelProvider, ImmutableList.<String>of(), ImmutableMap.<String, Object>of());
     }
 
     private WebTarget(ChannelProvider channelProvider,
                       ImmutableList<String> path,
-                      ImmutableMap<String, String> queryParams) {
+                      ImmutableMap<String, Object> queryParams) {
         this.channelProvider = channelProvider;
         this.path = path;
         this.queryParams = queryParams;
@@ -52,8 +52,14 @@ public class WebTarget {
         String resource = PATH_SEPARATOR + StringUtils.join(path, PATH_SEPARATOR);
 
         List<String> params = new ArrayList<>();
-        for (Map.Entry<String, String> entry : queryParams.entrySet()) {
-            params.add(entry.getKey() + "=" + entry.getValue());
+        for (Map.Entry<String, Object> entry : queryParams.entrySet()) {
+            if (entry.getValue() instanceof Iterable) {
+                for (Object i : (Iterable) entry.getValue()) {
+                    params.add(entry.getKey() + "=" + i.toString());
+                }
+            } else {
+                params.add(entry.getKey() + "=" + entry.getValue().toString());
+            }
         }
 
         if (!params.isEmpty()) {
@@ -73,9 +79,9 @@ public class WebTarget {
     }
 
     public WebTarget queryParam(String name, Object value) {
-        ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String>builder().putAll(queryParams);
+        ImmutableMap.Builder<String, Object> builder = ImmutableMap.<String, Object>builder().putAll(queryParams);
         if (value != null) {
-            builder.put(name, value.toString());
+            builder.put(name, value);
         }
         return new WebTarget(channelProvider, path, builder.build());
     }

--- a/src/main/java/com/github/dockerjava/netty/exec/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/netty/exec/BuildImageCmdExec.java
@@ -57,6 +57,8 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
         }
         if (command.getTags() != null && !command.getTags().isEmpty()) {
             webTarget = webTarget.queryParam("t", command.getTags());
+        } else if (command.getTag() != null) {
+            webTarget = webTarget.queryParam("t", command.getTag());
         }
         if (command.getRemote() != null) {
             webTarget = webTarget.queryParam("remote", command.getRemote().toString());

--- a/src/main/java/com/github/dockerjava/netty/exec/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/netty/exec/BuildImageCmdExec.java
@@ -55,8 +55,8 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
         if (dockerFilePath != null && command.getRemote() == null && !"Dockerfile".equals(dockerFilePath)) {
             webTarget = webTarget.queryParam("dockerfile", dockerFilePath);
         }
-        if (command.getTag() != null) {
-            webTarget = webTarget.queryParam("t", command.getTag());
+        if (command.getTags() != null && !command.getTags().isEmpty()) {
+            webTarget = webTarget.queryParam("t", command.getTags());
         }
         if (command.getRemote() != null) {
             webTarget = webTarget.queryParam("remote", command.getRemote().toString());

--- a/src/test/java/com/github/dockerjava/core/command/BuildImageCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/BuildImageCmdImplTest.java
@@ -7,13 +7,16 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.UUID;
 
 import org.apache.commons.io.FileUtils;
@@ -283,7 +286,8 @@ public class BuildImageCmdImplTest extends AbstractDockerClientTest {
         File baseDir = fileFromBuildTestResource("labels");
 
         String imageId = dockerClient.buildImageCmd(baseDir).withNoCache(true)
-                .withTag("docker-java-test:tag1").withTag("docker-java-test:tag2")
+                .withTag("fallback-when-withTags-not-called")
+                .withTags(new HashSet<>(Arrays.asList("docker-java-test:tag1", "docker-java-test:tag2")))
                 .exec(new BuildImageResultCallback())
                 .awaitImageId();
 
@@ -292,8 +296,7 @@ public class BuildImageCmdImplTest extends AbstractDockerClientTest {
         LOG.info("Image Inspect: {}", inspectImageResponse.toString());
 
         assertThat(inspectImageResponse.getRepoTags().size(), equalTo(2));
-        assertThat(inspectImageResponse.getRepoTags().contains("docker-java-test:tag1"), equalTo(true));
-        assertThat(inspectImageResponse.getRepoTags().contains("docker-java-test:tag2"), equalTo(true));
+        assertThat(inspectImageResponse.getRepoTags(), containsInAnyOrder("docker-java-test:tag1", "docker-java-test:tag2"));
     }
 
     public void dockerfileNotInBaseDirectory() throws Exception {

--- a/src/test/java/com/github/dockerjava/core/command/BuildImageCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/BuildImageCmdImplTest.java
@@ -274,6 +274,28 @@ public class BuildImageCmdImplTest extends AbstractDockerClientTest {
         assertThat(inspectImageResponse.getConfig().getLabels().get("test"), equalTo("abc"));
     }
 
+    @Test
+    public void multipleTags() throws Exception {
+        if (!getVersion(dockerClient).isGreaterOrEqual(RemoteApiVersion.VERSION_1_21)) {
+            throw new SkipException("API version should be >= 1.21");
+        }
+
+        File baseDir = fileFromBuildTestResource("labels");
+
+        String imageId = dockerClient.buildImageCmd(baseDir).withNoCache(true)
+                .withTag("docker-java-test:tag1").withTag("docker-java-test:tag2")
+                .exec(new BuildImageResultCallback())
+                .awaitImageId();
+
+        InspectImageResponse inspectImageResponse = dockerClient.inspectImageCmd(imageId).exec();
+        assertThat(inspectImageResponse, not(nullValue()));
+        LOG.info("Image Inspect: {}", inspectImageResponse.toString());
+
+        assertThat(inspectImageResponse.getRepoTags().size(), equalTo(2));
+        assertThat(inspectImageResponse.getRepoTags().contains("docker-java-test:tag1"), equalTo(true));
+        assertThat(inspectImageResponse.getRepoTags().contains("docker-java-test:tag2"), equalTo(true));
+    }
+
     public void dockerfileNotInBaseDirectory() throws Exception {
         File baseDirectory = fileFromBuildTestResource("dockerfileNotInBaseDirectory");
         File dockerfile = fileFromBuildTestResource("dockerfileNotInBaseDirectory/dockerfileFolder/Dockerfile");

--- a/src/test/java/com/github/dockerjava/netty/exec/BuildImageCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/BuildImageCmdExecTest.java
@@ -7,13 +7,16 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.UUID;
 
 import org.apache.commons.io.FileUtils;
@@ -288,7 +291,8 @@ public class BuildImageCmdExecTest extends AbstractNettyDockerClientTest {
         File baseDir = fileFromBuildTestResource("labels");
 
         String imageId = dockerClient.buildImageCmd(baseDir).withNoCache(true)
-                .withTag("docker-java-test:tag1").withTag("docker-java-test:tag2")
+                .withTag("fallback-when-withTags-not-called")
+                .withTags(new HashSet<>(Arrays.asList("docker-java-test:tag1", "docker-java-test:tag2")))
                 .exec(new BuildImageResultCallback())
                 .awaitImageId();
 
@@ -297,8 +301,7 @@ public class BuildImageCmdExecTest extends AbstractNettyDockerClientTest {
         LOG.info("Image Inspect: {}", inspectImageResponse.toString());
 
         assertThat(inspectImageResponse.getRepoTags().size(), equalTo(2));
-        assertThat(inspectImageResponse.getRepoTags().contains("docker-java-test:tag1"), equalTo(true));
-        assertThat(inspectImageResponse.getRepoTags().contains("docker-java-test:tag2"), equalTo(true));
+        assertThat(inspectImageResponse.getRepoTags(), containsInAnyOrder("docker-java-test:tag1", "docker-java-test:tag2"));
     }
 
     public void dockerfileNotInBaseDirectory() throws Exception {


### PR DESCRIPTION
Several tags for image can be defined by subsequent  calling `withTag()` method of `BuildImageCmd`.

@marcuslinke please check my modifications of Netty `WebTarget` class to support several query parameters with the same name as this class is widely used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/739)
<!-- Reviewable:end -->
