### PR TITLE
Encode spaces as %20 rather than + in URL params

### DIFF
--- a/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
@@ -137,7 +137,7 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
         if (value != null && !value.isEmpty()) {
             try {
                 return webTarget.queryParam(name,
-                        URLEncoder.encode(MAPPER.writeValueAsString(value), "UTF-8"));
+                        URLEncoder.encode(MAPPER.writeValueAsString(value), "UTF-8").replaceAll("\\+", "%20"));
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/src/test/java/com/github/dockerjava/core/command/BuildImageCmdImplTest.java
+++ b/src/test/java/com/github/dockerjava/core/command/BuildImageCmdImplTest.java
@@ -260,7 +260,7 @@ public class BuildImageCmdImplTest extends AbstractDockerClientTest {
     public void buildArgs() throws Exception {
         File baseDir = fileFromBuildTestResource("buildArgs");
 
-        String imageId = dockerClient.buildImageCmd(baseDir).withNoCache(true).withBuildArg("testArg", "abc")
+        String imageId = dockerClient.buildImageCmd(baseDir).withNoCache(true).withBuildArg("testArg", "abc !@#$%^&*()_+")
                 .exec(new BuildImageResultCallback())
                 .awaitImageId();
 
@@ -268,7 +268,7 @@ public class BuildImageCmdImplTest extends AbstractDockerClientTest {
         assertThat(inspectImageResponse, not(nullValue()));
         LOG.info("Image Inspect: {}", inspectImageResponse.toString());
 
-        assertThat(inspectImageResponse.getConfig().getLabels().get("test"), equalTo("abc"));
+        assertThat(inspectImageResponse.getConfig().getLabels().get("test"), equalTo("abc !@#$%^&*()_+"));
     }
 
     @Test

--- a/src/test/java/com/github/dockerjava/netty/exec/BuildImageCmdExecTest.java
+++ b/src/test/java/com/github/dockerjava/netty/exec/BuildImageCmdExecTest.java
@@ -265,7 +265,7 @@ public class BuildImageCmdExecTest extends AbstractNettyDockerClientTest {
     public void buildArgs() throws Exception {
         File baseDir = fileFromBuildTestResource("buildArgs");
 
-        String imageId = dockerClient.buildImageCmd(baseDir).withNoCache(true).withBuildArg("testArg", "abc")
+        String imageId = dockerClient.buildImageCmd(baseDir).withNoCache(true).withBuildArg("testArg", "abc !@#$%^&*()_+")
                 .exec(new BuildImageResultCallback())
                 .awaitImageId();
 
@@ -273,7 +273,7 @@ public class BuildImageCmdExecTest extends AbstractNettyDockerClientTest {
         assertThat(inspectImageResponse, not(nullValue()));
         LOG.info("Image Inspect: {}", inspectImageResponse.toString());
 
-        assertThat(inspectImageResponse.getConfig().getLabels().get("test"), equalTo("abc"));
+        assertThat(inspectImageResponse.getConfig().getLabels().get("test"), equalTo("abc !@#$%^&*()_+"));
     }
 
     @Test


### PR DESCRIPTION
Java `URLEncoder` will replace spaces with `+` but it seems that Docker expects all URL parameters to be encoded using `%XY`.

This PR will fix [gradle-docker-plugin](https://github.com/bmuschko/gradle-docker-plugin/issues/451) issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/916)
<!-- Reviewable:end -->
