### PR TITLE
Add option Consistency for mount in ContainerSpec

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/Consistency.java
+++ b/src/main/java/com/github/dockerjava/api/model/Consistency.java
@@ -1,0 +1,22 @@
+package com.github.dockerjava.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.dockerjava.core.RemoteApiVersion;
+
+/**
+ * @since {@link RemoteApiVersion#VERSION_1_29}
+ */
+public enum Consistency {
+
+    @JsonProperty("default")
+    DEFAULT,
+
+    @JsonProperty("consistent")
+    CONSISTENT,
+
+    @JsonProperty("cached")
+    CACHED,
+
+    @JsonProperty("delegated")
+    DELEGATED
+}

--- a/src/main/java/com/github/dockerjava/api/model/Mount.java
+++ b/src/main/java/com/github/dockerjava/api/model/Mount.java
@@ -41,6 +41,12 @@ public class Mount implements Serializable {
     private Boolean readOnly;
 
     /**
+     * @since 1.29
+     */
+    @JsonProperty("Consistency")
+    private Consistency consistency;
+
+    /**
      * @since 1.24
      */
     @JsonProperty("BindOptions")
@@ -113,6 +119,22 @@ public class Mount implements Serializable {
      */
     public Mount withReadOnly(Boolean readOnly) {
         this.readOnly = readOnly;
+        return this;
+    }
+
+    /**
+     * @see #consistency
+     */
+    @CheckForNull
+    public Consistency getConsistency() {
+        return consistency;
+    }
+
+    /**
+     * @see #consistency
+     */
+    public Mount withConsistency(Consistency consistency) {
+        this.consistency = consistency;
         return this;
     }
 

--- a/src/test/java/com/github/dockerjava/cmd/swarm/CreateServiceCmdExecIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/swarm/CreateServiceCmdExecIT.java
@@ -1,9 +1,12 @@
 package com.github.dockerjava.cmd.swarm;
 
 import com.github.dockerjava.api.exception.DockerException;
+import com.github.dockerjava.api.model.Consistency;
 import com.github.dockerjava.api.model.ContainerSpec;
 import com.github.dockerjava.api.model.EndpointResolutionMode;
 import com.github.dockerjava.api.model.EndpointSpec;
+import com.github.dockerjava.api.model.Mount;
+import com.github.dockerjava.api.model.MountType;
 import com.github.dockerjava.api.model.Network;
 import com.github.dockerjava.api.model.NetworkAttachmentConfig;
 import com.github.dockerjava.api.model.PortConfig;
@@ -16,11 +19,15 @@ import com.github.dockerjava.api.model.SwarmSpec;
 import com.github.dockerjava.api.model.TaskSpec;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 
 import static com.github.dockerjava.junit.DockerRule.DEFAULT_IMAGE;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -32,36 +39,32 @@ public class CreateServiceCmdExecIT extends SwarmCmdIT {
     public static final Logger LOG = LoggerFactory.getLogger(CreateServiceCmdExecIT.class);
     private static final String SERVICE_NAME = "theservice";
 
-    @Test
-    public void testCreateService() throws DockerException {
+    @Before
+    public void setUp() throws Exception {
         dockerRule.getClient().initializeSwarmCmd(new SwarmSpec())
                 .withListenAddr("127.0.0.1")
                 .withAdvertiseAddr("127.0.0.1")
                 .exec();
+    }
 
+    @Test
+    public void testCreateService() throws DockerException {
         dockerRule.getClient().createServiceCmd(new ServiceSpec()
                 .withName(SERVICE_NAME)
                 .withTaskTemplate(new TaskSpec()
                         .withContainerSpec(new ContainerSpec()
                                 .withImage(DEFAULT_IMAGE))))
-        .exec();
+                .exec();
 
         List<Service> services = dockerRule.getClient().listServicesCmd()
                 .withNameFilter(Lists.newArrayList(SERVICE_NAME))
                 .exec();
 
         assertThat(services, hasSize(1));
-
-        dockerRule.getClient().removeServiceCmd(SERVICE_NAME).exec();
     }
 
     @Test
     public void testCreateServiceWithNetworks() {
-        dockerRule.getClient().initializeSwarmCmd(new SwarmSpec())
-                .withListenAddr("127.0.0.1")
-                .withAdvertiseAddr("127.0.0.1")
-                .exec();
-
         String networkId = dockerRule.getClient().createNetworkCmd().withName("networkname")
                 .withDriver("overlay")
                 .withIpam(new Network.Ipam()
@@ -79,7 +82,7 @@ public class CreateServiceCmdExecIT extends SwarmCmdIT {
                                 .withTarget(networkId)
                                 .withAliases(Lists.<String>newArrayList("alias1", "alias2"))
                 ))
-                .withLabels(ImmutableMap.of("com.docker.java.usage","SwarmServiceIT"))
+                .withLabels(ImmutableMap.of("com.docker.java.usage", "SwarmServiceIT"))
                 .withMode(new ServiceModeConfig().withReplicated(
                         new ServiceReplicatedModeOptions()
                                 .withReplicas(1)
@@ -100,8 +103,51 @@ public class CreateServiceCmdExecIT extends SwarmCmdIT {
         assertThat(services, hasSize(1));
 
         assertThat(services.get(0).getSpec(), is(spec));
-
-        dockerRule.getClient().removeServiceCmd(SERVICE_NAME).exec();
     }
 
+    private static <T> T randomFrom(Random r, T[] array) {
+        return array[r.nextInt(array.length)];
+    }
+
+    @Test
+    public void testCreateServiceWithConsistency() {
+        final Random random = new Random();
+        final Mount mount = new Mount().withTarget("/tmp/foo")
+                .withType(randomFrom(random, MountType.values()))
+                .withConsistency(randomFrom(random, Consistency.values()));
+        final ContainerSpec containerSpec = new ContainerSpec()
+                .withImage("busybox")
+                .withMounts(Collections.singletonList(mount));
+        final TaskSpec taskSpec = new TaskSpec()
+                .withForceUpdate(0)
+                .withContainerSpec(containerSpec);
+        final ServiceModeConfig modeConfig = new ServiceModeConfig()
+                .withReplicated(new ServiceReplicatedModeOptions().withReplicas(1));
+        final ServiceSpec spec = new ServiceSpec()
+                .withName(SERVICE_NAME)
+                .withTaskTemplate(taskSpec)
+                .withLabels(ImmutableMap.of("com.docker.java.usage", "SwarmServiceIT"))
+                .withMode(modeConfig)
+                .withEndpointSpec(new EndpointSpec()
+                        .withMode(EndpointResolutionMode.VIP)
+                        .withPorts(Lists.newArrayList(new PortConfig()
+                                .withPublishMode(PortConfig.PublishMode.host)
+                                .withPublishedPort(22)
+                                .withProtocol(PortConfigProtocol.TCP)
+                        )));
+
+        dockerRule.getClient().createServiceCmd(spec).exec();
+
+        List<Service> services = dockerRule.getClient().listServicesCmd()
+                .withNameFilter(Lists.newArrayList(SERVICE_NAME))
+                .exec();
+
+        assertThat(services, hasSize(1));
+        assertThat(services.get(0).getSpec(), is(spec));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        dockerRule.getClient().removeServiceCmd(SERVICE_NAME).exec();
+    }
 }


### PR DESCRIPTION
Since version 1.29, there is a new option was added to```mount``` object in ```ContainerSpec``` of ```TaskTemplated```: https://docs.docker.com/engine/api/v1.29/#operation/ServiceCreate

I'm not sure why the test is failed. Any comments are appreciated. 👍 

Cc @fengxx

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1001)
<!-- Reviewable:end -->
