### PR TITLE
NettyDockerCmdExecFactory ignores API version configuration

### DIFF
--- a/src/main/java/com/github/dockerjava/netty/NettyDockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/netty/NettyDockerCmdExecFactory.java
@@ -172,6 +172,8 @@ public class NettyDockerCmdExecFactory implements DockerCmdExecFactory {
 
     private NettyInitializer nettyInitializer;
 
+    private WebTarget baseResource;
+
     private ChannelProvider channelProvider = new ChannelProvider() {
         @Override
         public DuplexChannel getChannel() {
@@ -199,6 +201,8 @@ public class NettyDockerCmdExecFactory implements DockerCmdExecFactory {
         }
 
         eventLoopGroup = nettyInitializer.init(bootstrap, dockerClientConfig);
+
+        baseResource = new WebTarget(channelProvider).path(dockerClientConfig.getApiVersion().asWebPathPart());
     }
 
     private DuplexChannel connect() {
@@ -619,6 +623,7 @@ public class NettyDockerCmdExecFactory implements DockerCmdExecFactory {
     }
 
     private WebTarget getBaseResource() {
-        return new WebTarget(channelProvider);
+        checkNotNull(baseResource, "Factory not initialized, baseResource not set. You probably forgot to call init()!");
+        return baseResource;
     }
 }

--- a/src/test/java/com/github/dockerjava/netty/NettyDockerCmdExecFactoryConfigTest.java
+++ b/src/test/java/com/github/dockerjava/netty/NettyDockerCmdExecFactoryConfigTest.java
@@ -1,0 +1,142 @@
+package com.github.dockerjava.netty;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.testng.Assert.assertEquals;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.util.CharsetUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.annotations.Test;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.core.DefaultDockerClientConfig;
+import com.github.dockerjava.core.DefaultDockerClientConfig.Builder;
+import com.github.dockerjava.core.DockerClientBuilder;
+
+public class NettyDockerCmdExecFactoryConfigTest {
+
+    @Test
+    public void testNettyDockerCmdExecFactoryConfigWithApiVersion() throws Exception {
+        NettyDockerCmdExecFactory factory = new NettyDockerCmdExecFactory();
+        Builder configBuilder = DefaultDockerClientConfig.createDefaultConfigBuilder()
+            .withDockerHost("tcp://localhost:2378")
+            .withApiVersion("1.23");
+
+        DockerClient client = DockerClientBuilder.getInstance(configBuilder)
+                .withDockerCmdExecFactory(factory)
+                .build();
+
+        FakeDockerServer server = new FakeDockerServer(2378);
+        server.start();
+        try {
+            client.versionCmd().exec();
+
+            List<HttpRequest> requests = server.getRequests();
+
+            assertEquals(requests.size(), 1);
+            assertEquals(requests.get(0).uri(), "/v1.23/version");
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testNettyDockerCmdExecFactoryConfigWithoutApiVersion() throws Exception {
+        NettyDockerCmdExecFactory factory = new NettyDockerCmdExecFactory();
+        Builder configBuilder = DefaultDockerClientConfig.createDefaultConfigBuilder().withDockerHost("tcp://localhost:2378");
+
+        DockerClient client = DockerClientBuilder.getInstance(configBuilder)
+            .withDockerCmdExecFactory(factory)
+            .build();
+
+        FakeDockerServer server = new FakeDockerServer(2378);
+        server.start();
+        try {
+            client.versionCmd().exec();
+
+            List<HttpRequest> requests = server.getRequests();
+
+            assertEquals(requests.size(), 1);
+            assertEquals(requests.get(0).uri(), "/version");
+        } finally {
+            server.stop();
+        }
+    }
+
+    private class FakeDockerServer {
+        private final int port;
+        private final NioEventLoopGroup parent;
+        private final NioEventLoopGroup child;
+        private final List<HttpRequest> requests = new ArrayList<>();
+        private Channel channel;
+
+        private FakeDockerServer(int port) {
+            this.port = port;
+            this.parent = new NioEventLoopGroup();
+            this.child = new NioEventLoopGroup();
+        }
+
+        private void start() throws Exception {
+            ServerBootstrap bootstrap = new ServerBootstrap();
+            bootstrap.group(parent, child)
+                .channel(NioServerSocketChannel.class)
+                .childHandler(new ChannelInitializer<SocketChannel>() {
+                    @Override
+                    protected void initChannel(SocketChannel socketChannel) throws Exception {
+                        ChannelPipeline pipeline = socketChannel.pipeline();
+                        pipeline.addLast("codec", new HttpServerCodec());
+                        pipeline.addLast("httpHandler", new SimpleChannelInboundHandler<Object>() {
+                            @Override
+                            protected void channelRead0(ChannelHandlerContext context, Object message) throws Exception {
+                                if (message instanceof HttpRequest) {
+                                    // Keep track of processed requests
+                                    HttpRequest request = (HttpRequest) message;
+                                    requests.add(request);
+                                }
+
+                                if (message instanceof HttpContent) {
+                                    // Write an empty JSON response back to the client
+                                    FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.copiedBuffer("{}", CharsetUtil.UTF_8));
+                                    response.headers().set(CONTENT_TYPE, "application/json; charset=UTF-8");
+                                    response.headers().set(CONTENT_LENGTH, response.content().readableBytes());
+                                    context.writeAndFlush(response);
+                                }
+                            }
+                        });
+                    }
+                });
+
+            channel = bootstrap.bind(port).syncUninterruptibly().channel();
+        }
+
+        private void stop() throws Exception {
+            parent.shutdownGracefully();
+            child.shutdownGracefully();
+            channel.closeFuture().sync();
+        }
+
+        private List<HttpRequest> getRequests() {
+            return requests;
+        }
+    }
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/808)
<!-- Reviewable:end -->
