### PR TITLE
Fix .dockerignore handling on Windows

### DIFF
--- a/src/main/java/com/github/dockerjava/core/dockerfile/Dockerfile.java
+++ b/src/main/java/com/github/dockerjava/core/dockerfile/Dockerfile.java
@@ -252,7 +252,8 @@ public class Dockerfile {
          * will be respected.
          */
         private String effectiveMatchingIgnorePattern(File file) {
-            String relativeFilename = FilePathUtil.relativize(baseDirectory, file);
+            // normalize path to replace '/' to '\' on Windows
+            String relativeFilename = FilenameUtils.normalize(FilePathUtil.relativize(baseDirectory, file));
 
             List<String> matchingPattern = matchingIgnorePatterns(relativeFilename);
 


### PR DESCRIPTION
When excluding files from build context using patterns defined in `.dockerignore` file `FilePathUtil.relativize()` method is used. It changes path separator to `/` which leads to files not being properly excluded on Windows machines. This PR fixes that issue.

This PR is partially related to #890 and [gradle-docker-java plugin issue](https://github.com/bmuschko/gradle-docker-plugin/issues/432) as it is impossible to exclude subdirectories and/or files on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/893)
<!-- Reviewable:end -->
