### PR TITLE
Expose --cpu-quota parameter during container creation - Fixes #863

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
@@ -51,6 +51,9 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
     Integer getCpuPeriod();
 
     @CheckForNull
+    Integer getCpuQuota();
+
+    @CheckForNull
     String getCpusetCpus();
 
     /**
@@ -258,6 +261,8 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
      * @since 1.19
      */
     CreateContainerCmd withCpuPeriod(Integer cpuPeriod);
+
+    CreateContainerCmd withCpuQuota(Integer cpuQuota);
 
     CreateContainerCmd withCpusetCpus(String cpusetCpus);
 

--- a/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
@@ -220,6 +220,12 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
 
     @Override
     @JsonIgnore
+    public Integer getCpuQuota() {
+        return hostConfig.getCpuQuota();
+    }
+
+    @Override
+    @JsonIgnore
     public String getCpusetCpus() {
         return hostConfig.getCpusetCpus();
     }
@@ -579,6 +585,13 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     public CreateContainerCmd withContainerIDFile(String containerIDFile) {
         checkNotNull(containerIDFile, "no containerIDFile was specified");
         hostConfig.withContainerIDFile(containerIDFile);
+        return this;
+    }
+
+    @Override
+    public CreateContainerCmd withCpuQuota(Integer cpuQuota) {
+        checkNotNull(cpuQuota, "cpuQuota was not specified");
+        hostConfig.withCpuQuota(cpuQuota);
         return this;
     }
 

--- a/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/CreateContainerCmdImplTest.java
@@ -801,4 +801,18 @@ public class CreateContainerCmdImplTest extends AbstractDockerClientTest {
         }
         assertThat(containerNetwork, notNullValue());
     }
+
+    public void createContainerWithCpuQuota() throws DockerException {
+        CreateContainerResponse container = dockerClient.createContainerCmd(BUSYBOX_IMAGE).withName("container")
+                .withCpuQuota(50000)
+                .exec();
+
+        LOG.info("Created container {}", container.toString());
+
+        assertThat(container.getId(), not(isEmptyString()));
+
+        InspectContainerResponse inspectContainerResponse = dockerClient.inspectContainerCmd(container.getId()).exec();
+
+        assertEquals(Integer.valueOf(50000), inspectContainerResponse.getHostConfig().getCpuQuota());
+    }
 }


### PR DESCRIPTION
This pull request exposes the option to set `--cpu-quota`.

Issue #863 requests for the option `--cpus`, although it's not yet exposed in [the remote api](https://docs.docker.com/engine/api/v1.29/#operation/ContainerCreate). Docker [calculates](https://github.com/moby/moby/blob/c85f92de15d8f7162b7579143d2be74d8453996d/daemon/cluster/executor/container/container.go#L432-L436) `--cpu-quota` and `--cpu-period` value from `--cpus` automatically by using the kernel's default quota period.

The formula is the following:

```java
private static final int CPU_QUOTA_PERIOD = 100000;

public static int calcQuotaFromCpuNumber(double cpuNumber) {
	return (int)(cpuNumber * CPU_QUOTA_PERIOD);
}
```

Therefore, in order to set an equivalent value of `--cpus=0.5` use instead `--cpu-quota=50000` and `--cpu-period=100000`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/867)
<!-- Reviewable:end -->
