### PR TITLE
Generate OSGi compliant manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,8 @@
 		<maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
 		<maven-failsafe-plugin.version>2.19.1</maven-failsafe-plugin.version>
 		<maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
+		<maven-bundlor-plugin.version>1.1.2.RELEASE</maven-bundlor-plugin.version>
+		<maven-build-helper-plugin.version>3.0.0</maven-build-helper-plugin.version>
 	</properties>
 
 	<dependencies>
@@ -269,6 +271,19 @@
 		</repository>
 	</distributionManagement>
 
+	<pluginRepositories>
+		<pluginRepository>
+			<id>eclipse.virgo.build.bundles.release</id>
+			<name>Eclipse Virgo Build</name>
+			<url>http://build.eclipse.org/rt/virgo/maven/bundles/release</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>com.springsource.repository.bundles.external</id>
+			<name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
+			<url>http://repository.springsource.com/maven/bundles/external</url>
+		</pluginRepository>
+	</pluginRepositories>
+
 	<build>
 		<pluginManagement>
 			<plugins>
@@ -295,6 +310,11 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
 					<version>${maven-jar-plugin.version}</version>
+					<configuration>
+						<archive>
+							<manifestFile>target/classes/META-INF/MANIFEST.MF</manifestFile>
+						</archive>
+					</configuration>
 					<executions>
 						<execution>
 							<goals>
@@ -429,6 +449,37 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.eclipse.virgo.bundlor</groupId>
+				<artifactId>org.eclipse.virgo.bundlor.maven</artifactId>
+				<version>${maven-bundlor-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>bundlor</id>
+						<goals>
+							<goal>bundlor</goal>
+						</goals>
+						<configuration>
+							<failOnWarnings>true</failOnWarnings>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>${maven-build-helper-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>parse-version</id>
+						<goals>
+							<goal>parse-version</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/template.mf
+++ b/template.mf
@@ -1,0 +1,32 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: com.github.docker-java
+Bundle-Version: ${parsedVersion.osgiVersion}
+Bundle-Name: ${project.name}
+Version-Patterns:
+ default;pattern="[=.=.=, =.+1.0)",
+ short;pattern="[=.=,+1.0)"
+Import-Template:
+ com.fasterxml.jackson.*;version="${jackson-jaxrs.version}",
+ com.google.common.*;version="${guava.version:short}",
+ io.netty.*;version="${netty.version:default}";resolution:=optional,
+ javax.ws.rs.*;version="[2.0.0, 2.1.0)",
+ org.apache.commons.codec.*;version="${commons-codec.version:short}",
+ org.apache.commons.compress.*;version="${commons-compress.version:short}",
+ org.apache.commons.io.*;version="${commons-io.version:short}",
+ org.apache.commons.lang.*;version="${commons-lang.version:short}",
+ org.apache.http.*;version="[4.4.0, 4.6.0)",
+ org.bouncycastle.*;version="${bouncycastle.version:short}",
+ org.glassfish.jersey.*;version="${jersey.version:default}",
+ org.slf4j.*;version="[1.7.0, 1.8.0)",
+ org.newsclub.net.unix;version="${junixsocket.version:default}";resolution:=optional
+Excluded-Exports:
+ org.apache.http.impl.io,
+ org.newsclub.net.unix,
+ com.github.dockerjava.core.*,
+ com.github.dockerjava.jaxrs.*,
+ com.github.dockerjava.netty.*
+Excluded-Imports:
+ javax.annotation,
+ javax.net.ssl,
+ edu.umd.cs.findbugs.annotations

--- a/template.mf
+++ b/template.mf
@@ -23,7 +23,6 @@ Import-Template:
 Excluded-Exports:
  org.apache.http.impl.io,
  org.newsclub.net.unix,
- com.github.dockerjava.core.*,
  com.github.dockerjava.jaxrs.*,
  com.github.dockerjava.netty.*
 Excluded-Imports:


### PR DESCRIPTION
Manifest is generated by the [Bundlor](http://www.eclipse.org/virgo/documentation/bundlor-documentation-1.1.2.RELEASE/docs/user-guide/htmlsingle/user-guide.html) plugin according to the template defined in `template.mf` file. 

Import package versions are mainly derived from properties defined in `pom.xml`.
Imports of Netty packages are marked as optional.

Bundle version is generated by the [Build Helper](http://www.mojohaus.org/build-helper-maven-plugin/parse-version-mojo.html) plugin to be OSGi compliant when developing `SNAPSHOT`s.

This will fix #789

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/797)
<!-- Reviewable:end -->
