### PR TITLE
Add db LoggingType

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/LogConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/LogConfig.java
@@ -79,6 +79,7 @@ public class LogConfig implements Serializable {
         GELF("gelf"),
         FLUENTD("fluentd"),
         AWSLOGS("awslogs"),
+        DB("db"), // Synology specific driver
         SPLUNK("splunk");
 
         private String type;


### PR DESCRIPTION
Synology uses it's own logging type called db. 

See issue #783

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/839)
<!-- Reviewable:end -->
