### PR TITLE
Adds network labels to `createNetworkCmd` and `Network` domain

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/CreateNetworkCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/CreateNetworkCmd.java
@@ -36,6 +36,12 @@ public interface CreateNetworkCmd extends SyncDockerCmd<CreateNetworkResponse> {
     @CheckForNull
     Boolean getEnableIPv6();
 
+    /**
+     * @since {@link RemoteApiVersion#VERSION_1_23}
+     */
+    @CheckForNull
+    Map<String, String> getLabels();
+
     /** The new network's name. Required. */
     CreateNetworkCmd withName(@Nonnull String name);
 
@@ -51,6 +57,11 @@ public interface CreateNetworkCmd extends SyncDockerCmd<CreateNetworkResponse> {
     CreateNetworkCmd withCheckDuplicate(boolean checkForDuplicate);
 
     CreateNetworkCmd withInternal(boolean internal);
+
+    /**
+     * @since {@link RemoteApiVersion#VERSION_1_23}
+     */
+    CreateNetworkCmd withLabels(Map<String, String> labels);
 
     CreateNetworkCmd withEnableIpv6(boolean enableIpv6);
 

--- a/src/main/java/com/github/dockerjava/api/model/Network.java
+++ b/src/main/java/com/github/dockerjava/api/model/Network.java
@@ -34,6 +34,9 @@ public class Network implements Serializable {
     @JsonProperty("Containers")
     private Map<String, ContainerNetworkConfig> containers;
 
+    @JsonProperty("Labels")
+    private Map<String, String> labels;
+
     @JsonProperty("Options")
     private Map<String, String> options;
 
@@ -52,6 +55,12 @@ public class Network implements Serializable {
     public String getDriver() {
         return driver;
     }
+
+
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+
 
     public Ipam getIpam() {
         return ipam;

--- a/src/main/java/com/github/dockerjava/core/command/CreateNetworkCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CreateNetworkCmdImpl.java
@@ -1,14 +1,14 @@
 package com.github.dockerjava.core.command;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.dockerjava.api.command.CreateNetworkCmd;
 import com.github.dockerjava.api.command.CreateNetworkResponse;
 import com.github.dockerjava.api.command.DockerCmdSyncExec;
 import com.github.dockerjava.api.model.Network;
 import com.github.dockerjava.api.model.Network.Ipam;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class CreateNetworkCmdImpl extends AbstrDockerCmd<CreateNetworkCmd, CreateNetworkResponse>
         implements CreateNetworkCmd {
@@ -27,6 +27,9 @@ public class CreateNetworkCmdImpl extends AbstrDockerCmd<CreateNetworkCmd, Creat
 
     @JsonProperty("CheckDuplicate")
     private Boolean checkDuplicate;
+
+    @JsonProperty("Labels")
+    private Map<String, String> labels;
 
     @JsonProperty("Internal")
     private Boolean internal;
@@ -74,6 +77,12 @@ public class CreateNetworkCmdImpl extends AbstrDockerCmd<CreateNetworkCmd, Creat
     }
 
     @Override
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+
+
+    @Override
     public CreateNetworkCmd withName(String name) {
         this.name = name;
         return this;
@@ -106,6 +115,12 @@ public class CreateNetworkCmdImpl extends AbstrDockerCmd<CreateNetworkCmd, Creat
     @Override
     public CreateNetworkCmd withInternal(boolean internal) {
         this.internal = internal;
+        return this;
+    }
+
+    @Override
+    public CreateNetworkCmd withLabels(Map<String, String> labels) {
+        this.labels = labels;
         return this;
     }
 

--- a/src/test/java/com/github/dockerjava/core/command/CreateNetworkCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/CreateNetworkCmdImplTest.java
@@ -12,6 +12,10 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 
 @Test(groups = "integration")
 public class CreateNetworkCmdImplTest extends AbstractDockerClientTest {
@@ -64,4 +68,21 @@ public class CreateNetworkCmdImplTest extends AbstractDockerClientTest {
         assertEquals(network.getDriver(), "bridge");
         assertEquals("10.67.79.0/24", network.getIpam().getConfig().iterator().next().getSubnet());
     }
+
+
+    @Test
+    public void createNetworkWithLabels() throws DockerException {
+
+        String networkName = "testNetwork";
+        CreateNetworkResponse createNetworkResponse = dockerClient.createNetworkCmd()
+            .withName(networkName).withLabels(Collections.singletonMap("test", "abc")).exec();
+
+        assertNotNull(createNetworkResponse.getId());
+
+        Network network = dockerClient.inspectNetworkCmd().withNetworkId(createNetworkResponse.getId()).exec();
+        assertEquals(network.getName(), networkName);
+        assertThat(network.getLabels().get("test"), equalTo("abc"));
+        assertEquals(network.getDriver(), "bridge");
+    }
+
 }


### PR DESCRIPTION
Hey, 

it looks like we're missing `Labels` on both `Network` domain and `CreateNetworkCmd`.

I'm not sure if all followed all the conventions. Please tell me how can i fix it if something is missing. Thx!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/760)
<!-- Reviewable:end -->
