### PR TITLE
fix HTTP/1.1 compliance (missing Host header)

### DIFF
--- a/src/main/java/com/github/dockerjava/netty/NettyDockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/netty/NettyDockerCmdExecFactory.java
@@ -99,16 +99,20 @@ public class NettyDockerCmdExecFactory extends AbstractDockerCmdExecFactory impl
         bootstrap = new Bootstrap();
 
         String scheme = dockerClientConfig.getDockerHost().getScheme();
+        String host = "";
 
         if ("unix".equals(scheme)) {
             nettyInitializer = new UnixDomainSocketInitializer();
+            host = "DUMMY";
         } else if ("tcp".equals(scheme)) {
             nettyInitializer = new InetSocketInitializer();
+            host = dockerClientConfig.getDockerHost().getHost() + ":"
+                + Integer.toString(dockerClientConfig.getDockerHost().getPort());
         }
 
         eventLoopGroup = nettyInitializer.init(bootstrap, dockerClientConfig);
 
-        baseResource = new NettyWebTarget(channelProvider).path(dockerClientConfig.getApiVersion().asWebPathPart());
+        baseResource = new NettyWebTarget(channelProvider, host).path(dockerClientConfig.getApiVersion().asWebPathPart());
     }
 
     private DuplexChannel connect() {

--- a/src/main/java/com/github/dockerjava/netty/NettyWebTarget.java
+++ b/src/main/java/com/github/dockerjava/netty/NettyWebTarget.java
@@ -31,6 +31,8 @@ public class NettyWebTarget implements WebTarget {
 
     private final ChannelProvider channelProvider;
 
+    private final String host;
+
     private final ImmutableList<String> path;
 
     private final ImmutableMap<String, String> queryParams;
@@ -42,16 +44,18 @@ public class NettyWebTarget implements WebTarget {
 
     private static final String PATH_SEPARATOR = "/";
 
-    public NettyWebTarget(ChannelProvider channelProvider) {
-        this(channelProvider, ImmutableList.<String>of(), ImmutableMap.<String, String>of(),
+    public NettyWebTarget(ChannelProvider channelProvider, String host) {
+        this(channelProvider, host, ImmutableList.<String>of(), ImmutableMap.<String, String>of(),
                 ImmutableMap.<String, Set<String>>of());
     }
 
     private NettyWebTarget(ChannelProvider channelProvider,
+                      String host,
                       ImmutableList<String> path,
                       ImmutableMap<String, String> queryParams,
                       ImmutableMap<String, Set<String>> queryParamsSet) {
         this.channelProvider = channelProvider;
+        this.host = host;
         this.path = path;
         this.queryParams = queryParams;
         this.queryParamsSet = queryParamsSet;
@@ -64,7 +68,7 @@ public class NettyWebTarget implements WebTarget {
             newPath.addAll(Arrays.asList(StringUtils.split(component, PATH_SEPARATOR)));
         }
 
-        return new NettyWebTarget(channelProvider, newPath.build(), queryParams, queryParamsSet);
+        return new NettyWebTarget(channelProvider, host, newPath.build(), queryParams, queryParamsSet);
     }
 
     public NettyInvocationBuilder request() {
@@ -85,7 +89,8 @@ public class NettyWebTarget implements WebTarget {
             resource = resource + "?" + StringUtils.join(params, "&");
         }
 
-        return new NettyInvocationBuilder(channelProvider, resource);
+        return new NettyInvocationBuilder(channelProvider, resource)
+            .header("Host", host);
     }
 
     /**
@@ -106,7 +111,7 @@ public class NettyWebTarget implements WebTarget {
             component = component.replaceAll("\\{" + name + "\\}", value.toString());
             newPath.add(component);
         }
-        return new NettyWebTarget(channelProvider, newPath.build(), queryParams, queryParamsSet);
+        return new NettyWebTarget(channelProvider, host, newPath.build(), queryParams, queryParamsSet);
     }
 
     public NettyWebTarget queryParam(String name, Object value) {
@@ -114,7 +119,7 @@ public class NettyWebTarget implements WebTarget {
         if (value != null) {
             builder.put(name, value.toString());
         }
-        return new NettyWebTarget(channelProvider, path, builder.build(), queryParamsSet);
+        return new NettyWebTarget(channelProvider, host, path, builder.build(), queryParamsSet);
     }
 
     public NettyWebTarget queryParamsSet(String name, Set<?> values) {
@@ -126,7 +131,7 @@ public class NettyWebTarget implements WebTarget {
             }
             builder.put(name, valueBuilder.build());
         }
-        return new NettyWebTarget(channelProvider, path, queryParams, builder.build());
+        return new NettyWebTarget(channelProvider, host, path, queryParams, builder.build());
     }
 
     public NettyWebTarget queryParamsJsonMap(String name, Map<String, String> values) {

--- a/src/test/java/com/github/dockerjava/netty/NettyWebTargetTest.java
+++ b/src/test/java/com/github/dockerjava/netty/NettyWebTargetTest.java
@@ -22,7 +22,7 @@ public class NettyWebTargetTest {
 
     @Test
     public void verifyImmutability() throws Exception {
-        NettyWebTarget emptyWebTarget = new NettyWebTarget(channelProvider);
+        NettyWebTarget emptyWebTarget = new NettyWebTarget(channelProvider, "DUMMY");
 
         NettyWebTarget initWebTarget = emptyWebTarget.path("/containers/{id}/attach").resolveTemplate("id", "d03da378b592")
                 .queryParam("logs", "true");
@@ -30,12 +30,12 @@ public class NettyWebTargetTest {
         NettyWebTarget anotherWebTarget = emptyWebTarget.path("/containers/{id}/attach")
                 .resolveTemplate("id", "2cfada4e3c07").queryParam("stdin", "true");
 
-        assertEquals(new NettyWebTarget(channelProvider), emptyWebTarget);
+        assertEquals(new NettyWebTarget(channelProvider, "DUMMY"), emptyWebTarget);
 
-        assertEquals(new NettyWebTarget(channelProvider).path("/containers/d03da378b592/attach")
+        assertEquals(new NettyWebTarget(channelProvider, "DUMMY").path("/containers/d03da378b592/attach")
                 .queryParam("logs", "true"), initWebTarget);
 
-        assertEquals(new NettyWebTarget(channelProvider).path("/containers/2cfada4e3c07/attach")
+        assertEquals(new NettyWebTarget(channelProvider, "DUMMY").path("/containers/2cfada4e3c07/attach")
                 .queryParam("stdin", "true"), anotherWebTarget);
     }
 }


### PR DESCRIPTION
HTTP requests sent by docker-java do not provide a value in the `Host` header.
```
GET /containers/json HTTP/1.1
host:
connection: keep-alive
accept-encoding: gzip
accept: application/json
```
This is not valid HTTP/1.1 since the `Host` header is mandatory and must contain at least the server hostname
https://tools.ietf.org/html/rfc2616#section-14.23

This is an issue when the docker daemon is behind a reverse proxy, especially nginx rejects this with a *400 Bad Request*
https://issues.jenkins-ci.org/browse/JENKINS-48912

Note: the jersey backend does not seem to be affected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/988)
<!-- Reviewable:end -->
