### PR TITLE
Add details option for GET /containers/{id}/logs

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/LogContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/LogContainerCmd.java
@@ -25,6 +25,8 @@ import com.github.dockerjava.api.model.Frame;
  * @param since
  *            - UNIX timestamp (integer) to filter logs. Specifying a timestamp will only output log-entries since that timestamp. Default:
  *            0 (unfiltered)
+ * @param details
+ *            - true or false, if true, show extra details provided to logs. Defaults to false.
  */
 public interface LogContainerCmd extends AsyncDockerCmd<LogContainerCmd, Frame> {
 
@@ -45,6 +47,9 @@ public interface LogContainerCmd extends AsyncDockerCmd<LogContainerCmd, Frame> 
 
     @CheckForNull
     Boolean hasStderrEnabled();
+
+    @CheckForNull
+    Boolean hasDetailsEnabled();
 
     @CheckForNull
     Integer getSince();
@@ -68,6 +73,8 @@ public interface LogContainerCmd extends AsyncDockerCmd<LogContainerCmd, Frame> 
     LogContainerCmd withTail(Integer tail);
 
     LogContainerCmd withSince(Integer since);
+
+    LogContainerCmd withDetails(Boolean details);
 
     /**
      * @throws com.github.dockerjava.api.NotFoundException

--- a/src/main/java/com/github/dockerjava/api/command/LogContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/LogContainerCmd.java
@@ -74,6 +74,9 @@ public interface LogContainerCmd extends AsyncDockerCmd<LogContainerCmd, Frame> 
 
     LogContainerCmd withSince(Integer since);
 
+    /**
+     * @since Docker Remote API 1.23
+     */
     LogContainerCmd withDetails(Boolean details);
 
     /**

--- a/src/main/java/com/github/dockerjava/core/command/LogContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/LogContainerCmdImpl.java
@@ -24,12 +24,14 @@ import com.github.dockerjava.api.model.Frame;
  * @param since
  *            - UNIX timestamp (integer) to filter logs. Specifying a timestamp will only output log-entries since that timestamp. Default:
  *            0 (unfiltered)
+ * @param details
+ *            - true or false, if true, show extra details provided to logs. Defaults to false.
  */
 public class LogContainerCmdImpl extends AbstrAsyncDockerCmd<LogContainerCmd, Frame> implements LogContainerCmd {
 
     private String containerId;
 
-    private Boolean followStream, timestamps, stdout, stderr;
+    private Boolean followStream, timestamps, stdout, stderr, details;
 
     private Integer tail, since;
 
@@ -66,6 +68,11 @@ public class LogContainerCmdImpl extends AbstrAsyncDockerCmd<LogContainerCmd, Fr
     @Override
     public Boolean hasStderrEnabled() {
         return stderr;
+    }
+
+    @Override
+    public Boolean hasDetailsEnabled() {
+        return details;
     }
 
     @Override
@@ -119,6 +126,12 @@ public class LogContainerCmdImpl extends AbstrAsyncDockerCmd<LogContainerCmd, Fr
     @Override
     public LogContainerCmd withSince(Integer since) {
         this.since = since;
+        return this;
+    }
+
+    @Override
+    public LogContainerCmd withDetails(Boolean details) {
+        this.details = details;
         return this;
     }
 

--- a/src/main/java/com/github/dockerjava/jaxrs/LogContainerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/LogContainerCmdExec.java
@@ -41,6 +41,7 @@ public class LogContainerCmdExec extends AbstrAsyncDockerCmdExec<LogContainerCmd
         webTarget = booleanQueryParam(webTarget, "stdout", command.hasStdoutEnabled());
         webTarget = booleanQueryParam(webTarget, "stderr", command.hasStderrEnabled());
         webTarget = booleanQueryParam(webTarget, "follow", command.hasFollowStreamEnabled());
+        webTarget = booleanQueryParam(webTarget, "details", command.hasDetailsEnabled());
 
         LOGGER.trace("GET: {}", webTarget);
 

--- a/src/test/java/com/github/dockerjava/cmd/LogContainerCmdIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/LogContainerCmdIT.java
@@ -3,6 +3,7 @@ package com.github.dockerjava.cmd;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.command.LogContainerCmd;
 import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.LogConfig;
 import com.github.dockerjava.api.model.StreamType;
 import com.github.dockerjava.core.command.WaitContainerResultCallback;
 import com.github.dockerjava.utils.LogContainerTestCallback;
@@ -11,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -201,8 +203,12 @@ public class LogContainerCmdIT extends CmdIT {
 
     @Test
     public void asyncLogContainerWithDetails() throws Exception {
-        CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox")
-                .withCmd("--log-driver", "journald", "--log-opt", "env=ENV_VAR", "-e", "ENV_VAR=logtester.1234", "flyinprogrammer/logtester")
+        HashMap<String, String> config = new HashMap<>();
+        config.put("env", "ENV_VAR");
+        LogConfig logConfig = new LogConfig(LogConfig.LoggingType.JOURNALD, config);
+        CreateContainerResponse container = dockerRule.getClient().createContainerCmd("flyinprogrammer/logtester")
+                .withEnv("ENV_VAR=logtester.1234")
+                .withLogConfig(logConfig)
                 .exec();
 
         LOG.info("Created container: {}", container.toString());
@@ -226,8 +232,12 @@ public class LogContainerCmdIT extends CmdIT {
 
     @Test
     public void asyncLogContainerWithoutDetails() throws Exception {
-        CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox")
-                .withCmd("--log-driver", "journald", "--log-opt", "env=ENV_VAR", "-e", "ENV_VAR=logtester.1234", "flyinprogrammer/logtester")
+        HashMap<String, String> config = new HashMap<>();
+        config.put("env", "ENV_VAR");
+        LogConfig logConfig = new LogConfig(LogConfig.LoggingType.JOURNALD, config);
+        CreateContainerResponse container = dockerRule.getClient().createContainerCmd("flyinprogrammer/logtester")
+                .withEnv("ENV_VAR=logtester.1234")
+                .withLogConfig(logConfig)
                 .exec();
 
         LOG.info("Created container: {}", container.toString());


### PR DESCRIPTION
In page `Engine API version history` (https://docs.docker.com/engine/api/version-history/), there is a new `v1.23 API change` for `GET /containers/(id or name)/logs`, which now accepts a `details` query parameter to stream the extra attributes that were provided to the containers `LogOpts`, such as environment variables and labels, with the logs.
This `details` is a boolean option. If `true`, extra details provided to logs will be shown. The default value is `false`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/967)
<!-- Reviewable:end -->
