### PR TITLE
Add javadoc for `saveImageCmd'

### DIFF
--- a/src/main/java/com/github/dockerjava/api/DockerClient.java
+++ b/src/main/java/com/github/dockerjava/api/DockerClient.java
@@ -111,6 +111,10 @@ public interface DockerClient extends Closeable {
 
     InspectImageCmd inspectImageCmd(@Nonnull String imageId);
 
+    /**
+     * @param name
+     *            The name, e.g. "alexec/busybox" or just "busybox" if you want to default. Not null.
+     */
     SaveImageCmd saveImageCmd(@Nonnull String name);
 
     /**


### PR DESCRIPTION
Maybe we can automatically copy the documentation from `SaveImageCmd.withName`, but I don't know how.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/749)
<!-- Reviewable:end -->
