### PR TITLE
fix #927 avoid double encoding for url query string, NettyWebTarget#r…

### DIFF
--- a/src/main/java/com/github/dockerjava/core/exec/ListServicesCmdExec.java
+++ b/src/main/java/com/github/dockerjava/core/exec/ListServicesCmdExec.java
@@ -12,8 +12,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
-import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
-
 public class ListServicesCmdExec extends AbstrSyncDockerCmdExec<ListServicesCmd, List<Service>> implements
         ListServicesCmd.Exec {
 
@@ -29,7 +27,7 @@ public class ListServicesCmdExec extends AbstrSyncDockerCmdExec<ListServicesCmd,
 
         if (command.getFilters() != null && !command.getFilters().isEmpty()) {
             webTarget = webTarget
-                    .queryParam("filters", urlPathSegmentEscaper().escape(FiltersEncoder.jsonEncode(command.getFilters())));
+                    .queryParam("filters", FiltersEncoder.jsonEncode(command.getFilters()));
         }
 
         LOGGER.trace("GET: {}", webTarget);

--- a/src/main/java/com/github/dockerjava/core/exec/ListSwarmNodesCmdExec.java
+++ b/src/main/java/com/github/dockerjava/core/exec/ListSwarmNodesCmdExec.java
@@ -12,8 +12,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
-import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
-
 public class ListSwarmNodesCmdExec extends AbstrSyncDockerCmdExec<ListSwarmNodesCmd, List<SwarmNode>> implements
         ListSwarmNodesCmd.Exec {
 
@@ -30,7 +28,7 @@ public class ListSwarmNodesCmdExec extends AbstrSyncDockerCmdExec<ListSwarmNodes
 
         if (command.getFilters() != null && !command.getFilters().isEmpty()) {
             webTarget = webTarget
-                    .queryParam("filters", urlPathSegmentEscaper().escape(FiltersEncoder.jsonEncode(command.getFilters())));
+                    .queryParam("filters", FiltersEncoder.jsonEncode(command.getFilters()));
         }
 
         LOGGER.trace("GET: {}", webTarget);

--- a/src/main/java/com/github/dockerjava/core/exec/ListTasksCmdExec.java
+++ b/src/main/java/com/github/dockerjava/core/exec/ListTasksCmdExec.java
@@ -12,8 +12,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
-import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
-
 public class ListTasksCmdExec extends AbstrSyncDockerCmdExec<ListTasksCmd, List<Task>> implements
         ListTasksCmd.Exec {
 
@@ -29,7 +27,7 @@ public class ListTasksCmdExec extends AbstrSyncDockerCmdExec<ListTasksCmd, List<
 
         if (command.getFilters() != null && !command.getFilters().isEmpty()) {
             webTarget = webTarget
-                    .queryParam("filters", urlPathSegmentEscaper().escape(FiltersEncoder.jsonEncode(command.getFilters())));
+                    .queryParam("filters", FiltersEncoder.jsonEncode(command.getFilters()));
         }
 
         LOGGER.trace("GET: {}", webTarget);


### PR DESCRIPTION
* fix #927 avoid double encoding for url query string, NettyWebTarget#request will encode the string, we can skip urlPathSegmentEscaper
* The change is for netty only since jetty don't use the class under exec package

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/996)
<!-- Reviewable:end -->
