### PR TITLE
Update jacoco

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -531,7 +531,7 @@
 					<plugin>
 						<groupId>org.jacoco</groupId>
 						<artifactId>jacoco-maven-plugin</artifactId>
-						<version>0.7.7.201606060606</version>
+						<version>0.8.1</version>
 						<executions>
 							<execution>
 								<goals>


### PR DESCRIPTION
Update jacoco version.

Jacoco 0.8.1 is released.
The jacoco version contains JDK10 support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1017)
<!-- Reviewable:end -->
