### PR TITLE
Clone system properties on access in default config

### DIFF
--- a/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
+++ b/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
@@ -188,7 +188,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
     }
 
     public static Builder createDefaultConfigBuilder() {
-        return createDefaultConfigBuilder(System.getenv(), System.getProperties());
+        return createDefaultConfigBuilder(System.getenv(), (Properties) System.getProperties().clone());
     }
 
     /**


### PR DESCRIPTION
Reducing the time window of the race condition of #771 to the time it takes to clone the system properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/774)
<!-- Reviewable:end -->
