### PR TITLE
Add ability to add labels when running commit

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/CommitCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/CommitCmd.java
@@ -3,6 +3,8 @@ package com.github.dockerjava.api.command;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
+import java.util.Map;
+
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.ExposedPorts;
 import com.github.dockerjava.api.model.Volumes;
@@ -28,6 +30,9 @@ public interface CommitCmd extends SyncDockerCmd<String> {
 
     @CheckForNull
     String getHostname();
+
+    @CheckForNull
+    Map<String, String> getLabels();
 
     @CheckForNull
     Integer getMemory();
@@ -87,6 +92,8 @@ public interface CommitCmd extends SyncDockerCmd<String> {
     CommitCmd withExposedPorts(ExposedPorts exposedPorts);
 
     CommitCmd withHostname(String hostname);
+
+    CommitCmd withLabels(Map<String, String> labels);
 
     CommitCmd withMemory(Integer memory);
 

--- a/src/main/java/com/github/dockerjava/core/command/CommitCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CommitCmdImpl.java
@@ -2,6 +2,8 @@ package com.github.dockerjava.core.command;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.dockerjava.api.command.CommitCmd;
 import com.github.dockerjava.api.exception.NotFoundException;
@@ -42,6 +44,9 @@ public class CommitCmdImpl extends AbstrDockerCmd<CommitCmd, String> implements 
 
     @JsonProperty("Hostname")
     private String hostname;
+
+    @JsonProperty("Labels")
+    private Map<String, String> labels;
 
     @JsonProperty("Memory")
     private Integer memory;
@@ -186,6 +191,17 @@ public class CommitCmdImpl extends AbstrDockerCmd<CommitCmd, String> implements 
     public CommitCmdImpl withEnv(String... env) {
         checkNotNull(env, "env was not specified");
         this.env = env;
+        return this;
+    }
+
+    @Override
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+
+    @Override
+    public CommitCmdImpl withLabels(Map<String, String> labels) {
+        this.labels = labels;
         return this;
     }
 

--- a/src/test/java/com/github/dockerjava/netty/exec/CommitCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/CommitCmdExecTest.java
@@ -8,7 +8,9 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.testinfected.hamcrest.jpa.HasFieldWithValue.hasField;
 
 import java.lang.reflect.Method;
+import java.util.Map;
 
+import com.google.common.collect.ImmutableMap;
 import org.testng.ITestResult;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterTest;
@@ -54,7 +56,7 @@ public class CommitCmdExecTest extends AbstractNettyDockerClientTest {
         assertThat(container.getId(), not(isEmptyString()));
         dockerClient.startContainerCmd(container.getId()).exec();
 
-        LOG.info("Commiting container: {}", container.toString());
+        LOG.info("Committing container: {}", container.toString());
         String imageId = dockerClient.commitCmd(container.getId()).exec();
 
         InspectImageResponse inspectImageResponse = dockerClient.inspectImageCmd(imageId).exec();
@@ -66,6 +68,26 @@ public class CommitCmdExecTest extends AbstractNettyDockerClientTest {
         InspectImageResponse busyboxImg = dockerClient.inspectImageCmd("busybox").exec();
 
         assertThat(inspectImageResponse.getParent(), equalTo(busyboxImg.getId()));
+    }
+
+    @Test
+    public void commitWithLabels() throws DockerException {
+
+        CreateContainerResponse container = dockerClient.createContainerCmd("busybox").withCmd("touch", "/test").exec();
+
+        LOG.info("Created container: {}", container.toString());
+        assertThat(container.getId(), not(isEmptyString()));
+        dockerClient.startContainerCmd(container.getId()).exec();
+
+        LOG.info("Committing container: {}", container.toString());
+        Map<String, String> labels = ImmutableMap.of("label1", "abc", "label2", "123");
+        String imageId = dockerClient.commitCmd(container.getId()).withLabels(labels).exec();
+
+        InspectImageResponse inspectImageResponse = dockerClient.inspectImageCmd(imageId).exec();
+        LOG.info("Image Inspect: {}", inspectImageResponse.toString());
+        Map<String, String> responseLabels = inspectImageResponse.getContainerConfig().getLabels();
+        assertThat(responseLabels.get("label1"), equalTo("abc"));
+        assertThat(responseLabels.get("label2"), equalTo("123"));
     }
 
     @Test(expectedExceptions = NotFoundException.class)


### PR DESCRIPTION
Along the lines of https://github.com/docker-java/docker-java/pull/760, this adds support for adding labels, but in this case, when creating images from containers via `commit`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/791)
<!-- Reviewable:end -->
