### PR TITLE
Include empty directories in build context

### DIFF
--- a/src/test/java/com/github/dockerjava/core/dockerfile/DockerfileAddMultipleFilesTest.java
+++ b/src/test/java/com/github/dockerjava/core/dockerfile/DockerfileAddMultipleFilesTest.java
@@ -59,11 +59,12 @@ public class DockerfileAddMultipleFilesTest {
     @Test
     public void addFiles() throws IOException {
         File baseDir = fileFromBuildTestResource("ADD/files");
+        new File(baseDir, "emptydir").mkdir();
         Dockerfile dockerfile = new Dockerfile(new File(baseDir, "Dockerfile"), baseDir);
         Dockerfile.ScannedResult result = dockerfile.parse();
         Collection<String> filesToAdd = transform(result.filesToAdd, TO_FILE_NAMES);
 
-        assertThat(filesToAdd, containsInAnyOrder("Dockerfile", "src1", "src2"));
+        assertThat(filesToAdd, containsInAnyOrder("emptydir", "Dockerfile", "src1", "src2"));
     }
 
     private File fileFromBuildTestResource(String resource) {


### PR DESCRIPTION
Listing files in build context utilized Commons IO helper method [FileUtils.listFiles()](https://commons.apache.org/proper/commons-io/javadocs/api-2.5/org/apache/commons/io/FileUtils.html#listFiles(java.io.File,%20org.apache.commons.io.filefilter.IOFileFilter,%20org.apache.commons.io.filefilter.IOFileFilter)) which does not return empty directories. This PR implements custom method which lists files in build context also handling empty dirs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/889)
<!-- Reviewable:end -->
