### PR TITLE
fix(#806): filter config.json before unmarshalling

### DIFF
--- a/src/main/java/com/github/dockerjava/core/AuthConfigFile.java
+++ b/src/main/java/com/github/dockerjava/core/AuthConfigFile.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang.StringUtils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.AuthConfigurations;
 
@@ -26,6 +27,7 @@ public class AuthConfigFile {
     private static final TypeReference<Map<String, Map<String, AuthConfig>>> CONFIG_JSON_MAP_TYPE =
         new TypeReference<Map<String, Map<String, AuthConfig>>>() {
         };
+    private static final String AUTHS_PROPERTY = "auths";
 
     private final Map<String, AuthConfig> authConfigMap;
 
@@ -114,10 +116,12 @@ public class AuthConfigFile {
          */
         try {
             // try registry version 2
-            Map<String, Map<String, AuthConfig>>  configJson = MAPPER.readValue(confFile, CONFIG_JSON_MAP_TYPE);
-            if (configJson != null) {
-                configMap = configJson.get("auths");
+            final ObjectNode node = filterNonAuthsFromJSON(confFile);
+            Map<String, Map<String, AuthConfig>>  configJson = MAPPER.convertValue(node, CONFIG_JSON_MAP_TYPE);
+            if (configJson != null && !configJson.isEmpty()) {
+                configMap = configJson.get(AUTHS_PROPERTY);
             }
+
         } catch (IOException e1) {
             try {
                 // try registry version 1
@@ -156,6 +160,15 @@ public class AuthConfigFile {
         }
         return configFile;
 
+    }
+
+    private static ObjectNode filterNonAuthsFromJSON(final File confFile) throws IOException {
+        final ObjectNode node = MAPPER.readValue(confFile, ObjectNode.class);
+        if (!node.has(AUTHS_PROPERTY)) {
+            throw new IOException("No Auth Config contained");
+        }
+        node.retain(AUTHS_PROPERTY);
+        return node;
     }
 
     static void decodeAuth(String auth, AuthConfig config) throws IOException {

--- a/src/test/java/com/github/dockerjava/core/AuthConfigFileTest.java
+++ b/src/test/java/com/github/dockerjava/core/AuthConfigFileTest.java
@@ -69,6 +69,19 @@ public class AuthConfigFileTest {
     }
 
     @Test
+    public void validJsonWithUnknown() throws IOException {
+        AuthConfig authConfig1 = new AuthConfig()
+                .withEmail("foo@example.com")
+                .withUsername("foo")
+                .withPassword("bar")
+                .withRegistryAddress("quay.io");
+
+        AuthConfigFile expected = new AuthConfigFile();
+        expected.addConfig(authConfig1);
+        runTest("validJsonWithUnknown.json");
+    }
+
+    @Test
     public void validLegacy() throws IOException {
         AuthConfig authConfig = new AuthConfig()
                 .withEmail("foo@example.com")

--- a/src/test/resources/testAuthConfigFile/validJsonWithUnknown.json
+++ b/src/test/resources/testAuthConfigFile/validJsonWithUnknown.json
@@ -1,0 +1,11 @@
+{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth" : "Zm9vOmJhcg==",
+      "email" :"foo@example.com"
+    }
+  },
+  "HttpHeaders": {
+    "User-Agent": "user agent"
+  }
+}


### PR DESCRIPTION
As ObjectMapper expects all propeties of json content to match AuthConfig it fails on any other
like "credStore" or "HttpHeaders". As only "auths" is used the json is mapped to ObjectNode so
we can remove any other property. The content of this filtered node can be used as source for
unmarshalling AuthConfig.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/851)
<!-- Reviewable:end -->
