### PR TITLE
skip instead of throw error on non-linux os

### DIFF
--- a/src/test/java/com/github/dockerjava/netty/exec/AttachContainerCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/AttachContainerCmdExecTest.java
@@ -10,8 +10,10 @@ import java.io.File;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.lang.reflect.Method;
+import java.util.Locale;
 
 import org.testng.ITestResult;
+import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeMethod;
@@ -30,6 +32,10 @@ public class AttachContainerCmdExecTest extends AbstractNettyDockerClientTest {
 
     @BeforeTest
     public void beforeTest() throws Exception {
+        // io.netty.channel.epollNative#loadNativeLibrary only support Linux
+        if (!System.getProperty("os.name").toLowerCase(Locale.UK).trim().startsWith("linux")) {
+            throw new SkipException("only support Linux");
+        }
         super.beforeTest();
     }
 


### PR DESCRIPTION
see also: https://github.com/netty/netty/blob/4.1/transport-native-epoll/src/main/java/io/netty/channel/epoll/Native.java#L189

tested on mac and centos

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/854)
<!-- Reviewable:end -->
