### PR TITLE
add tmpfs mount support since v1.29

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/Mount.java
+++ b/src/main/java/com/github/dockerjava/api/model/Mount.java
@@ -53,6 +53,12 @@ public class Mount implements Serializable {
     private VolumeOptions volumeOptions;
 
     /**
+     * @since 1.29
+     */
+    @JsonProperty("TmpfsOptions")
+    private TmpfsOptions tmpfsOptions;
+
+    /**
      * @see #type
      */
     @CheckForNull
@@ -129,6 +135,9 @@ public class Mount implements Serializable {
      */
     public Mount withBindOptions(BindOptions bindOptions) {
         this.bindOptions = bindOptions;
+        if (bindOptions != null) {
+            this.type = MountType.BIND;
+        }
         return this;
     }
 
@@ -145,6 +154,28 @@ public class Mount implements Serializable {
      */
     public Mount withVolumeOptions(VolumeOptions volumeOptions) {
         this.volumeOptions = volumeOptions;
+        if (volumeOptions != null) {
+            this.type = MountType.VOLUME;
+        }
+        return this;
+    }
+
+    /**
+     * @see #tmpfsOptions
+     */
+    @CheckForNull
+    public TmpfsOptions getTmpfsOptions() {
+        return tmpfsOptions;
+    }
+
+    /**
+     * @see #tmpfsOptions
+     */
+    public Mount withTmpfsOptions(TmpfsOptions tmpfsOptions) {
+        this.tmpfsOptions = tmpfsOptions;
+        if (tmpfsOptions != null) {
+            this.type = MountType.TMPFS;
+        }
         return this;
     }
 

--- a/src/main/java/com/github/dockerjava/api/model/MountType.java
+++ b/src/main/java/com/github/dockerjava/api/model/MountType.java
@@ -11,5 +11,10 @@ public enum MountType {
     BIND,
 
     @JsonProperty("volume")
-    VOLUME
+    VOLUME,
+
+    //@since 1.29
+    @JsonProperty("tmpfs")
+    TMPFS
+
 }

--- a/src/main/java/com/github/dockerjava/api/model/TmpfsOptions.java
+++ b/src/main/java/com/github/dockerjava/api/model/TmpfsOptions.java
@@ -1,0 +1,61 @@
+package com.github.dockerjava.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.dockerjava.core.RemoteApiVersion;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang.builder.ToStringStyle;
+
+import java.io.Serializable;
+
+/**
+ * @since {@link RemoteApiVersion#VERSION_1_29}
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TmpfsOptions implements Serializable {
+    private static final long serialVersionUID = 1L;
+    @JsonProperty("SizeBytes")
+    //The size for the tmpfs mount in bytes.
+    private Long sizeBytes;
+
+    //The permission mode for the tmpfs mount in an integer.
+    @JsonProperty("Mode")
+    private Integer mode;
+
+    public Long getSizeBytes() {
+        return sizeBytes;
+    }
+
+    public TmpfsOptions withSizeBytes(Long sizeBytes) {
+        this.sizeBytes = sizeBytes;
+        return this;
+    }
+
+    public Integer getMode() {
+        return mode;
+    }
+
+    public TmpfsOptions withMode(Integer mode) {
+        this.mode = mode;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+}


### PR DESCRIPTION
similar to command line option ` --mount type=tmpfs,dst=/dev/shm,tmpfs-size=1000000000`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/997)
<!-- Reviewable:end -->
