### PR TITLE
#806 - config.json now may have unstructured content without `auths`

### DIFF
--- a/src/test/java/com/github/dockerjava/core/AuthConfigFileTest.java
+++ b/src/test/java/com/github/dockerjava/core/AuthConfigFileTest.java
@@ -82,6 +82,13 @@ public class AuthConfigFileTest {
     }
 
     @Test
+    public void validJsonWithOnlyUnknown() throws IOException {
+        AuthConfigFile expected = new AuthConfigFile();
+        AuthConfigFile actual = runTest("validJsonWithOnlyUnknown.json");
+        Assert.assertEquals(actual, expected);
+    }
+
+    @Test
     public void validLegacy() throws IOException {
         AuthConfig authConfig = new AuthConfig()
                 .withEmail("foo@example.com")

--- a/src/test/resources/testAuthConfigFile/validJsonWithOnlyUnknown.json
+++ b/src/test/resources/testAuthConfigFile/validJsonWithOnlyUnknown.json
@@ -1,0 +1,3 @@
+{
+   "credsStore" : "osxkeychain"
+}


### PR DESCRIPTION
- the actually observed sample added as new test
- related to https://youtrack.jetbrains.com/issue/IDEA-175307

(cherry picked from commit d171baf)
Signed-off-by: borlander <borlander@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/884)
<!-- Reviewable:end -->
