### PR TITLE
Revert "skip instead of throw error on non-linux os"

### DIFF
--- a/src/test/java/com/github/dockerjava/netty/exec/AttachContainerCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/AttachContainerCmdExecTest.java
@@ -10,10 +10,8 @@ import java.io.File;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.lang.reflect.Method;
-import java.util.Locale;
 
 import org.testng.ITestResult;
-import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeMethod;
@@ -32,10 +30,6 @@ public class AttachContainerCmdExecTest extends AbstractNettyDockerClientTest {
 
     @BeforeTest
     public void beforeTest() throws Exception {
-        // io.netty.channel.epollNative#loadNativeLibrary only support Linux
-        if (!System.getProperty("os.name").toLowerCase(Locale.UK).trim().startsWith("linux")) {
-            throw new SkipException("only support Linux");
-        }
         super.beforeTest();
     }
 


### PR DESCRIPTION
since OSX is supported by https://github.com/docker-java/docker-java/pull/862, I would like to revert the commit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/901)
<!-- Reviewable:end -->
