### PR TITLE
Fix .dockerignore handling on Windows

### DIFF
--- a/src/main/java/com/github/dockerjava/core/dockerfile/Dockerfile.java
+++ b/src/main/java/com/github/dockerjava/core/dockerfile/Dockerfile.java
@@ -252,7 +252,8 @@ public class Dockerfile {
          * will be respected.
          */
         private String effectiveMatchingIgnorePattern(File file) {
-            String relativeFilename = FilePathUtil.relativize(baseDirectory, file);
+            // normalize path to replace '/' to '\' on Windows
+            String relativeFilename = FilenameUtils.normalize(FilePathUtil.relativize(baseDirectory, file));
 
             List<String> matchingPattern = matchingIgnorePatterns(relativeFilename);
 


### PR DESCRIPTION
#893 for `3.0.x`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/896)
<!-- Reviewable:end -->
