### PR TITLE
allow user to add custom command by extending NettyDockerCmdExecFactory

### DIFF
--- a/src/main/java/com/github/dockerjava/netty/NettyDockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/netty/NettyDockerCmdExecFactory.java
@@ -747,7 +747,7 @@ public class NettyDockerCmdExecFactory implements DockerCmdExecFactory {
         return channel;
     }
 
-    private WebTarget getBaseResource() {
+    protected WebTarget getBaseResource() {
         checkNotNull(baseResource, "Factory not initialized, baseResource not set. You probably forgot to call init()!");
         return baseResource;
     }


### PR DESCRIPTION
In `JerseyDockerCmdExecFactory` both `getBaseResource` and `getDockerClientConfig` are protected, but in `NettyDockerCmdExecFactory` only `getDockerClientConfig` is protected.   To implement AbstrDockerCmdExec need access getBaseResource

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/888)
<!-- Reviewable:end -->
