### PR TITLE
Add awaitSuccess with timeout while pulling image

### DIFF
--- a/src/main/java/com/github/dockerjava/core/command/PullImageResultCallback.java
+++ b/src/main/java/com/github/dockerjava/core/command/PullImageResultCallback.java
@@ -50,4 +50,25 @@ public class PullImageResultCallback extends ResultCallbackTemplate<PullImageRes
             throw new DockerClientException("Could not pull image: " + message);
         }
     }
+    
+    /**
+     * Awaits the image to be pulled successful, with timeout
+     *
+     * @throws DockerClientException
+     *             if the pull fails.
+     */
+    public void awaitSuccess(long timeout, TimeUnit timeUnit) {
+        try {
+            awaitCompletion(timeout, timeUnit);
+        } catch (InterruptedException e) {
+            throw new DockerClientException("", e);
+        }
+
+        if (latestItem == null) {
+            throw new DockerClientException("Could not pull image");
+        } else if (!latestItem.isPullSuccessIndicated()) {
+            String message = (latestItem.getError() != null) ? latestItem.getError() : latestItem.getStatus();
+            throw new DockerClientException("Could not pull image: " + message);
+        }
+    }
 }


### PR DESCRIPTION
I'm facing a scenario where Image pulling is taking a lot of time and I need it to timeout after a specific time.   The pull request includes an overloaded `awaitSuccess` method which calls the overloaded `awaitCompletion(timeout, timeoutUnit)` method (already provided), instead of the `awaitCompletion()` method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/939)
<!-- Reviewable:end -->
