### PR TITLE
Fix #921, make AuthConfig compatible with indentitytoken which was in…

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/AuthConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/AuthConfig.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import javax.annotation.CheckForNull;
 import java.io.Serializable;
 
 @JsonInclude(Include.NON_NULL)
@@ -41,6 +40,13 @@ public class AuthConfig implements Serializable {
      */
     @JsonProperty("registrytoken")
     private String registrytoken;
+
+
+    /**
+     * @since {@link com.github.dockerjava.core.RemoteApiVersion#VERSION_1_23}
+     */
+    @JsonProperty("identitytoken")
+    private String identitytoken;
 
     public String getUsername() {
         return username;
@@ -90,7 +96,6 @@ public class AuthConfig implements Serializable {
     /**
      * @see #registrytoken
      */
-    @CheckForNull
     public String getRegistrytoken() {
         return registrytoken;
     }
@@ -100,6 +105,21 @@ public class AuthConfig implements Serializable {
      */
     public AuthConfig withRegistrytoken(String registrytoken) {
         this.registrytoken = registrytoken;
+        return this;
+    }
+
+    /**
+     * @see #identitytoken
+     */
+    public String getIdentitytoken() {
+        return identitytoken;
+    }
+
+    /**
+     * @see #identitytoken
+     */
+    public AuthConfig withIdentityToken(String identitytoken) {
+        this.identitytoken = identitytoken;
         return this;
     }
 

--- a/src/main/java/com/github/dockerjava/core/AbstractDockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/core/AbstractDockerCmdExecFactory.java
@@ -138,7 +138,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public abstract class AbstractDockerCmdExecFactory implements DockerCmdExecFactory {
 
-    private DockerClientConfig dockerClientConfig;
+    protected DockerClientConfig dockerClientConfig;
 
     protected DockerClientConfig getDockerClientConfig() {
         checkNotNull(dockerClientConfig,

--- a/src/test/java/com/github/dockerjava/api/model/AuthConfigTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/AuthConfigTest.java
@@ -61,4 +61,24 @@ public class AuthConfigTest {
 
         assertThat(authConfig1, equalTo(authConfig));
     }
+
+    @Test
+    public void compatibleWithIdentitytoken() throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+        final JavaType type = mapper.getTypeFactory().uncheckedSimpleType(AuthConfig.class);
+
+        final AuthConfig authConfig = testRoundTrip(RemoteApiVersion.VERSION_1_23,
+                "/auth/config.json",
+                type
+        );
+
+        String identitytoken = "403f751f5f2b21...";
+        assertThat(authConfig, notNullValue());
+        assertThat(authConfig.getIdentitytoken(), is(identitytoken));
+
+
+        final AuthConfig authConfig1 = new AuthConfig().withIdentityToken(identitytoken);
+
+        assertThat(authConfig1, equalTo(authConfig));
+    }
 }

--- a/src/test/resources/samples/1.23/auth/config.json
+++ b/src/test/resources/samples/1.23/auth/config.json
@@ -1,0 +1,3 @@
+{
+  "identitytoken": "403f751f5f2b21..."
+}


### PR DESCRIPTION
Fix #921, make AuthConfig compatible with indentitytoken which was introduced in DOCKER API 1.23

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1004)
<!-- Reviewable:end -->
