### PR TITLE
exclude commons-logging from httpclient since docker-java uses slf4j/logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
 			<version>${httpclient.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>


### PR DESCRIPTION
See http://stackoverflow.com/questions/21569536/can-i-use-apache-httpclient-without-commons-logging-jar and https://www.slf4j.org/legacy.html for background.

-DB

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/816)
<!-- Reviewable:end -->
