### PR TITLE
#806 - config.json now may have unstructured content without `auths`

### DIFF
--- a/src/main/java/com/github/dockerjava/netty/NettyDockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/netty/NettyDockerCmdExecFactory.java
@@ -1,18 +1,6 @@
 package com.github.dockerjava.netty;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
-import java.security.Security;
-
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLParameters;
-
 import org.apache.commons.lang.SystemUtils;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import com.github.dockerjava.api.command.AttachContainerCmd;
 import com.github.dockerjava.api.command.AuthCmd;

--- a/src/test/java/com/github/dockerjava/core/AuthConfigFileTest.java
+++ b/src/test/java/com/github/dockerjava/core/AuthConfigFileTest.java
@@ -82,6 +82,13 @@ public class AuthConfigFileTest {
     }
 
     @Test
+    public void validJsonWithOnlyUnknown() throws IOException {
+        AuthConfigFile expected = new AuthConfigFile();
+        AuthConfigFile actual = runTest("validJsonWithOnlyUnknown.json");
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
     public void validLegacy() throws IOException {
         AuthConfig authConfig = new AuthConfig()
                 .withEmail("foo@example.com")

--- a/src/test/resources/testAuthConfigFile/validJsonWithOnlyUnknown.json
+++ b/src/test/resources/testAuthConfigFile/validJsonWithOnlyUnknown.json
@@ -1,0 +1,3 @@
+{
+   "credsStore" : "osxkeychain"
+}


### PR DESCRIPTION
- the actually observed sample added as new test
- related to https://youtrack.jetbrains.com/issue/IDEA-175307

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/876)
<!-- Reviewable:end -->
