### PR TITLE
adapt repositoryName with SHA256

### DIFF
--- a/src/main/java/com/github/dockerjava/core/NameParser.java
+++ b/src/main/java/com/github/dockerjava/core/NameParser.java
@@ -5,6 +5,7 @@ package com.github.dockerjava.core;
 
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
@@ -19,6 +20,8 @@ public class NameParser {
 
     // CHECKSTYLE:OFF
     private static final int RepositoryNameTotalLengthMax = 255;
+
+    private static final String SHA256_SEPARATOR = "@sha256:";
 
     private static final Pattern RepositoryNameComponentRegexp = Pattern.compile("[a-z0-9]+(?:[._-][a-z0-9]+)*");
 
@@ -37,6 +40,9 @@ public class NameParser {
             return new ReposTag(name, "");
         }
         String tag = name.substring(n + 1);
+        if (StringUtils.containsIgnoreCase(name, SHA256_SEPARATOR)) {
+            return new ReposTag(name, "");
+        }
         if (!tag.contains("/")) {
             return new ReposTag(name.substring(0, n), tag);
         }
@@ -109,6 +115,9 @@ public class NameParser {
         if (hostname.contains("index.docker.io")) {
             throw new InvalidRepositoryNameException(String.format("Invalid repository name, try \"%s\" instead",
                     reposName));
+        }
+        if (StringUtils.containsIgnoreCase(reposName, SHA256_SEPARATOR)) {
+            reposName = StringUtils.substringBeforeLast(reposName, SHA256_SEPARATOR);
         }
 
         validateRepoName(reposName);

--- a/src/test/java/com/github/dockerjava/core/NameParserTest.java
+++ b/src/test/java/com/github/dockerjava/core/NameParserTest.java
@@ -90,8 +90,20 @@ public class NameParserTest {
     }
 
     @Test
+    public void testResolveRepositoryNameWithNamespaceAndSHA256() throws Exception {
+        HostnameReposName resolved = NameParser.resolveRepositoryName("namespace/repository@sha256:sha256");
+        assertEquals(resolved, new HostnameReposName(AuthConfig.DEFAULT_SERVER_ADDRESS, "namespace/repository@sha256:sha256"));
+    }
+
+    @Test
     public void testResolveRepositoryNameWithNamespaceAndHostname() throws Exception {
         HostnameReposName resolved = NameParser.resolveRepositoryName("localhost:5000/namespace/repository");
+        assertEquals(resolved, new HostnameReposName("localhost:5000", "namespace/repository"));
+    }
+
+    @Test
+    public void testResolveRepositoryNameWithNamespaceAndHostnameAndSHA256() throws Exception {
+        HostnameReposName resolved = NameParser.resolveRepositoryName("localhost:5000/namespace/repository@sha256:sha256");
         assertEquals(resolved, new HostnameReposName("localhost:5000", "namespace/repository"));
     }
 
@@ -122,5 +134,17 @@ public class NameParserTest {
 
         resolved = NameParser.parseRepositoryTag("localhost:5000/namespace/repository:tag");
         assertEquals(resolved, new ReposTag("localhost:5000/namespace/repository", "tag"));
+    }
+
+    @Test
+    public void testResolveReposTagWithSHA256() throws Exception {
+        ReposTag resolved = NameParser.parseRepositoryTag("repository@sha256:sha256");
+        assertEquals(resolved, new ReposTag("repository@sha256:sha256", ""));
+
+        resolved = NameParser.parseRepositoryTag("namespace/repository@sha256:sha256");
+        assertEquals(resolved, new ReposTag("namespace/repository@sha256:sha256", ""));
+
+        resolved = NameParser.parseRepositoryTag("localhost:5000/namespace/repository@sha256:sha256");
+        assertEquals(resolved, new ReposTag("localhost:5000/namespace/repository@sha256:sha256", ""));
     }
 }


### PR DESCRIPTION
Refer to Docker Docs [Pull an image by digest (immutable identifier)](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier)

We can use command 
```
docker pull ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
```
to pull a specific version image.

HTTP API can use by
```
curl -d '{}' -v 127.0.0.1:2376/images/create?fromImage=ubuntu@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
```

And also we can use the SHA256 digest version to create a container.

So, I commit this change to adapt repositoryName with SHA256.

Thanks a lot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/973)
<!-- Reviewable:end -->
