### PR TITLE
tarInputStream was changed during exec and rerun the method will thro…

### DIFF
--- a/src/main/java/com/github/dockerjava/core/command/CopyArchiveToContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CopyArchiveToContainerCmdImpl.java
@@ -143,6 +143,7 @@ public class CopyArchiveToContainerCmdImpl extends AbstrDockerCmd<CopyArchiveToC
             } catch (IOException e) {
                 throw new DockerClientException("Unable to read temp file " + toUpload.toFile().getAbsolutePath(), e);
             } finally {
+                this.tarInputStream = null;
                 // remove tmp docker-javaxxx.tar.gz
                 toUpload.toFile().delete();
             }

--- a/src/test/java/com/github/dockerjava/cmd/CopyArchiveToContainerCmdIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/CopyArchiveToContainerCmdIT.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.cmd;
 
+import com.github.dockerjava.api.command.CopyArchiveToContainerCmd;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.core.command.WaitContainerResultCallback;
@@ -45,6 +46,17 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
                 .withHostResource("src/test/resources/testReadFile")
                 .exec();
         assertFileCopied(container);
+    }
+
+    @Test
+    public void copyStreamToContainerTwice() throws Exception {
+        CreateContainerResponse container = prepareContainerForCopy("rerun");
+        CopyArchiveToContainerCmd copyArchiveToContainerCmd=dockerRule.getClient().copyArchiveToContainerCmd(container.getId())
+                .withHostResource("src/test/resources/testReadFile");
+        copyArchiveToContainerCmd.exec();
+        assertFileCopied(container);
+        //run again to make sure no DockerClientException
+        copyArchiveToContainerCmd.exec();
     }
 
     private CreateContainerResponse prepareContainerForCopy(String method) {


### PR DESCRIPTION
tarInputStream was changed during exec and rerun the method will throw client error: Only one of host resource or tar input stream should be defined to perform the copy, not both

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1003)
<!-- Reviewable:end -->
