### PR TITLE
add support for swarm service/task logs

### DIFF
--- a/src/main/java/com/github/dockerjava/api/DockerClient.java
+++ b/src/main/java/com/github/dockerjava/api/DockerClient.java
@@ -39,6 +39,7 @@ import com.github.dockerjava.api.command.ListTasksCmd;
 import com.github.dockerjava.api.command.ListVolumesCmd;
 import com.github.dockerjava.api.command.LoadImageCmd;
 import com.github.dockerjava.api.command.LogContainerCmd;
+import com.github.dockerjava.api.command.LogSwarmObjectCmd;
 import com.github.dockerjava.api.command.PauseContainerCmd;
 import com.github.dockerjava.api.command.PingCmd;
 import com.github.dockerjava.api.command.PullImageCmd;
@@ -373,6 +374,22 @@ public interface DockerClient extends Closeable {
      * @since 1.24
      */
     ListTasksCmd listTasksCmd();
+
+    /**
+     * Command to get service log
+     *
+     * @return the command
+     * @since 1.29
+     */
+    LogSwarmObjectCmd logServiceCmd(String serviceId);
+
+    /**
+     * Command to get task log
+     *
+     * @return the command
+     * @since 1.29
+     */
+    LogSwarmObjectCmd logTaskCmd(String taskId);
 
     @Override
     void close() throws IOException;

--- a/src/main/java/com/github/dockerjava/api/command/DockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/api/command/DockerCmdExecFactory.java
@@ -163,6 +163,13 @@ public interface DockerCmdExecFactory extends Closeable {
      */
     RemoveServiceCmd.Exec createRemoveServiceCmdExec();
 
+    /**
+     * @param endpoint endpoint name to tail logs
+     * @return
+     * @since {@link RemoteApiVersion#VERSION_1_29}
+     */
+    LogSwarmObjectCmd.Exec logSwarmObjectExec(String endpoint);
+
     // nodes
 
     /**

--- a/src/main/java/com/github/dockerjava/api/command/LogSwarmObjectCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/LogSwarmObjectCmd.java
@@ -1,0 +1,94 @@
+package com.github.dockerjava.api.command;
+
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.model.Frame;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+/**
+ * Get docker service/task stdout/stderr logs
+ */
+public interface LogSwarmObjectCmd extends AsyncDockerCmd<LogSwarmObjectCmd, Frame> {
+    /**
+     * @param id ID or name of the service
+     * @return self
+     */
+    LogSwarmObjectCmd withId(@Nonnull String id);
+
+    /**
+     * @param follow Return the logs as a raw stream.
+     * @return self
+     */
+    LogSwarmObjectCmd withFollow(Boolean follow);
+
+    /**
+     * @param timestamps Add timestamps to every log line
+     * @return self
+     */
+    LogSwarmObjectCmd withTimestamps(Boolean timestamps);
+
+    /**
+     * @param stdout Return logs from stdout
+     * @return self
+     */
+    LogSwarmObjectCmd withStdout(Boolean stdout);
+
+    /**
+     * @param stderr Return logs from stderr
+     * @return self
+     */
+    LogSwarmObjectCmd withStderr(Boolean stderr);
+
+    /**
+     * @param tail only return this number of log lines from the end of the logs.
+     * @return self
+     */
+    LogSwarmObjectCmd withTail(Integer tail);
+
+    /**
+     * @param since Only return logs since this time, as a UNIX timestamp
+     * @return self
+     */
+    LogSwarmObjectCmd withSince(Integer since);
+
+    /**
+     * @param details Show service context and extra details provided to logs.
+     * @return
+     */
+    LogSwarmObjectCmd withDetails(Boolean details);
+
+    @CheckForNull
+    String getId();
+
+    @CheckForNull
+    Integer getTail();
+
+    @CheckForNull
+    Boolean getFollow();
+
+    @CheckForNull
+    Boolean getTimestamps();
+
+    @CheckForNull
+    Boolean getStdout();
+
+    @CheckForNull
+    Boolean getStderr();
+
+    @CheckForNull
+    Integer getSince();
+
+    @CheckForNull
+    Boolean getDetails();
+
+    /**
+     * @throws com.github.dockerjava.api.exception.NotFoundException no such service
+     */
+    @Override
+    <T extends ResultCallback<Frame>> T exec(T resultCallback);
+
+    interface Exec extends DockerCmdAsyncExec<LogSwarmObjectCmd, Frame> {
+    }
+
+}

--- a/src/main/java/com/github/dockerjava/core/AbstractDockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/core/AbstractDockerCmdExecFactory.java
@@ -41,6 +41,7 @@ import com.github.dockerjava.api.command.ListTasksCmd;
 import com.github.dockerjava.api.command.ListVolumesCmd;
 import com.github.dockerjava.api.command.LoadImageCmd;
 import com.github.dockerjava.api.command.LogContainerCmd;
+import com.github.dockerjava.api.command.LogSwarmObjectCmd;
 import com.github.dockerjava.api.command.PauseContainerCmd;
 import com.github.dockerjava.api.command.PingCmd;
 import com.github.dockerjava.api.command.PullImageCmd;
@@ -133,6 +134,7 @@ import com.github.dockerjava.core.exec.UpdateSwarmCmdExec;
 import com.github.dockerjava.core.exec.UpdateSwarmNodeCmdExec;
 import com.github.dockerjava.core.exec.VersionCmdExec;
 import com.github.dockerjava.core.exec.WaitContainerCmdExec;
+import com.github.dockerjava.core.exec.LogSwarmObjectExec;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -483,6 +485,11 @@ public abstract class AbstractDockerCmdExecFactory implements DockerCmdExecFacto
     @Override
     public ListTasksCmd.Exec listTasksCmdExec() {
         return new ListTasksCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public LogSwarmObjectCmd.Exec logSwarmObjectExec(String endpoint) {
+        return new LogSwarmObjectExec(getBaseResource(), getDockerClientConfig(), endpoint);
     }
 
     protected abstract WebTarget getBaseResource();

--- a/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
+++ b/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
@@ -41,6 +41,7 @@ import com.github.dockerjava.api.command.ListTasksCmd;
 import com.github.dockerjava.api.command.ListVolumesCmd;
 import com.github.dockerjava.api.command.LoadImageCmd;
 import com.github.dockerjava.api.command.LogContainerCmd;
+import com.github.dockerjava.api.command.LogSwarmObjectCmd;
 import com.github.dockerjava.api.command.PauseContainerCmd;
 import com.github.dockerjava.api.command.PingCmd;
 import com.github.dockerjava.api.command.PullImageCmd;
@@ -109,6 +110,7 @@ import com.github.dockerjava.core.command.ListTasksCmdImpl;
 import com.github.dockerjava.core.command.ListVolumesCmdImpl;
 import com.github.dockerjava.core.command.LoadImageCmdImpl;
 import com.github.dockerjava.core.command.LogContainerCmdImpl;
+import com.github.dockerjava.core.command.LogSwarmObjectImpl;
 import com.github.dockerjava.core.command.PauseContainerCmdImpl;
 import com.github.dockerjava.core.command.PingCmdImpl;
 import com.github.dockerjava.core.command.PullImageCmdImpl;
@@ -542,7 +544,8 @@ public class DockerClientImpl implements Closeable, DockerClient {
         return new ListSwarmNodesCmdImpl(getDockerCmdExecFactory().listSwarmNodeCmdExec());
     }
 
-    @Override public ListServicesCmd listServicesCmd() {
+    @Override
+    public ListServicesCmd listServicesCmd() {
         return new ListServicesCmdImpl(getDockerCmdExecFactory().createListServicesCmdExec());
     }
 
@@ -564,6 +567,16 @@ public class DockerClientImpl implements Closeable, DockerClient {
     @Override
     public RemoveServiceCmd removeServiceCmd(String serviceId) {
         return new RemoveServiceCmdImpl(getDockerCmdExecFactory().createRemoveServiceCmdExec(), serviceId);
+    }
+
+    @Override
+    public LogSwarmObjectCmd logServiceCmd(String serviceId) {
+        return new LogSwarmObjectImpl(getDockerCmdExecFactory().logSwarmObjectExec("services"), serviceId);
+    }
+
+    @Override
+    public LogSwarmObjectCmd logTaskCmd(String taskId) {
+        return new LogSwarmObjectImpl(getDockerCmdExecFactory().logSwarmObjectExec("tasks"), taskId);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/core/command/LogSwarmObjectImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/LogSwarmObjectImpl.java
@@ -1,0 +1,121 @@
+package com.github.dockerjava.core.command;
+
+import com.github.dockerjava.api.command.DockerCmdAsyncExec;
+import com.github.dockerjava.api.command.LogSwarmObjectCmd;
+import com.github.dockerjava.api.model.Frame;
+
+import javax.annotation.Nonnull;
+
+public class LogSwarmObjectImpl extends AbstrAsyncDockerCmd<LogSwarmObjectCmd, Frame> implements LogSwarmObjectCmd {
+    private String id;
+    private Boolean followStream;
+    private Boolean timestamps;
+    private Boolean stdout;
+    private Boolean stderr;
+    private Boolean tailAll;
+    private Boolean follow;
+    private Integer tail;
+    private Integer since;
+    private Boolean details;
+
+    public LogSwarmObjectImpl(DockerCmdAsyncExec<LogSwarmObjectCmd, Frame> execution, String id) {
+        super(execution);
+        this.id = id;
+    }
+
+    @Override
+    public LogSwarmObjectImpl withId(@Nonnull String id) {
+        this.id = id;
+        return this;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Boolean getFollowStream() {
+        return followStream;
+    }
+
+    public LogSwarmObjectImpl withFollowStream(Boolean followStream) {
+        this.followStream = followStream;
+        return this;
+    }
+
+    public Boolean getTimestamps() {
+        return timestamps;
+    }
+
+    @Override
+    public LogSwarmObjectImpl withTimestamps(Boolean timestamps) {
+        this.timestamps = timestamps;
+        return this;
+    }
+
+    public Boolean getStdout() {
+        return stdout;
+    }
+
+    public LogSwarmObjectImpl withStdout(Boolean stdout) {
+        this.stdout = stdout;
+        return this;
+    }
+
+    public Boolean getStderr() {
+        return stderr;
+    }
+
+    public LogSwarmObjectImpl withStderr(Boolean stderr) {
+        this.stderr = stderr;
+        return this;
+    }
+
+    public Boolean getTailAll() {
+        return tailAll;
+    }
+
+    public LogSwarmObjectImpl withTailAll(Boolean tailAll) {
+        this.tailAll = tailAll;
+        return this;
+    }
+
+    public Integer getTail() {
+        return tail;
+    }
+
+    @Override
+    public LogSwarmObjectImpl withTail(Integer tail) {
+        this.tail = tail;
+        return this;
+    }
+
+    public Integer getSince() {
+        return since;
+    }
+
+    @Override
+    public LogSwarmObjectImpl withSince(Integer since) {
+        this.since = since;
+        return this;
+    }
+
+    public Boolean getFollow() {
+        return follow;
+    }
+
+    @Override
+    public LogSwarmObjectImpl withFollow(Boolean follow) {
+        this.follow = follow;
+        return this;
+    }
+
+    @Override
+    public LogSwarmObjectCmd withDetails(Boolean details) {
+        this.details = details;
+        return this;
+    }
+
+    public Boolean getDetails() {
+        return details;
+    }
+}

--- a/src/main/java/com/github/dockerjava/core/exec/LogSwarmObjectExec.java
+++ b/src/main/java/com/github/dockerjava/core/exec/LogSwarmObjectExec.java
@@ -1,0 +1,48 @@
+package com.github.dockerjava.core.exec;
+
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.LogSwarmObjectCmd;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.core.WebTarget;
+
+import com.github.dockerjava.core.DockerClientConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LogSwarmObjectExec extends AbstrAsyncDockerCmdExec<LogSwarmObjectCmd, Frame> implements
+        LogSwarmObjectCmd.Exec {
+    private String endpoint = "";
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogSwarmObjectExec.class);
+
+    public LogSwarmObjectExec(com.github.dockerjava.core.WebTarget baseResource, DockerClientConfig dockerClientConfig, String endpoint) {
+        super(baseResource, dockerClientConfig);
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    protected Void execute0(LogSwarmObjectCmd command, ResultCallback<Frame> resultCallback) {
+
+        WebTarget webTarget = getBaseResource().path("/" + endpoint + "/{id}/logs").resolveTemplate("id", command.getId());
+
+        if (command.getTail() != null) {
+            webTarget = webTarget.queryParam("tail", command.getTail());
+        } else {
+            webTarget = webTarget.queryParam("tail", "all");
+        }
+
+        if (command.getSince() != null) {
+            webTarget = webTarget.queryParam("since", command.getSince());
+        }
+
+        webTarget = booleanQueryParam(webTarget, "timestamps", command.getTimestamps());
+        webTarget = booleanQueryParam(webTarget, "stdout", command.getStdout());
+        webTarget = booleanQueryParam(webTarget, "stderr", command.getStderr());
+        webTarget = booleanQueryParam(webTarget, "follow", command.getFollow());
+
+        LOGGER.trace("GET: {}", webTarget);
+
+        webTarget.request().get(resultCallback);
+
+        return null;
+    }
+}

--- a/src/main/java/com/github/dockerjava/jaxrs/JerseyDockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/JerseyDockerCmdExecFactory.java
@@ -44,6 +44,7 @@ import com.github.dockerjava.api.command.ListTasksCmd;
 import com.github.dockerjava.api.command.ListVolumesCmd;
 import com.github.dockerjava.api.command.LoadImageCmd;
 import com.github.dockerjava.api.command.LogContainerCmd;
+import com.github.dockerjava.api.command.LogSwarmObjectCmd;
 import com.github.dockerjava.api.command.PauseContainerCmd;
 import com.github.dockerjava.api.command.PingCmd;
 import com.github.dockerjava.api.command.PullImageCmd;
@@ -618,6 +619,11 @@ public class JerseyDockerCmdExecFactory implements DockerCmdExecFactory {
     @Override
     public RemoveServiceCmd.Exec createRemoveServiceCmdExec() {
         return new RemoveServiceCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public LogSwarmObjectCmd.Exec logSwarmObjectExec(String endpoint) {
+        return new LogSwarmObjectExec(getBaseResource(), getDockerClientConfig(), endpoint);
     }
 
     //node

--- a/src/main/java/com/github/dockerjava/jaxrs/LogSwarmObjectExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/LogSwarmObjectExec.java
@@ -1,0 +1,50 @@
+package com.github.dockerjava.jaxrs;
+
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.LogSwarmObjectCmd;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.core.async.FrameStreamProcessor;
+import com.github.dockerjava.jaxrs.async.AbstractCallbackNotifier;
+import com.github.dockerjava.jaxrs.async.GETCallbackNotifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.client.WebTarget;
+
+public class LogSwarmObjectExec extends AbstrAsyncDockerCmdExec<LogSwarmObjectCmd, Frame> implements
+        LogSwarmObjectCmd.Exec {
+
+    public LogSwarmObjectExec(WebTarget baseResource, DockerClientConfig dockerClientConfig, String endpoint) {
+        super(baseResource, dockerClientConfig);
+        this.endpoint = endpoint;
+    }
+
+    private String endpoint = "";
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogSwarmObjectExec.class);
+
+    @Override
+    protected AbstractCallbackNotifier<Frame> callbackNotifier(LogSwarmObjectCmd command, ResultCallback<Frame> resultCallback) {
+
+        WebTarget webTarget = getBaseResource().path("/" + endpoint + "/{id}/logs").resolveTemplate("id", command.getId());
+
+        if (command.getTail() != null) {
+            webTarget = webTarget.queryParam("tail", command.getTail());
+        } else {
+            webTarget = webTarget.queryParam("tail", "all");
+        }
+
+        if (command.getSince() != null) {
+            webTarget = webTarget.queryParam("since", command.getSince());
+        }
+
+        webTarget = booleanQueryParam(webTarget, "timestamps", command.getTimestamps());
+        webTarget = booleanQueryParam(webTarget, "stdout", command.getStdout());
+        webTarget = booleanQueryParam(webTarget, "stderr", command.getStderr());
+        webTarget = booleanQueryParam(webTarget, "follow", command.getFollow());
+        webTarget = booleanQueryParam(webTarget, "details", command.getDetails());
+        LOGGER.trace("GET: {}", webTarget);
+
+        return new GETCallbackNotifier<Frame>(new FrameStreamProcessor(), resultCallback, webTarget.request());
+    }
+}

--- a/src/test/java/com/github/dockerjava/cmd/swarm/LogSwarmObjectIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/swarm/LogSwarmObjectIT.java
@@ -1,0 +1,76 @@
+package com.github.dockerjava.cmd.swarm;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.LogSwarmObjectCmd;
+import com.github.dockerjava.api.model.ContainerSpec;
+import com.github.dockerjava.api.model.ServiceModeConfig;
+import com.github.dockerjava.api.model.ServiceReplicatedModeOptions;
+import com.github.dockerjava.api.model.ServiceRestartCondition;
+import com.github.dockerjava.api.model.ServiceRestartPolicy;
+import com.github.dockerjava.api.model.ServiceSpec;
+import com.github.dockerjava.api.model.SwarmSpec;
+import com.github.dockerjava.api.model.Task;
+import com.github.dockerjava.api.model.TaskSpec;
+import com.github.dockerjava.api.model.TaskState;
+import com.github.dockerjava.utils.LogContainerTestCallback;
+import org.junit.Test;
+import org.mockito.internal.matchers.Contains;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class LogSwarmObjectIT extends SwarmCmdIT {
+    @Test
+    public void testLogsCmd() throws InterruptedException, IOException {
+        String snippet = "hello world";
+        DockerClient docker1 = startDockerInDocker();
+        docker1.initializeSwarmCmd(new SwarmSpec()).exec();
+        TaskSpec taskSpec = new TaskSpec().withContainerSpec(
+                new ContainerSpec().withImage("busybox").withCommand(Arrays.asList("echo", snippet)))
+                .withRestartPolicy(new ServiceRestartPolicy().withCondition(ServiceRestartCondition.NONE));
+        ServiceSpec serviceSpec = new ServiceSpec()
+                .withMode(new ServiceModeConfig().withReplicated(new ServiceReplicatedModeOptions().withReplicas(1)))
+                .withTaskTemplate(taskSpec)
+                .withName("log-worker");
+        String serviceId = docker1.createServiceCmd(serviceSpec).exec().getId();
+        int since = (int) System.currentTimeMillis() / 1000;
+        //wait the service to end
+        List<Task> tasks = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            tasks = docker1.listTasksCmd().withServiceFilter(serviceId).withStateFilter(TaskState.SHUTDOWN).exec();
+            if (tasks.size() == 1) {
+                break;
+            } else {
+                TimeUnit.SECONDS.sleep(3);
+            }
+        }
+        assertThat(tasks.size(), is(1));
+        String taskId = tasks.get(0).getId();
+        //check service log
+        validateLog(docker1.logServiceCmd(serviceId).withStdout(true), snippet);
+        //check task log
+        validateLog(docker1.logTaskCmd(taskId).withStdout(true), snippet);
+        //check details/context
+        validateLog(docker1.logServiceCmd(serviceId).withStdout(true).withDetails(true), "com.docker.swarm.service.id=" + serviceId);
+        validateLog(docker1.logTaskCmd(taskId).withStdout(true).withDetails(true), "com.docker.swarm.service.id=" + serviceId);
+        //check since
+        validateLog(docker1.logServiceCmd(serviceId).withStdout(true).withSince(since), snippet);
+        validateLog(docker1.logTaskCmd(taskId).withStdout(true).withSince(since), snippet);
+        docker1.removeServiceCmd(serviceId).exec();
+    }
+
+    private void validateLog(LogSwarmObjectCmd logCmd, String messsage) throws InterruptedException, IOException {
+        LogContainerTestCallback loggingCallback = new LogContainerTestCallback();
+        logCmd.exec(loggingCallback);
+        loggingCallback.awaitCompletion(5, TimeUnit.SECONDS);
+        assertThat(loggingCallback.toString(), new Contains(messsage));
+        loggingCallback.close();
+    }
+}

--- a/src/test/java/com/github/dockerjava/cmd/swarm/SwarmCmdIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/swarm/SwarmCmdIT.java
@@ -37,7 +37,7 @@ public abstract class SwarmCmdIT extends CmdIT {
     private static final int MAX_CONNECT_ATTEMPTS = 5;
     private static final int CONNECT_ATTEMPT_INTERVAL = 200;
     private static final String DOCKER_IN_DOCKER_IMAGE_REPOSITORY = "docker";
-    private static final String DOCKER_IN_DOCKER_IMAGE_TAG = "1.12-dind";
+    private static final String DOCKER_IN_DOCKER_IMAGE_TAG = "17.12-dind";
 
     @Before
     public void beforeTest() throws Exception {

--- a/src/test/java/com/github/dockerjava/core/TestDockerCmdExecFactory.java
+++ b/src/test/java/com/github/dockerjava/core/TestDockerCmdExecFactory.java
@@ -46,6 +46,7 @@ import com.github.dockerjava.api.command.ListTasksCmd;
 import com.github.dockerjava.api.command.ListVolumesCmd;
 import com.github.dockerjava.api.command.LoadImageCmd;
 import com.github.dockerjava.api.command.LogContainerCmd;
+import com.github.dockerjava.api.command.LogSwarmObjectCmd;
 import com.github.dockerjava.api.command.PauseContainerCmd;
 import com.github.dockerjava.api.command.PingCmd;
 import com.github.dockerjava.api.command.PullImageCmd;
@@ -492,6 +493,11 @@ public class TestDockerCmdExecFactory implements DockerCmdExecFactory {
     @Override
     public RemoveServiceCmd.Exec createRemoveServiceCmdExec() {
         return delegate.createRemoveServiceCmdExec();
+    }
+
+    @Override
+    public LogSwarmObjectCmd.Exec logSwarmObjectExec(String endpoint) {
+        return delegate.logSwarmObjectExec(endpoint);
     }
 
     // nodes


### PR DESCRIPTION
* tail the logs of a service or task, supported in v1.29

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1000)
<!-- Reviewable:end -->
