### PR TITLE
Add support for private docker registry version 2

### DIFF
--- a/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
+++ b/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
@@ -9,6 +9,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
@@ -54,6 +57,8 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
     private static final String DOCKER_JAVA_PROPERTIES = "docker-java.properties";
 
     private static final String DOCKER_CFG = ".dockercfg";
+
+    private static final String CONFIG_JSON = "config.json";
 
     private static final Set<String> CONFIG_KEYS = new HashSet<String>();
 
@@ -253,9 +258,9 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
     public AuthConfig effectiveAuthConfig(String imageName) {
         AuthConfig authConfig = null;
 
-        File dockerCfgFile = new File(getDockerConfig() + File.separator + DOCKER_CFG);
+        File dockerCfgFile = getDockerConfigFile();
 
-        if (dockerCfgFile.exists() && dockerCfgFile.isFile() && imageName != null) {
+        if (dockerCfgFile != null) {
             AuthConfigFile authConfigFile;
             try {
                 authConfigFile = AuthConfigFile.loadConfig(dockerCfgFile);
@@ -279,19 +284,34 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
 
     @Override
     public AuthConfigurations getAuthConfigurations() {
-        File dockerCfgFile = new File(getDockerConfig() + File.separator + DOCKER_CFG);
-        if (dockerCfgFile.exists() && dockerCfgFile.isFile()) {
+        File dockerCfgFile = getDockerConfigFile();
+
+        if (dockerCfgFile != null) {
             AuthConfigFile authConfigFile;
             try {
                 authConfigFile = AuthConfigFile.loadConfig(dockerCfgFile);
             } catch (IOException e) {
-                throw new DockerClientException("Failed to parse dockerCfgFile", e);
+                throw new DockerClientException("Failed to parse dockerCfgFile: " +
+                    dockerCfgFile.getAbsolutePath(), e);
             }
 
             return authConfigFile.getAuthConfigurations();
         }
 
         return new AuthConfigurations();
+    }
+
+    private File getDockerConfigFile() {
+        final Path configJson = Paths.get(getDockerConfig(), CONFIG_JSON);
+        final Path dockerCfg = Paths.get(getDockerConfig(), DOCKER_CFG);
+
+        if (Files.exists(configJson)) {
+            return configJson.toFile();
+        } else if (Files.exists(dockerCfg)) {
+            return dockerCfg.toFile();
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
+++ b/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
@@ -2,12 +2,15 @@ package com.github.dockerjava.core;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
+import java.io.File;
 import java.lang.reflect.Field;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -18,6 +21,8 @@ import org.testng.annotations.Test;
 
 import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.model.AuthConfig;
+import com.github.dockerjava.api.model.AuthConfigurations;
+import com.google.common.io.Resources;
 
 public class DefaultDockerClientConfigTest {
 
@@ -199,6 +204,38 @@ public class DefaultDockerClientConfigTest {
 
         builder.withDockerTlsVerify("1");
         assertThat((Boolean) field.get(builder), is(true));
+    }
+
+    @Test
+    public void testGetAuthConfigurationsFromDockerCfg() throws URISyntaxException {
+        File cfgFile = new File(Resources.getResource("com.github.dockerjava.core/registry.v1").toURI());
+        DefaultDockerClientConfig clientConfig = new DefaultDockerClientConfig(URI.create(
+            "unix://foo"), cfgFile.getAbsolutePath(), "apiVersion", "registryUrl", "registryUsername", "registryPassword",
+            "registryEmail", null);
+
+        AuthConfigurations authConfigurations = clientConfig.getAuthConfigurations();
+        assertThat(authConfigurations, notNullValue());
+        assertThat(authConfigurations.getConfigs().get("https://test.docker.io/v1/"), notNullValue());
+
+        AuthConfig authConfig = authConfigurations.getConfigs().get("https://test.docker.io/v1/");
+        assertThat(authConfig.getUsername(), equalTo("user"));
+        assertThat(authConfig.getPassword(), equalTo("password"));
+    }
+
+    @Test
+    public void testGetAuthConfigurationsFromConfigJson() throws URISyntaxException {
+        File cfgFile = new File(Resources.getResource("com.github.dockerjava.core/registry.v2").toURI());
+        DefaultDockerClientConfig clientConfig = new DefaultDockerClientConfig(URI.create(
+            "unix://foo"), cfgFile.getAbsolutePath(), "apiVersion", "registryUrl", "registryUsername", "registryPassword",
+            "registryEmail", null);
+
+        AuthConfigurations authConfigurations = clientConfig.getAuthConfigurations();
+        assertThat(authConfigurations, notNullValue());
+        assertThat(authConfigurations.getConfigs().get("https://test.docker.io/v2/"), notNullValue());
+
+        AuthConfig authConfig = authConfigurations.getConfigs().get("https://test.docker.io/v2/");
+        assertThat(authConfig.getUsername(), equalTo("user"));
+        assertThat(authConfig.getPassword(), equalTo("password"));
     }
 
 }

--- a/src/test/resources/com.github.dockerjava.core/registry.v1/.dockercfg
+++ b/src/test/resources/com.github.dockerjava.core/registry.v1/.dockercfg
@@ -1,0 +1,5 @@
+{
+  "https://test.docker.io/v1/": {
+    "auth": "dXNlcjpwYXNzd29yZA=="
+  }
+}

--- a/src/test/resources/com.github.dockerjava.core/registry.v2/config.json
+++ b/src/test/resources/com.github.dockerjava.core/registry.v2/config.json
@@ -1,0 +1,7 @@
+{
+  "auths": {
+    "https://test.docker.io/v2/": {
+      "auth": "dXNlcjpwYXNzd29yZA=="
+    }
+  }
+}


### PR DESCRIPTION
Private docker registry version 1 expects the authentication credentials in $DOCKER_HOME/.dockercfg while version 2 expects them in $DOCKER_HOME/config.json. Support for both paths is needed to make docker-java more portable.

This pull request has the following modifications:
* When resolving the path of the authentication configuration file, $DOCKER_HOME/config.json
  (v2) is tried before $DOCKER_HOME/.dockercfg (v1)
* When parsing the content of the authentication configuration file, the format of 
  config.json (v2) is tried before .dockercfg (v1)
* Test for both config.json (v2) and dockercfg (v1) have been added

Related issue: https://github.com/docker-java/docker-java/issues/754

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/756)
<!-- Reviewable:end -->
