### PR TITLE
Add pidsLimit option when creating containers #779

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/HostConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/HostConfig.java
@@ -170,6 +170,9 @@ public class HostConfig implements Serializable {
     @JsonProperty("PidMode")
     private String pidMode;
 
+    @JsonProperty("PidsLimit")
+    private Integer pidsLimit;
+
     /**
      * @since {@link RemoteApiVersion#VERSION_1_20}
      */
@@ -293,6 +296,11 @@ public class HostConfig implements Serializable {
     @CheckForNull
     public String getPidMode() {
         return pidMode;
+    }
+
+    @CheckForNull
+    public Integer getPidsLimit() {
+        return pidsLimit;
     }
 
     /**
@@ -688,6 +696,14 @@ public class HostConfig implements Serializable {
      */
     public HostConfig withPidMode(String pidMode) {
         this.pidMode = pidMode;
+        return this;
+    }
+
+     /**
+      * @see #pidsLimit
+      */
+    public HostConfig withPidsLimit(Integer pidsLimit) {
+        this.pidsLimit = pidsLimit;
         return this;
     }
 

--- a/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
@@ -584,9 +584,9 @@ public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
     @Test
     public void createContainerWithPidsLimit() throws DockerException {
 
-        HostConfig hostConfig = new HostConfig().withCmd("true").withPidsLimit(1024);
+        HostConfig hostConfig = new HostConfig().withPidsLimit(1024);
 
-        CreateContainerResponse container = dockerClient.createContainerCmd(BUSYBOX_IMAGE).withHostConfig(hostConfig).exec();
+        CreateContainerResponse container = dockerClient.createContainerCmd(BUSYBOX_IMAGE).withHostConfig(hostConfig).withCmd("true").exec();
 
         LOG.info("Created container {}", container.toString());
 

--- a/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
@@ -579,6 +579,25 @@ public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
     }
 
     /**
+     * This test is intended to test the pidLimit option that will help prevent fork bombs and will prevent one container from taking the rest
+     */
+    @Test
+    public void createContainerWithPidsLimit() throws DockerException {
+
+        HostConfig hostConfig = new HostConfig().withCmd("true").withPidsLimit(1024);
+
+        CreateContainerResponse container = dockerClient.createContainerCmd(BUSYBOX_IMAGE).withHostConfig(hostConfig).exec();
+
+        LOG.info("Created container {}", container.toString());
+
+        assertThat(container.getId(), not(isEmptyString()));
+
+        InspectContainerResponse inspectContainerResponse = dockerClient.inspectContainerCmd(container.getId()).exec();
+
+        assertThat(inspectContainerResponse.getHostConfig().getPidsLimit(), is(equalTo(1024)));
+    }
+
+    /**
      * This tests support for --net option for the docker run command: --net="bridge" Set the Network mode for the container 'bridge':
      * creates a new network stack for the container on the docker bridge 'none': no networking for this container 'container:': reuses
      * another container network stack 'host': use the host network stack inside the container. Note: the host mode gives the container full


### PR DESCRIPTION
Enable pid limitation is a cgroups configuration that is able to limit the number of processes that a container can create. This setting is extremely useful as it can prevent fork bombs.

For more details see pids.max https://www.kernel.org/doc/Documentation/cgroup-v1/pids.txt

I have created a fix for this and will soon submit a pull request to HostConfig.java with Testing done.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/780)
<!-- Reviewable:end -->
