### PR TITLE
Allow an explicit Dockerfile location string to be specified to the build command

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
@@ -117,6 +117,8 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
 
     BuildImageCmd withDockerfile(File dockerfile);
 
+    BuildImageCmd withDockerfilePath(String dockerfilePath);
+
     BuildImageCmd withNoCache(Boolean noCache);
 
     BuildImageCmd withRemove(Boolean rm);

--- a/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
@@ -38,6 +38,8 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
 
     private File dockerFile;
 
+    private String dockerFilePath;
+
     private File baseDirectory;
 
     private String cpusetcpus;
@@ -119,7 +121,9 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
 
     @Override
     public String getPathToDockerfile() {
-        if (baseDirectory != null && dockerFile != null) {
+        if (dockerFilePath != null) {
+            return dockerFilePath;
+        } else if (baseDirectory != null && dockerFile != null) {
             return FilePathUtil.relativize(baseDirectory, dockerFile);
         } else {
             return null;
@@ -284,6 +288,13 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
             // we just created the file this should never happen.
             throw new RuntimeException(e);
         }
+        return this;
+    }
+
+    @Override
+    public BuildImageCmd withDockerfilePath(String dockerfilePath) {
+        checkNotNull(dockerfilePath, "dockerfilePath is null");
+        this.dockerFilePath = dockerfilePath;
         return this;
     }
 

--- a/src/test/java/com/github/dockerjava/core/command/BuildImageCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/BuildImageCmdImplTest.java
@@ -84,6 +84,15 @@ public class BuildImageCmdImplTest extends AbstractDockerClientTest {
     }
 
     @Test
+    public void buildImageFromTarWithDockerfileNotInBaseDirectory() throws Exception {
+        File baseDir = fileFromBuildTestResource("dockerfileNotInBaseDirectory");
+        Collection<File> files = FileUtils.listFiles(baseDir, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
+        File tarFile = CompressArchiveUtil.archiveTARFiles(baseDir, files, UUID.randomUUID().toString());
+        String response = dockerfileBuild(new FileInputStream(tarFile), "dockerfileFolder/Dockerfile");
+        assertThat(response, containsString("Successfully executed testrun.sh"));
+    }
+
+    @Test
     public void onBuild() throws Exception {
         File baseDir = fileFromBuildTestResource("ONBUILD/parent");
 
@@ -121,6 +130,11 @@ public class BuildImageCmdImplTest extends AbstractDockerClientTest {
         File baseDir = fileFromBuildTestResource("ADD/folder");
         String response = dockerfileBuild(baseDir);
         assertThat(response, containsString("Successfully executed testAddFolder.sh"));
+    }
+
+    private String dockerfileBuild(InputStream tarInputStream, String dockerFilePath) throws Exception {
+
+        return execBuild(dockerClient.buildImageCmd().withTarInputStream(tarInputStream).withDockerfilePath(dockerFilePath));
     }
 
     private String dockerfileBuild(InputStream tarInputStream) throws Exception {

--- a/src/test/java/com/github/dockerjava/netty/exec/BuildImageCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/BuildImageCmdExecTest.java
@@ -89,6 +89,15 @@ public class BuildImageCmdExecTest extends AbstractNettyDockerClientTest {
     }
 
     @Test
+    public void buildImageFromTarWithDockerfileNotInBaseDirectory() throws Exception {
+        File baseDir = fileFromBuildTestResource("dockerfileNotInBaseDirectory");
+        Collection<File> files = FileUtils.listFiles(baseDir, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
+        File tarFile = CompressArchiveUtil.archiveTARFiles(baseDir, files, UUID.randomUUID().toString());
+        String response = dockerfileBuild(new FileInputStream(tarFile), "dockerfileFolder/Dockerfile");
+        assertThat(response, containsString("Successfully executed testrun.sh"));
+    }
+
+    @Test
     public void onBuild() throws Exception {
         File baseDir = fileFromBuildTestResource("ONBUILD/parent");
 
@@ -126,6 +135,11 @@ public class BuildImageCmdExecTest extends AbstractNettyDockerClientTest {
         File baseDir = fileFromBuildTestResource("ADD/folder");
         String response = dockerfileBuild(baseDir);
         assertThat(response, containsString("Successfully executed testAddFolder.sh"));
+    }
+
+    private String dockerfileBuild(InputStream tarInputStream, String dockerFilePath) throws Exception {
+
+        return execBuild(dockerClient.buildImageCmd().withTarInputStream(tarInputStream).withDockerfilePath(dockerFilePath));
     }
 
     private String dockerfileBuild(InputStream tarInputStream) throws Exception {


### PR DESCRIPTION
When supplying a tar stream to the build command, API consumers just want to pass a String location of the Dockerfile within the tar stream they are supplying

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/825)
<!-- Reviewable:end -->
