### PR TITLE
Make NettyDockerCmdExecFactory has compatibility both Linux and OSX automatically

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 		<!-- test dependencies -->
 		<logback.version>1.1.7</logback.version>
 		<testng.version>6.9.10</testng.version>
-		<netty.version>4.1.3.Final</netty.version>
+		<netty.version>4.1.11.Final</netty.version>
 		<hamcrest.library.version>1.3</hamcrest.library.version>
 		<hamcrest.jpa-matchers>1.8</hamcrest.jpa-matchers>
 		<lambdaj.version>2.3.3</lambdaj.version>
@@ -257,6 +257,12 @@
 			<artifactId>netty-transport-native-epoll</artifactId>
 			<version>${netty.version}</version>
 			<classifier>linux-x86_64</classifier>
+		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-transport-native-kqueue</artifactId>
+			<version>${netty.version}</version>
+			<classifier>osx-x86_64</classifier>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
This PR make compatibility  both Linux and OSX and automatically setting the EventLoopGroup (EpollEventLoopGroup or KQueueEventLoopGroup) .

**Due to  netty/netty#6837 this PR only work on OSX 10.12**

Inspired by @marcuslinke 's branch **netty-native-kqueue** and we discussion #859 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/862)
<!-- Reviewable:end -->
