### PR TITLE
Docker API update to 1.25 and support for cache-from command as part …

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
@@ -51,6 +51,12 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
     Set<String> getTags();
 
     /**
+     * "Cache-from" in API
+     */
+    @CheckForNull
+    Set<String> getCacheFrom();
+
+    /**
      * "remote" in API
      */
     @CheckForNull
@@ -129,6 +135,11 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
     BuildImageCmd withTag(String tag);
 
     BuildImageCmd withTags(Set<String> tags);
+
+    /*
+     * @since {@link RemoteApiVersion#VERSION_1_25}
+     */
+    BuildImageCmd withCacheFrom(Set<String> cacheFrom);
 
     BuildImageCmd withRemote(URI remote);
 

--- a/src/main/java/com/github/dockerjava/core/RemoteApiVersion.java
+++ b/src/main/java/com/github/dockerjava/core/RemoteApiVersion.java
@@ -72,6 +72,12 @@ public class RemoteApiVersion implements Serializable {
      */
     public static final RemoteApiVersion VERSION_1_24 = RemoteApiVersion.create(1, 24);
 
+    /*
+     * @see <a href="https://docs.docker.com/engine/api/v1.25/">Docker API 1.25</a>
+     */
+    public static final RemoteApiVersion VERSION_1_25 = RemoteApiVersion.create(1, 25);
+
+
     /**
      * Unknown, docker doesn't reflect reality. I.e. we implemented method, but for javadoc it not clear when it was added.
      */

--- a/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
@@ -30,6 +30,8 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
 
     private Set<String> tags;
 
+    private Set<String> cacheFrom;
+
     private Boolean noCache;
 
     private Boolean remove = true;
@@ -97,6 +99,11 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
     @CheckForNull
     public Set<String> getTags() {
         return tags;
+    }
+
+    @CheckForNull
+    public Set<String> getCacheFrom() {
+       return cacheFrom;
     }
 
     @Override
@@ -206,6 +213,12 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
     @Override
     public BuildImageCmd withTags(Set<String> tags) {
         this.tags = tags;
+        return this;
+    }
+
+    @Override
+    public BuildImageCmd withCacheFrom(Set<String> cacheFrom) {
+        this.cacheFrom = cacheFrom;
         return this;
     }
 

--- a/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
@@ -75,6 +75,12 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
             webTarget = webTarget.queryParam("t", command.getTag());
         }
 
+        if (command.getCacheFrom() != null) {
+            for (String c: command.getCacheFrom()) {
+               webTarget = webTarget.queryParam("cachefrom", c);
+            }
+        }
+
         if (command.getRemote() != null) {
             webTarget = webTarget.queryParam("remote", command.getRemote().toString());
         }

--- a/src/main/java/com/github/dockerjava/netty/exec/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/netty/exec/BuildImageCmdExec.java
@@ -58,10 +58,8 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
             webTarget = webTarget.queryParam("t", command.getTag());
         }
 
-        if (command.getCacheFrom() != null) {
-            for (String c: command.getCacheFrom()) {
-               webTarget = webTarget.queryParam("cachefrom", c);
-            }
+        if (command.getCacheFrom() != null && !command.getCacheFrom().isEmpty()) {
+            webTarget = webTarget.queryParamsSet("cachefrom", command.getCacheFrom());
         }
 
         if (command.getRemote() != null) {

--- a/src/main/java/com/github/dockerjava/netty/exec/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/netty/exec/BuildImageCmdExec.java
@@ -55,7 +55,13 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
         if (command.getTags() != null && !command.getTags().isEmpty()) {
             webTarget = webTarget.queryParamsSet("t", command.getTags());
         } else if (isNotBlank(command.getTag())) {
-            webTarget = webTarget.queryParam("t", command.getTags());
+            webTarget = webTarget.queryParam("t", command.getTag());
+        }
+
+        if (command.getCacheFrom() != null) {
+            for (String c: command.getCacheFrom()) {
+               webTarget = webTarget.queryParam("cachefrom", c);
+            }
         }
 
         if (command.getRemote() != null) {

--- a/src/test/java/com/github/dockerjava/netty/exec/BuildImageCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/BuildImageCmdExecTest.java
@@ -318,6 +318,29 @@ public class BuildImageCmdExecTest extends AbstractNettyDockerClientTest {
         assertThat(inspectImageResponse.getRepoTags(), containsInAnyOrder("docker-java-test:tag1", "docker-java-test:tag2"));
     }
 
+    @Test
+    public void cacheFrom() throws Exception {
+    	if (!getVersion(dockerClient).isGreaterOrEqual(RemoteApiVersion.VERSION_1_25)) {
+    		throw new SkipException("API version should be >= 1.25");
+    	}
+    	File baseDir1 = fileFromBuildTestResource("CacheFrom/test1");
+    	String imageId1 = dockerClient.buildImageCmd(baseDir1)
+    			.exec(new BuildImageResultCallback())
+    			.awaitImageId();
+    	InspectImageResponse inspectImageResponse1 = dockerClient.inspectImageCmd(imageId1).exec();
+    	assertThat(inspectImageResponse1, not(nullValue()));
+    	
+    	File baseDir2 = fileFromBuildTestResource("CacheFrom/test2");
+    	String imageId2 = dockerClient.buildImageCmd(baseDir2).withCacheFrom(new HashSet<>(Arrays.asList(imageId1)))
+    			.exec(new BuildImageResultCallback())
+    			.awaitImageId();
+    	InspectImageResponse inspectImageResponse2 = dockerClient.inspectImageCmd(imageId2).exec();
+    	assertThat(inspectImageResponse2, not(nullValue()));
+    	
+    	// Compare whether the image2's parent layer is from image1 so that cache is used
+    	assertThat(inspectImageResponse2.getParent(), equalTo(inspectImageResponse1.getId()));    			
+    }
+
     public void dockerfileNotInBaseDirectory() throws Exception {
         File baseDirectory = fileFromBuildTestResource("dockerfileNotInBaseDirectory");
         File dockerfile = fileFromBuildTestResource("dockerfileNotInBaseDirectory/dockerfileFolder/Dockerfile");


### PR DESCRIPTION
The layer caching is changed after the docker 17.03 release, so added the support for cache-from argument as part of the docker build and optionally upgraded the Docker remote API to 1.25.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/842)
<!-- Reviewable:end -->
