### PR TITLE
Added healthcheck support in container inspect JSON result

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
+++ b/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
@@ -1,12 +1,7 @@
 package com.github.dockerjava.api.command;
 
-import java.util.List;
-
 import javax.annotation.CheckForNull;
-
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -20,11 +15,12 @@ import com.github.dockerjava.api.model.VolumeBinds;
 import com.github.dockerjava.api.model.VolumeRW;
 import com.github.dockerjava.api.model.VolumesRW;
 import com.github.dockerjava.core.RemoteApiVersion;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
 
 /**
- *
  * @author Konstantin Pelykh (kpelykh@gmail.com)
- *
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class InspectContainerResponse {
@@ -112,7 +108,7 @@ public class InspectContainerResponse {
     }
 
     public Integer getSizeRootFs() {
-        return  sizeRootFs;
+        return sizeRootFs;
     }
 
     public String getCreated() {
@@ -215,195 +211,36 @@ public class InspectContainerResponse {
         return execIds;
     }
 
-    @Override
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
-    }
-
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public class ContainerState {
+    public static class HealthState {
 
-        /**
-         * @since {@link RemoteApiVersion#VERSION_1_20}
-         */
-        @CheckForNull
         @JsonProperty("Status")
         private String status;
 
-        /**
-         * @since < {@link RemoteApiVersion#VERSION_1_16}
-         */
-        @CheckForNull
-        @JsonProperty("Running")
-        private Boolean running;
+        @JsonProperty("FailingStreak")
+        private Integer failingStreak;
 
-        /**
-         * @since {@link RemoteApiVersion#VERSION_1_17}
-         */
-        @CheckForNull
-        @JsonProperty("Paused")
-        private Boolean paused;
+        @JsonProperty("Log")
+        private String[] log;
 
-        /**
-         * @since {@link RemoteApiVersion#VERSION_1_17}
-         */
-        @CheckForNull
-        @JsonProperty("Restarting")
-        private Boolean restarting;
-
-        /**
-         * @since {@link RemoteApiVersion#VERSION_1_17}
-         */
-        @CheckForNull
-        @JsonProperty("OOMKilled")
-        private Boolean oomKilled;
-
-        /**
-         * <a href="https://github.com/docker/docker/pull/18127">Unclear</a>
-         *
-         * @since {@link RemoteApiVersion#UNKNOWN_VERSION}
-         */
-        @CheckForNull
-        @JsonProperty("Dead")
-        private Boolean dead;
-
-        /**
-         * @since < {@link RemoteApiVersion#VERSION_1_16}
-         */
-        @CheckForNull
-        @JsonProperty("Pid")
-        private Integer pid;
-
-        /**
-         * @since < {@link RemoteApiVersion#VERSION_1_16}
-         */
-        @CheckForNull
-        @JsonProperty("ExitCode")
-        private Integer exitCode;
-
-        /**
-         * @since {@link RemoteApiVersion#VERSION_1_17}
-         */
-        @CheckForNull
-        @JsonProperty("Error")
-        private String error;
-
-        /**
-         * @since < {@link RemoteApiVersion#VERSION_1_16}
-         */
-        @CheckForNull
-        @JsonProperty("StartedAt")
-        private String startedAt;
-
-        /**
-         * @since {@link RemoteApiVersion#VERSION_1_17}
-         */
-        @CheckForNull
-        @JsonProperty("FinishedAt")
-        private String finishedAt;
-
-        /**
-         * See {@link #status}
-         */
-        @CheckForNull
         public String getStatus() {
             return status;
         }
 
-        /**
-         * See {@link #running}
-         */
-        @CheckForNull
-        public Boolean getRunning() {
-            return running;
+        public Integer getFailingStreak() {
+            return failingStreak;
         }
 
-        /**
-         * See {@link #paused}
-         */
-        @CheckForNull
-        public Boolean getPaused() {
-            return paused;
+        public String[] getLog() {
+            return log;
         }
+    }
 
-        /**
-         * See {@link #restarting}
-         */
-        @CheckForNull
-        public Boolean getRestarting() {
-            return restarting;
-        }
 
-        /**
-         * See {@link #oomKilled}
-         */
-        @CheckForNull
-        public Boolean getOOMKilled() {
-            return oomKilled;
-        }
 
-        /**
-         * See {@link #dead}
-         */
-        @CheckForNull
-        public Boolean getDead() {
-            return dead;
-        }
-
-        /**
-         * See {@link #pid}
-         */
-        @CheckForNull
-        public Integer getPid() {
-            return pid;
-        }
-
-        /**
-         * See {@link #exitCode}
-         */
-        @CheckForNull
-        public Integer getExitCode() {
-            return exitCode;
-        }
-
-        /**
-         * See {@link #error}
-         */
-        @CheckForNull
-        public String getError() {
-            return error;
-        }
-
-        /**
-         * See {@link #startedAt}
-         */
-        @CheckForNull
-        public String getStartedAt() {
-            return startedAt;
-        }
-
-        /**
-         * See {@link #finishedAt}
-         */
-        @CheckForNull
-        public String getFinishedAt() {
-            return finishedAt;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            return EqualsBuilder.reflectionEquals(this, o);
-        }
-
-        @Override
-        public int hashCode() {
-            return HashCodeBuilder.reflectionHashCode(this);
-        }
-
-        @Override
-        public String toString() {
-            return ToStringBuilder.reflectionToString(this);
-        }
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -544,4 +381,203 @@ public class InspectContainerResponse {
             return HashCodeBuilder.reflectionHashCode(this);
         }
     }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class ContainerState {
+
+        /**
+         * @since {@link RemoteApiVersion#VERSION_1_20}
+         */
+        @CheckForNull
+        @JsonProperty("Status")
+        private String status;
+
+        /**
+         * @since < {@link RemoteApiVersion#VERSION_1_16}
+         */
+        @CheckForNull
+        @JsonProperty("Running")
+        private Boolean running;
+
+        /**
+         * @since {@link RemoteApiVersion#VERSION_1_17}
+         */
+        @CheckForNull
+        @JsonProperty("Paused")
+        private Boolean paused;
+
+        /**
+         * @since {@link RemoteApiVersion#VERSION_1_17}
+         */
+        @CheckForNull
+        @JsonProperty("Restarting")
+        private Boolean restarting;
+
+        /**
+         * @since {@link RemoteApiVersion#VERSION_1_17}
+         */
+        @CheckForNull
+        @JsonProperty("OOMKilled")
+        private Boolean oomKilled;
+
+        /**
+         * <a href="https://github.com/docker/docker/pull/18127">Unclear</a>
+         *
+         * @since {@link RemoteApiVersion#UNKNOWN_VERSION}
+         */
+        @CheckForNull
+        @JsonProperty("Dead")
+        private Boolean dead;
+
+        /**
+         * @since < {@link RemoteApiVersion#VERSION_1_16}
+         */
+        @CheckForNull
+        @JsonProperty("Pid")
+        private Integer pid;
+
+        /**
+         * @since < {@link RemoteApiVersion#VERSION_1_16}
+         */
+        @CheckForNull
+        @JsonProperty("ExitCode")
+        private Integer exitCode;
+
+        /**
+         * @since {@link RemoteApiVersion#VERSION_1_17}
+         */
+        @CheckForNull
+        @JsonProperty("Error")
+        private String error;
+
+        /**
+         * @since < {@link RemoteApiVersion#VERSION_1_16}
+         */
+        @CheckForNull
+        @JsonProperty("StartedAt")
+        private String startedAt;
+
+        /**
+         * @since {@link RemoteApiVersion#VERSION_1_17}
+         */
+        @CheckForNull
+        @JsonProperty("FinishedAt")
+        private String finishedAt;
+
+
+        /**
+         * @since Docker version 1.12
+         */
+        @JsonProperty("Health")
+        private HealthState health;
+
+        /**
+         * See {@link #status}
+         */
+        @CheckForNull
+        public String getStatus() {
+            return status;
+        }
+
+        /**
+         * See {@link #running}
+         */
+        @CheckForNull
+        public Boolean getRunning() {
+            return running;
+        }
+
+        /**
+         * See {@link #paused}
+         */
+        @CheckForNull
+        public Boolean getPaused() {
+            return paused;
+        }
+
+        /**
+         * See {@link #restarting}
+         */
+        @CheckForNull
+        public Boolean getRestarting() {
+            return restarting;
+        }
+
+        /**
+         * See {@link #oomKilled}
+         */
+        @CheckForNull
+        public Boolean getOOMKilled() {
+            return oomKilled;
+        }
+
+        /**
+         * See {@link #dead}
+         */
+        @CheckForNull
+        public Boolean getDead() {
+            return dead;
+        }
+
+        /**
+         * See {@link #pid}
+         */
+        @CheckForNull
+        public Integer getPid() {
+            return pid;
+        }
+
+        /**
+         * See {@link #exitCode}
+         */
+        @CheckForNull
+        public Integer getExitCode() {
+            return exitCode;
+        }
+
+        /**
+         * See {@link #error}
+         */
+        @CheckForNull
+        public String getError() {
+            return error;
+        }
+
+        /**
+         * See {@link #startedAt}
+         */
+        @CheckForNull
+        public String getStartedAt() {
+            return startedAt;
+        }
+
+        /**
+         * See {@link #finishedAt}
+         */
+        @CheckForNull
+        public String getFinishedAt() {
+            return finishedAt;
+        }
+
+        public HealthState getHealth() {
+            return health;
+        }
+
+        @Override
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this);
+        }        @Override
+        public boolean equals(Object o) {
+            return EqualsBuilder.reflectionEquals(this, o);
+        }
+
+
+
+        @Override
+        public String toString() {
+            return ToStringBuilder.reflectionToString(this);
+        }
+    }
+
+
 }

--- a/src/main/java/com/github/dockerjava/api/model/ContainerConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/ContainerConfig.java
@@ -1,5 +1,9 @@
 package com.github.dockerjava.api.model;
 
+import javax.annotation.CheckForNull;
+import java.io.Serializable;
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -8,10 +12,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
-
-import javax.annotation.CheckForNull;
-import java.io.Serializable;
-import java.util.Map;
 
 /**
  * Used as part of 'images/IMAGE/someimage' response.
@@ -85,6 +85,9 @@ public class ContainerConfig implements Serializable {
 
     @JsonProperty("WorkingDir")
     private String workingDir;
+
+    @JsonProperty("Healthcheck")
+    private Healthcheck healthcheck;
 
     @JsonIgnore
     public ExposedPort[] getExposedPorts() {
@@ -411,6 +414,10 @@ public class ContainerConfig implements Serializable {
         return workingDir;
     }
 
+    public Healthcheck getHealthcheck() {
+        return healthcheck;
+    }
+
     /**
      * @see #workingDir
      */
@@ -420,8 +427,8 @@ public class ContainerConfig implements Serializable {
     }
 
     @Override
-    public String toString() {
-        return ToStringBuilder.reflectionToString(this);
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
     }
 
     @Override
@@ -430,7 +437,28 @@ public class ContainerConfig implements Serializable {
     }
 
     @Override
-    public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this);
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(Include.NON_NULL)
+    public static class Healthcheck {
+
+        @JsonProperty("Interval")
+        private Long interval;
+
+        @JsonProperty("Timeout")
+        private Long timeout;
+
+        public Long getInterval() {
+            return interval;
+        }
+
+        public Long getTimeout() {
+            return timeout;
+        }
+    }
+
+
 }

--- a/src/test/java/com/github/dockerjava/api/command/CommandJSONSamples.java
+++ b/src/test/java/com/github/dockerjava/api/command/CommandJSONSamples.java
@@ -24,7 +24,7 @@ import com.github.dockerjava.test.serdes.JSONResourceRef;
  */
 public enum CommandJSONSamples implements JSONResourceRef {
 
-    inspectContainerResponse_full, inspectContainerResponse_full_1_21, inspectContainerResponse_empty;
+    inspectContainerResponse_full, inspectContainerResponse_full_1_21, inspectContainerResponse_empty, inspectContainerResponse_full_healthcheck;
 
     @Override
     public String getFileName() {

--- a/src/test/java/com/github/dockerjava/api/command/InspectContainerResponseTest.java
+++ b/src/test/java/com/github/dockerjava/api/command/InspectContainerResponseTest.java
@@ -15,9 +15,9 @@
  */
 package com.github.dockerjava.api.command;
 
-import org.testng.annotations.Test;
-
 import java.io.IOException;
+
+import org.testng.annotations.Test;
 
 import static com.github.dockerjava.test.serdes.JSONTestHelper.testRoundTrip;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -53,6 +53,18 @@ public class InspectContainerResponseTest {
         assertFalse(response.getVolumesRW()[1].getAccessMode().toBoolean());
         assertTrue(response.getVolumesRW()[0].getAccessMode().toBoolean());
         assertThat(response.getLogPath(), is("/mnt/sda1/var/lib/docker/containers/469e5edd8d5b33e3c905a7ffc97360ec6ee211d6782815fbcd144568045819e1/469e5edd8d5b33e3c905a7ffc97360ec6ee211d6782815fbcd144568045819e1-json.log"));
+    }
+
+    @Test
+    public void roundTrip_full_healthcheck() throws IOException {
+        InspectContainerResponse[] responses = testRoundTrip(CommandJSONSamples.inspectContainerResponse_full_healthcheck,
+                InspectContainerResponse[].class);
+        assertEquals(1, responses.length);
+        final InspectContainerResponse response = responses[0];
+
+        assertEquals(response.getState().getHealth().getStatus(), "starting");
+        assertEquals(response.getState().getHealth().getFailingStreak(), new Integer(0));
+        assertEquals(response.getState().getHealth().getLog(), new String[0]);
     }
 
     @Test

--- a/src/test/resources/com/github/dockerjava/api/command/inspectContainerResponse_full_healthcheck.json
+++ b/src/test/resources/com/github/dockerjava/api/command/inspectContainerResponse_full_healthcheck.json
@@ -1,0 +1,156 @@
+[
+  {
+    "Id": "fc1243c01bbb791d9eca64204d76f72fc47fbebbca892d7dd0a5cd0e4e346045",
+    "Created": "2015-11-20T21:10:34.775649753Z",
+    "Path": "cat",
+    "Args": [],
+    "State": {
+      "Status": "running",
+      "Running": true,
+      "Paused": false,
+      "Restarting": false,
+      "OOMKilled": false,
+      "Dead": false,
+      "Pid": 10912,
+      "ExitCode": 0,
+      "Error": "",
+      "StartedAt": "2015-11-20T21:10:34.845546358Z",
+      "FinishedAt": "0001-01-01T00:00:00Z",
+      "Health": {
+        "Status": "starting",
+        "FailingStreak": 0,
+        "Log": []
+      }
+    },
+    "Image": "c51f86c283408d1749d066333f7acd5d33b053b003a61ff6a7b36819ddcbc7b7",
+    "ResolvConfPath": "/mnt/sda1/var/lib/docker/containers/fc1243c01bbb791d9eca64204d76f72fc47fbebbca892d7dd0a5cd0e4e346045/resolv.conf",
+    "HostnamePath": "/mnt/sda1/var/lib/docker/containers/fc1243c01bbb791d9eca64204d76f72fc47fbebbca892d7dd0a5cd0e4e346045/hostname",
+    "HostsPath": "/mnt/sda1/var/lib/docker/containers/fc1243c01bbb791d9eca64204d76f72fc47fbebbca892d7dd0a5cd0e4e346045/hosts",
+    "LogPath": "/mnt/sda1/var/lib/docker/containers/fc1243c01bbb791d9eca64204d76f72fc47fbebbca892d7dd0a5cd0e4e346045/fc1243c01bbb791d9eca64204d76f72fc47fbebbca892d7dd0a5cd0e4e346045-json.log",
+    "Name": "/small_hodgkin",
+    "RestartCount": 0,
+    "Driver": "aufs",
+    "ExecDriver": "native-0.2",
+    "MountLabel": "",
+    "ProcessLabel": "",
+    "AppArmorProfile": "",
+    "ExecIDs": null,
+    "HostConfig": {
+      "Binds": null,
+      "ContainerIDFile": "",
+      "LxcConf": [],
+      "Memory": 0,
+      "MemoryReservation": 0,
+      "MemorySwap": 0,
+      "KernelMemory": 0,
+      "CpuShares": 0,
+      "CpuPeriod": 0,
+      "CpusetCpus": "",
+      "CpusetMems": "",
+      "CpuQuota": 0,
+      "BlkioWeight": 0,
+      "OomKillDisable": false,
+      "MemorySwappiness": -1,
+      "Privileged": false,
+      "PortBindings": {},
+      "Links": null,
+      "PublishAllPorts": false,
+      "Dns": null,
+      "DnsOptions": null,
+      "DnsSearch": null,
+      "ExtraHosts": null,
+      "VolumesFrom": null,
+      "Devices": [],
+      "NetworkMode": "default",
+      "IpcMode": "",
+      "PidMode": "",
+      "UTSMode": "",
+      "CapAdd": null,
+      "CapDrop": null,
+      "GroupAdd": null,
+      "RestartPolicy": {
+        "Name": "no",
+        "MaximumRetryCount": 0
+      },
+      "SecurityOpt": null,
+      "ReadonlyRootfs": false,
+      "Ulimits": null,
+      "LogConfig": {
+        "Type": "json-file",
+        "Config": {}
+      },
+      "CgroupParent": "",
+      "ConsoleSize": [
+        0,
+        0
+      ],
+      "VolumeDriver": ""
+    },
+    "GraphDriver": {
+      "Name": "aufs",
+      "Data": null
+    },
+    "Mounts": [],
+    "Config": {
+      "Hostname": "fc1243c01bbb",
+      "Domainname": "",
+      "User": "",
+      "AttachStdin": false,
+      "AttachStdout": false,
+      "AttachStderr": false,
+      "Tty": false,
+      "OpenStdin": true,
+      "StdinOnce": false,
+      "Env": null,
+      "Cmd": [
+        "cat"
+      ],
+      "Healthcheck": {
+        "Test": [
+          "CMD-SHELL",
+          "mysqladmin ping --silent"
+        ],
+        "Interval": 2000000000,
+        "Timeout": 3000000000
+      },
+      "Image": "busybox",
+      "Volumes": null,
+      "WorkingDir": "",
+      "Entrypoint": null,
+      "OnBuild": null,
+      "Labels": {},
+      "StopSignal": "SIGTERM"
+    },
+    "NetworkSettings": {
+      "Bridge": "",
+      "SandboxID": "5a6ded01bf23cc180e8ba6a059449ac832f28fa1d8367127e316607f92d3228c",
+      "HairpinMode": false,
+      "LinkLocalIPv6Address": "",
+      "LinkLocalIPv6PrefixLen": 0,
+      "Ports": {},
+      "SandboxKey": "/var/run/docker/netns/5a6ded01bf23",
+      "SecondaryIPAddresses": null,
+      "SecondaryIPv6Addresses": null,
+      "EndpointID": "6b4bb2aff9981d6e132cf37ebbfd370069061fab848ae56247b154717a99aba7",
+      "Gateway": "172.17.0.1",
+      "GlobalIPv6Address": "",
+      "GlobalIPv6PrefixLen": 0,
+      "IPAddress": "172.17.0.2",
+      "IPPrefixLen": 16,
+      "IPv6Gateway": "",
+      "MacAddress": "02:42:ac:11:00:02",
+      "Networks": {
+        "bridge": {
+          "EndpointID": "6b4bb2aff9981d6e132cf37ebbfd370069061fab848ae56247b154717a99aba7",
+          "Gateway": "172.17.0.1",
+          "IPAddress": "172.17.0.2",
+          "IPPrefixLen": 16,
+          "IPv6Gateway": "",
+          "GlobalIPv6Address": "",
+          "GlobalIPv6PrefixLen": 0,
+          "MacAddress": "02:42:ac:11:00:02"
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
Docker version 1.12 introduced [healthcheck support](https://docs.docker.com/engine/reference/builder/#/healthcheck). Healthcheck status is reported in docker inspech result. Result is there only if health check was used.

This PR includes unit test for parsing of JSON docker inspect report.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/763)
<!-- Reviewable:end -->
