### PR TITLE
add missing ListContainer filters

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/ListContainersCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/ListContainersCmd.java
@@ -1,11 +1,10 @@
 package com.github.dockerjava.api.command;
 
-import java.util.List;
-import java.util.Map;
+import com.github.dockerjava.api.model.Container;
 
 import javax.annotation.CheckForNull;
-
-import com.github.dockerjava.api.model.Container;
+import java.util.List;
+import java.util.Map;
 
 /**
  * List containers
@@ -38,16 +37,54 @@ public interface ListContainersCmd extends SyncDockerCmd<List<Container>> {
     ListContainersCmd withBefore(String before);
 
     /**
+     * @param name
+     *            - Show only containers that has the container's name
+     */
+    ListContainersCmd withNameFilter(String... name);
+
+    /**
+     * @param id
+     *            - Show only containers that has the container's id
+     */
+    ListContainersCmd withIdFilter(String... id);
+
+    /**
+     * @param ancestor
+     *            - Show only containers created from an image or a descendant.
+     */
+    ListContainersCmd withAncestorFilter(String... ancestor);
+
+    /**
+     * @param volume
+     *            - Show only containers with volume name or mount point destination
+     */
+    ListContainersCmd withVolumeFilter(String... volume);
+
+    /**
+     * @param network
+     *            - Show only containers with network id or network name
+     */
+    ListContainersCmd withNetworkFilter(String... network);
+
+    /**
+     * @param exited
+     *            - Show only containers that exited with the passed exitcode.
+     */
+    ListContainersCmd withExitedFilter(Integer exited);
+
+    /**
+     * Use {@link #withExitedFilter(Integer)} instead
      * @param exitcode
      *            - Show only containers that exited with the passed exitcode.
      */
+    @Deprecated
     ListContainersCmd withExitcodeFilter(Integer exitcode);
 
     /**
      * @param status
      *            - Show only containers with the passed status (created|restarting|running|paused|exited).
      */
-    ListContainersCmd withStatusFilter(String status);
+    ListContainersCmd withStatusFilter(String... status);
 
     /**
      * @param labels
@@ -84,6 +121,13 @@ public interface ListContainersCmd extends SyncDockerCmd<List<Container>> {
      *            - Show only containers created since Id, include non-running ones.
      */
     ListContainersCmd withSince(String since);
+
+    /**
+     * @param filterName
+     * @param filterValues
+     *            - Show only containers where the filter matches the given values
+     */
+    ListContainersCmd withFilter(String filterName, String... filterValues);
 
     interface Exec extends DockerCmdSyncExec<ListContainersCmd, List<Container>> {
     }

--- a/src/main/java/com/github/dockerjava/api/command/ListContainersCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/ListContainersCmd.java
@@ -3,6 +3,7 @@ package com.github.dockerjava.api.command;
 import com.github.dockerjava.api.model.Container;
 
 import javax.annotation.CheckForNull;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -40,31 +41,31 @@ public interface ListContainersCmd extends SyncDockerCmd<List<Container>> {
      * @param name
      *            - Show only containers that has the container's name
      */
-    ListContainersCmd withNameFilter(String... name);
+    ListContainersCmd withNameFilter(Collection<String> name);
 
     /**
      * @param id
      *            - Show only containers that has the container's id
      */
-    ListContainersCmd withIdFilter(String... id);
+    ListContainersCmd withIdFilter(Collection<String> id);
 
     /**
      * @param ancestor
      *            - Show only containers created from an image or a descendant.
      */
-    ListContainersCmd withAncestorFilter(String... ancestor);
+    ListContainersCmd withAncestorFilter(Collection<String> ancestor);
 
     /**
      * @param volume
      *            - Show only containers with volume name or mount point destination
      */
-    ListContainersCmd withVolumeFilter(String... volume);
+    ListContainersCmd withVolumeFilter(Collection<String> volume);
 
     /**
      * @param network
      *            - Show only containers with network id or network name
      */
-    ListContainersCmd withNetworkFilter(String... network);
+    ListContainersCmd withNetworkFilter(Collection<String> network);
 
     /**
      * @param exited
@@ -90,7 +91,7 @@ public interface ListContainersCmd extends SyncDockerCmd<List<Container>> {
      * @param labels
      *            - Show only containers with the passed labels.
      */
-    ListContainersCmd withLabelFilter(String... labels);
+    ListContainersCmd withLabelFilter(Collection<String> labels);
 
     /**
      * @param labels
@@ -127,7 +128,7 @@ public interface ListContainersCmd extends SyncDockerCmd<List<Container>> {
      * @param filterValues
      *            - Show only containers where the filter matches the given values
      */
-    ListContainersCmd withFilter(String filterName, String... filterValues);
+    ListContainersCmd withFilter(String filterName, Collection<String> filterValues);
 
     interface Exec extends DockerCmdSyncExec<ListContainersCmd, List<Container>> {
     }

--- a/src/main/java/com/github/dockerjava/api/command/ListContainersCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/ListContainersCmd.java
@@ -74,18 +74,10 @@ public interface ListContainersCmd extends SyncDockerCmd<List<Container>> {
     ListContainersCmd withExitedFilter(Integer exited);
 
     /**
-     * Use {@link #withExitedFilter(Integer)} instead
-     * @param exitcode
-     *            - Show only containers that exited with the passed exitcode.
-     */
-    @Deprecated
-    ListContainersCmd withExitcodeFilter(Integer exitcode);
-
-    /**
      * @param status
      *            - Show only containers with the passed status (created|restarting|running|paused|exited).
      */
-    ListContainersCmd withStatusFilter(String... status);
+    ListContainersCmd withStatusFilter(Collection<String> status);
 
     /**
      * @param labels

--- a/src/main/java/com/github/dockerjava/core/command/ListContainersCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ListContainersCmdImpl.java
@@ -138,11 +138,6 @@ public class ListContainersCmdImpl extends AbstrDockerCmd<ListContainersCmd, Lis
     }
 
     @Override
-    public ListContainersCmd withExitcodeFilter(Integer exitcode) {
-        return withExitedFilter(exitcode);
-    }
-
-    @Override
     public ListContainersCmd withFilter(String filterName, Collection<String> filterValues) {
         checkNotNull(filterValues, filterName + " was not specified");
         this.filters.withFilter(filterName, filterValues);
@@ -150,7 +145,7 @@ public class ListContainersCmdImpl extends AbstrDockerCmd<ListContainersCmd, Lis
     }
 
     @Override
-    public ListContainersCmd withStatusFilter(String... status) {
+    public ListContainersCmd withStatusFilter(Collection<String> status) {
         checkNotNull(status, "status was not specified");
         this.filters.withFilter("status", status);
         return this;

--- a/src/main/java/com/github/dockerjava/core/command/ListContainersCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ListContainersCmdImpl.java
@@ -4,6 +4,7 @@ import com.github.dockerjava.api.command.ListContainersCmd;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.core.util.FiltersBuilder;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -93,35 +94,33 @@ public class ListContainersCmdImpl extends AbstrDockerCmd<ListContainersCmd, Lis
     }
 
     @Override
-    public ListContainersCmd withNameFilter(String... name) {
+    public ListContainersCmd withNameFilter(Collection<String> name) {
         return withFilter("name", name);
     }
 
     @Override
-    public ListContainersCmd withIdFilter(String... id) {
+    public ListContainersCmd withIdFilter(Collection<String> id) {
         return withFilter("id", id);
     }
 
     @Override
-    public ListContainersCmd withAncestorFilter(String... ancestor) {
+    public ListContainersCmd withAncestorFilter(Collection<String> ancestor) {
         return withFilter("ancestor", ancestor);
     }
 
     @Override
-    public ListContainersCmd withVolumeFilter(String... volume) {
+    public ListContainersCmd withVolumeFilter(Collection<String> volume) {
         return withFilter("volume", volume);
     }
 
     @Override
-    public ListContainersCmd withNetworkFilter(String... network) {
+    public ListContainersCmd withNetworkFilter(Collection<String> network) {
         return withFilter("network", network);
     }
 
     @Override
-    public ListContainersCmd withLabelFilter(String... labels) {
-        checkNotNull(labels, "labels was not specified");
-        this.filters.withLabels(labels);
-        return this;
+    public ListContainersCmd withLabelFilter(Collection<String> labels) {
+        return withFilter("label", labels);
     }
 
     @Override
@@ -133,7 +132,9 @@ public class ListContainersCmdImpl extends AbstrDockerCmd<ListContainersCmd, Lis
 
     @Override
     public ListContainersCmd withExitedFilter(Integer exited) {
-        return withFilter("exited", exited.toString());
+        checkNotNull(exited, "exited was not specified");
+        this.filters.withFilter("exited", exited.toString());
+        return this;
     }
 
     @Override
@@ -142,7 +143,7 @@ public class ListContainersCmdImpl extends AbstrDockerCmd<ListContainersCmd, Lis
     }
 
     @Override
-    public ListContainersCmd withFilter(String filterName, String... filterValues) {
+    public ListContainersCmd withFilter(String filterName, Collection<String> filterValues) {
         checkNotNull(filterValues, filterName + " was not specified");
         this.filters.withFilter(filterName, filterValues);
         return this;

--- a/src/main/java/com/github/dockerjava/core/command/ListContainersCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ListContainersCmdImpl.java
@@ -1,14 +1,14 @@
 package com.github.dockerjava.core.command;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import com.github.dockerjava.api.command.ListContainersCmd;
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.core.util.FiltersBuilder;
 
 import java.util.List;
 import java.util.Map;
 
-import com.github.dockerjava.api.command.ListContainersCmd;
-import com.github.dockerjava.api.model.Container;
-import com.github.dockerjava.core.util.FiltersBuilder;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * List containers.
@@ -93,6 +93,31 @@ public class ListContainersCmdImpl extends AbstrDockerCmd<ListContainersCmd, Lis
     }
 
     @Override
+    public ListContainersCmd withNameFilter(String... name) {
+        return withFilter("name", name);
+    }
+
+    @Override
+    public ListContainersCmd withIdFilter(String... id) {
+        return withFilter("id", id);
+    }
+
+    @Override
+    public ListContainersCmd withAncestorFilter(String... ancestor) {
+        return withFilter("ancestor", ancestor);
+    }
+
+    @Override
+    public ListContainersCmd withVolumeFilter(String... volume) {
+        return withFilter("volume", volume);
+    }
+
+    @Override
+    public ListContainersCmd withNetworkFilter(String... network) {
+        return withFilter("network", network);
+    }
+
+    @Override
     public ListContainersCmd withLabelFilter(String... labels) {
         checkNotNull(labels, "labels was not specified");
         this.filters.withLabels(labels);
@@ -107,14 +132,24 @@ public class ListContainersCmdImpl extends AbstrDockerCmd<ListContainersCmd, Lis
     }
 
     @Override
+    public ListContainersCmd withExitedFilter(Integer exited) {
+        return withFilter("exited", exited.toString());
+    }
+
+    @Override
     public ListContainersCmd withExitcodeFilter(Integer exitcode) {
-        checkNotNull(exitcode, "exitcode was not specified");
-        this.filters.withFilter("exitcode", exitcode.toString());
+        return withExitedFilter(exitcode);
+    }
+
+    @Override
+    public ListContainersCmd withFilter(String filterName, String... filterValues) {
+        checkNotNull(filterValues, filterName + " was not specified");
+        this.filters.withFilter(filterName, filterValues);
         return this;
     }
 
     @Override
-    public ListContainersCmd withStatusFilter(String status) {
+    public ListContainersCmd withStatusFilter(String... status) {
         checkNotNull(status, "status was not specified");
         this.filters.withFilter("status", status);
         return this;

--- a/src/main/java/com/github/dockerjava/core/util/FiltersBuilder.java
+++ b/src/main/java/com/github/dockerjava/core/util/FiltersBuilder.java
@@ -2,6 +2,7 @@ package com.github.dockerjava.core.util;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,6 +23,11 @@ public class FiltersBuilder {
 
     public FiltersBuilder withFilter(String key, String... value) {
         filters.put(key, Arrays.asList(value));
+        return this;
+    }
+
+    public FiltersBuilder withFilter(String key, Collection<String> value) {
+        filters.put(key, value instanceof List ? (List<String>) value : new ArrayList<>(value));
         return this;
     }
 

--- a/src/test/java/com/github/dockerjava/cmd/ListContainersCmdIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/ListContainersCmdIT.java
@@ -1,25 +1,33 @@
 package com.github.dockerjava.cmd;
 
 import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.command.CreateNetworkResponse;
+import com.github.dockerjava.api.command.CreateVolumeResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Container;
-import com.google.common.collect.ImmutableMap;
+import com.github.dockerjava.api.model.Volume;
+import com.github.dockerjava.core.command.PullImageResultCallback;
+import com.github.dockerjava.core.command.WaitContainerResultCallback;
 import org.hamcrest.Matcher;
-import org.junit.Ignore;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static ch.lambdaj.Lambda.filter;
-import static com.github.dockerjava.utils.TestUtils.isNotSwarm;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
@@ -28,33 +36,55 @@ import static org.testinfected.hamcrest.jpa.PersistenceMatchers.hasField;
 
 public class ListContainersCmdIT extends CmdIT {
     private static final Logger LOG = LoggerFactory.getLogger(ListContainersCmdIT.class);
+    private static final String DEFAULT_IMAGE = "busybox";
+    private Map<String, String> testLabel;
 
-    @Ignore("can't work in parallel and second test seems cover this")
+    @Before
+    public void setUp() {
+        //generate unique ids per test to isolate each test case from each other
+        testLabel = Collections.singletonMap("test", UUID.randomUUID().toString());
+    }
+
+    @After
+    public void tearDown() {
+        //remove all containers created by this test
+        List<Container> containers = dockerRule.getClient().listContainersCmd()
+                .withLabelFilter(testLabel)
+                .withShowAll(true)
+                .exec();
+
+        for (Container container : containers) {
+            removeContainer(container.getId());
+        }
+    }
+
     @Test
     public void testListContainers() throws Exception {
-
-        String testImage = "busybox";
-
-        List<Container> containers = dockerRule.getClient().listContainersCmd().withShowAll(true).exec();
+        List<Container> containers = dockerRule.getClient().listContainersCmd()
+                .withLabelFilter(testLabel)
+                .withShowAll(true)
+                .exec();
         assertThat(containers, notNullValue());
         LOG.info("Container List: {}", containers);
 
         int size = containers.size();
 
-        CreateContainerResponse container1 = dockerRule.getClient().createContainerCmd(testImage).withCmd("echo").exec();
-
+        CreateContainerResponse container1 = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
+                .withLabels(testLabel)
+                .withCmd("echo")
+                .exec();
         assertThat(container1.getId(), not(isEmptyString()));
 
         InspectContainerResponse inspectContainerResponse = dockerRule.getClient().inspectContainerCmd(container1.getId()).exec();
-
-        assertThat(inspectContainerResponse.getConfig().getImage(), is(equalTo(testImage)));
+        assertThat(inspectContainerResponse.getConfig().getImage(), is(equalTo(DEFAULT_IMAGE)));
 
         dockerRule.getClient().startContainerCmd(container1.getId()).exec();
-
         LOG.info("container id: " + container1.getId());
 
-        List<Container> containers2 = dockerRule.getClient().listContainersCmd().withShowAll(true).exec();
-
+        List<Container> containers2 = dockerRule.getClient().listContainersCmd()
+                .withLabelFilter(testLabel)
+                .withShowAll(true)
+                .exec();
         for (Container container : containers2) {
             LOG.info("listContainer: id=" + container.getId() + " image=" + container.getImage());
         }
@@ -72,92 +102,268 @@ public class ListContainersCmdIT extends CmdIT {
 
         Container container2 = filteredContainers.get(0);
         assertThat(container2.getCommand(), not(isEmptyString()));
-        assertThat(container2.getImage(), startsWith(testImage));
+        assertThat(container2.getImage(), startsWith(DEFAULT_IMAGE));
     }
 
     @Test
     public void testListContainersWithLabelsFilter() throws Exception {
-
-        String testImage = "busybox";
-
-        List<Container> containers = dockerRule.getClient().listContainersCmd().withShowAll(true).exec();
-        assertThat(containers, notNullValue());
-        LOG.info("Container List: {}", containers);
-
-//        int size = containers.size();
-
-        CreateContainerResponse container1 = dockerRule.getClient().createContainerCmd(testImage).withCmd("echo").exec();
-
-        assertThat(container1.getId(), not(isEmptyString()));
-
-        InspectContainerResponse inspectContainerResponse = dockerRule.getClient().inspectContainerCmd(container1.getId()).exec();
-
-        assertThat(inspectContainerResponse.getConfig().getImage(), is(equalTo(testImage)));
-
-        dockerRule.getClient().startContainerCmd(container1.getId()).exec();
-
-        LOG.info("container id: " + container1.getId());
-
-        List<Container> containers2 = dockerRule.getClient().listContainersCmd().withShowAll(true).exec();
-
-        for (Container container : containers2) {
-            LOG.info("listContainer: id=" + container.getId() + " image=" + container.getImage());
-        }
-
-        // some parallel test may create containers
-//        assertThat(size + 1, is(equalTo(containers2.size())));
-        assertThat(containers2, (Matcher) hasItem(hasField("id", startsWith(container1.getId()))));
-
-        List<Container> filteredContainers = filter(hasField("id", startsWith(container1.getId())), containers2);
-        assertThat(filteredContainers.size(), is(equalTo(1)));
-
-        for (Container container : filteredContainers) {
-            LOG.info("filteredContainer: " + container);
-        }
-
-        Container container2 = filteredContainers.get(0);
-        assertThat(container2.getCommand(), not(isEmptyString()));
-        assertThat(container2.getImage(), startsWith(testImage));
-
-
-
-        Map<String, String> labels = ImmutableMap.of("test" + dockerRule.getKind(), "docker-java");
-        List<Container> containersForRemove = dockerRule.getClient().listContainersCmd().withShowAll(true)
-                .withLabelFilter(labels).exec();
-        if (containersForRemove != null) {
-            for (Container container : containersForRemove) {
-                dockerRule.getClient().removeContainerCmd(container.getId()).withForce(true).exec();
-            }
-        }
-
         // list with filter by Map label
-        dockerRule.getClient().createContainerCmd(testImage).withCmd("echo").withLabels(labels).exec();
+        dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE).withCmd("echo")
+                .withLabels(testLabel)
+                .exec();
 
         List<Container> filteredContainersByMap = dockerRule.getClient().listContainersCmd()
                 .withShowAll(true)
-                .withLabelFilter(labels)
+                .withLabelFilter(testLabel)
                 .exec();
 
-        assertThat(filteredContainersByMap.size(), is(equalTo( 1)));
+        assertThat(filteredContainersByMap.size(), is(1));
 
         Container container3 = filteredContainersByMap.get(0);
         assertThat(container3.getCommand(), not(isEmptyString()));
-        assertThat(container3.getImage(), startsWith(testImage));
+        assertThat(container3.getImage(), startsWith(DEFAULT_IMAGE));
 
         // List by string label
-        filteredContainers = dockerRule.getClient().listContainersCmd()
+        List<Container> filteredContainers = dockerRule.getClient().listContainersCmd()
                 .withShowAll(true)
-                .withLabelFilter("test" + dockerRule.getKind())
+                .withLabelFilter("test=" + testLabel.get("test"))
                 .exec();
 
-        assertThat(filteredContainers.size(), is(equalTo(1)));
+        assertThat(filteredContainers.size(), is(1));
 
         container3 = filteredContainers.get(0);
         assertThat(container3.getCommand(), not(isEmptyString()));
-        assertThat(container3.getImage(), startsWith(testImage));
-        if (isNotSwarm(dockerRule.getClient())) {
-            assertEquals(container3.getLabels(), labels);
-        }
+        assertThat(container3.getImage(), startsWith(DEFAULT_IMAGE));
+        assertEquals(testLabel.get("test"), container3.getLabels().get("test"));
     }
 
+    @Test
+    public void testNameFilter() throws Exception {
+        String testUUID = testLabel.get("test");
+
+        String id1, id2;
+        id1 = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
+                .withLabels(testLabel)
+                .withName("nameFilterTest1-" + testUUID)
+                .exec()
+                .getId();
+
+        id2 = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
+                .withLabels(testLabel)
+                .withName("nameFilterTest2-" + testUUID)
+                .exec()
+                .getId();
+
+        List<Container> filteredContainers = dockerRule.getClient().listContainersCmd()
+                .withShowAll(true)
+                .withNameFilter("nameFilterTest1-" + testUUID, "nameFilterTest2-" + testUUID)
+                .exec();
+
+        assertThat(filteredContainers.size(), is(2));
+        assertThat(filteredContainers.get(0).getId(), isOneOf(id1, id2));
+        assertThat(filteredContainers.get(1).getId(), isOneOf(id1, id2));
+    }
+
+    @Test
+    public void testIdsFilter() throws Exception {
+        String id1, id2;
+        id1 = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
+                .withLabels(testLabel)
+                .exec()
+                .getId();
+
+        id2 = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
+                .withLabels(testLabel)
+                .exec()
+                .getId();
+
+        List<Container> filteredContainers = dockerRule.getClient().listContainersCmd()
+                .withShowAll(true)
+                .withIdFilter(id1, id2)
+                .exec();
+
+        assertThat(filteredContainers.size(), is(2));
+        assertThat(filteredContainers.get(0).getId(), isOneOf(id1, id2));
+        assertThat(filteredContainers.get(1).getId(), isOneOf(id1, id2));
+    }
+
+    @Test
+    public void testStatusFilter() throws Exception {
+        String id1, id2;
+        id1 = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
+                .withCmd("sh", "-c", "sleep 99999")
+                .withLabels(testLabel)
+                .exec()
+                .getId();
+
+        id2 = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
+                .withCmd("sh", "-c", "sleep 99999")
+                .withLabels(testLabel)
+                .exec()
+                .getId();
+
+        List<Container> filteredContainers = dockerRule.getClient().listContainersCmd()
+                .withShowAll(true)
+                .withLabelFilter(testLabel)
+                .withStatusFilter("created")
+                .exec();
+
+        assertThat(filteredContainers.size(), is(2));
+        assertThat(filteredContainers.get(1).getId(), isOneOf(id1, id2));
+
+        dockerRule.getClient().startContainerCmd(id1).exec();
+
+        filteredContainers = dockerRule.getClient().listContainersCmd()
+                .withShowAll(true)
+                .withLabelFilter(testLabel)
+                .withStatusFilter("running")
+                .exec();
+
+        assertThat(filteredContainers.size(), is(1));
+        assertThat(filteredContainers.get(0).getId(), is(id1));
+
+        dockerRule.getClient().pauseContainerCmd(id1).exec();
+
+        filteredContainers = dockerRule.getClient().listContainersCmd()
+                .withShowAll(true)
+                .withLabelFilter(testLabel)
+                .withStatusFilter("paused")
+                .exec();
+
+        assertThat(filteredContainers.size(), is(1));
+        assertThat(filteredContainers.get(0).getId(), is(id1));
+
+        dockerRule.getClient().unpauseContainerCmd(id1).exec();
+        dockerRule.getClient().stopContainerCmd(id1).exec();
+
+        filteredContainers = dockerRule.getClient().listContainersCmd()
+                .withShowAll(true)
+                .withLabelFilter(testLabel)
+                .withStatusFilter("exited")
+                .exec();
+
+        assertThat(filteredContainers.size(), is(1));
+        assertThat(filteredContainers.get(0).getId(), is(id1));
+    }
+
+    @Test
+    public void testVolumeFilter() throws Exception {
+        String id;
+        CreateVolumeResponse volume = dockerRule.getClient().createVolumeCmd()
+                .withName("TestFilterVolume")
+                .withDriver("local")
+                .exec();
+
+        id = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
+                .withLabels(testLabel)
+                .withBinds(new Bind("TestFilterVolume", new Volume("/test")))
+                .exec()
+                .getId();
+
+        dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
+                .withLabels(testLabel)
+                .exec();
+
+        List<Container> filteredContainers = dockerRule.getClient().listContainersCmd()
+                .withShowAll(true)
+                .withLabelFilter(testLabel)
+                .withVolumeFilter("TestFilterVolume")
+                .exec();
+
+        assertThat(filteredContainers.size(), is(1));
+        assertThat(filteredContainers.get(0).getId(), is(id));
+    }
+
+    @Test
+    public void testNetworkFilter() throws Exception {
+        String id;
+        CreateNetworkResponse network = dockerRule.getClient().createNetworkCmd()
+                .withName("TestFilterNetwork")
+                .withDriver("bridge")
+                .exec();
+
+        id = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
+                .withLabels(testLabel)
+                .withNetworkMode("TestFilterNetwork")
+                .exec()
+                .getId();
+
+        dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
+                .withLabels(testLabel)
+                .exec();
+
+        List<Container> filteredContainers = dockerRule.getClient().listContainersCmd()
+                .withShowAll(true)
+                .withLabelFilter(testLabel)
+                .withNetworkFilter("TestFilterNetwork")
+                .exec();
+
+        assertThat(filteredContainers.size(), is(1));
+        assertThat(filteredContainers.get(0).getId(), is(id));
+    }
+
+    @Test
+    public void testAncestorFilter() throws Exception {
+        dockerRule.getClient().pullImageCmd("busybox")
+                .withTag("1.24")
+                .exec(new PullImageResultCallback())
+                .awaitSuccess();
+
+        dockerRule.getClient().createContainerCmd("busybox:1.24")
+                .withLabels(testLabel)
+                .exec();
+
+        String imageId = dockerRule.getClient().inspectImageCmd(DEFAULT_IMAGE).exec().getId();
+
+        String id = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
+                .withLabels(testLabel)
+                .exec()
+                .getId();
+
+        List<Container> filteredContainers = dockerRule.getClient().listContainersCmd()
+                .withLabelFilter(testLabel)
+                .withShowAll(true)
+                .withAncestorFilter(imageId)
+                .exec();
+
+        assertThat(filteredContainers.size(), is(1));
+        assertThat(filteredContainers.get(0).getId(), is(id));
+    }
+
+    @Test
+    public void testExitedFilter() throws Exception {
+        dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
+                .withLabels(testLabel)
+                .exec();
+
+        String id = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
+                .withLabels(testLabel)
+                .withCmd("sh", "-c", "exit 42")
+                .exec()
+                .getId();
+
+        dockerRule.getClient().startContainerCmd(id).exec();
+
+        Integer status = dockerRule.getClient().waitContainerCmd(id).exec(new WaitContainerResultCallback())
+                .awaitStatusCode();
+
+        assertThat(status, is(42));
+
+        List<Container> filteredContainers = dockerRule.getClient().listContainersCmd()
+                .withLabelFilter(testLabel)
+                .withShowAll(true)
+                .withExitedFilter(42)
+                .exec();
+
+        assertThat(filteredContainers.size(), is(1));
+        assertThat(filteredContainers.get(0).getId(), is(id));
+    }
+
+    private void removeContainer(String id) {
+        if (id != null) {
+            try {
+                dockerRule.getClient().removeContainerCmd(id).withForce(true).exec();
+            } catch (Exception ignored) {}
+        }
+    }
 }

--- a/src/test/java/com/github/dockerjava/cmd/ListContainersCmdIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/ListContainersCmdIT.java
@@ -1,8 +1,6 @@
 package com.github.dockerjava.cmd;
 
 import com.github.dockerjava.api.command.CreateContainerResponse;
-import com.github.dockerjava.api.command.CreateNetworkResponse;
-import com.github.dockerjava.api.command.CreateVolumeResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Container;
@@ -208,7 +206,7 @@ public class ListContainersCmdIT extends CmdIT {
         List<Container> filteredContainers = dockerRule.getClient().listContainersCmd()
                 .withShowAll(true)
                 .withLabelFilter(testLabel)
-                .withStatusFilter("created")
+                .withStatusFilter(singletonList("created"))
                 .exec();
 
         assertThat(filteredContainers.size(), is(2));
@@ -219,7 +217,7 @@ public class ListContainersCmdIT extends CmdIT {
         filteredContainers = dockerRule.getClient().listContainersCmd()
                 .withShowAll(true)
                 .withLabelFilter(testLabel)
-                .withStatusFilter("running")
+                .withStatusFilter(singletonList("running"))
                 .exec();
 
         assertThat(filteredContainers.size(), is(1));
@@ -230,7 +228,7 @@ public class ListContainersCmdIT extends CmdIT {
         filteredContainers = dockerRule.getClient().listContainersCmd()
                 .withShowAll(true)
                 .withLabelFilter(testLabel)
-                .withStatusFilter("paused")
+                .withStatusFilter(singletonList("paused"))
                 .exec();
 
         assertThat(filteredContainers.size(), is(1));
@@ -242,7 +240,7 @@ public class ListContainersCmdIT extends CmdIT {
         filteredContainers = dockerRule.getClient().listContainersCmd()
                 .withShowAll(true)
                 .withLabelFilter(testLabel)
-                .withStatusFilter("exited")
+                .withStatusFilter(singletonList("exited"))
                 .exec();
 
         assertThat(filteredContainers.size(), is(1));
@@ -252,7 +250,7 @@ public class ListContainersCmdIT extends CmdIT {
     @Test
     public void testVolumeFilter() throws Exception {
         String id;
-        CreateVolumeResponse volume = dockerRule.getClient().createVolumeCmd()
+        dockerRule.getClient().createVolumeCmd()
                 .withName("TestFilterVolume")
                 .withDriver("local")
                 .exec();
@@ -280,7 +278,7 @@ public class ListContainersCmdIT extends CmdIT {
     @Test
     public void testNetworkFilter() throws Exception {
         String id;
-        CreateNetworkResponse network = dockerRule.getClient().createNetworkCmd()
+        dockerRule.getClient().createNetworkCmd()
                 .withName("TestFilterNetwork")
                 .withDriver("bridge")
                 .exec();


### PR DESCRIPTION
The following filters were added:
- name
- id
- ancestor (filter on used image names)
- volume
- network
- renamed Exitcode to exited (don't know why it is now named differently)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/744)
<!-- Reviewable:end -->
