### PR TITLE
configure JerseyDockerCmdExecFactory to avoid chunked encoding (default of ApacheConnector)

### DIFF
--- a/src/main/java/com/github/dockerjava/jaxrs/JerseyDockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/JerseyDockerCmdExecFactory.java
@@ -87,6 +87,7 @@ import org.glassfish.jersey.apache.connector.ApacheClientProperties;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.RequestEntityProcessing;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -136,6 +137,8 @@ public class JerseyDockerCmdExecFactory implements DockerCmdExecFactory {
 
     private PoolingHttpClientConnectionManager connManager = null;
 
+    private RequestEntityProcessing requestEntityProcessing;
+
     @Override
     public void init(DockerClientConfig dockerClientConfig) {
         checkNotNull(dockerClientConfig, "config was not specified");
@@ -145,6 +148,9 @@ public class JerseyDockerCmdExecFactory implements DockerCmdExecFactory {
         clientConfig.connectorProvider(new ApacheConnectorProvider());
         clientConfig.property(CommonProperties.FEATURE_AUTO_DISCOVERY_DISABLE, true);
 
+        if (requestEntityProcessing != null) {
+            clientConfig.property(ClientProperties.REQUEST_ENTITY_PROCESSING, requestEntityProcessing);
+        }
         clientConfig.register(ResponseStatusExceptionFilter.class);
         clientConfig.register(JsonClientFilter.class);
         clientConfig.register(JacksonJsonProvider.class);
@@ -685,6 +691,16 @@ public class JerseyDockerCmdExecFactory implements DockerCmdExecFactory {
 
     public JerseyDockerCmdExecFactory withClientRequestFilters(ClientRequestFilter... clientRequestFilters) {
         this.clientRequestFilters = clientRequestFilters;
+        return this;
+    }
+
+    public JerseyDockerCmdExecFactory withBufferedRequestEntityProcessing() {
+        this.requestEntityProcessing = RequestEntityProcessing.BUFFERED;
+        return this;
+    }
+
+    public JerseyDockerCmdExecFactory withChunkedRequestEntityProcessing() {
+        this.requestEntityProcessing = RequestEntityProcessing.CHUNKED;
         return this;
     }
 

--- a/src/main/java/com/github/dockerjava/jaxrs/JerseyDockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/JerseyDockerCmdExecFactory.java
@@ -694,16 +694,10 @@ public class JerseyDockerCmdExecFactory implements DockerCmdExecFactory {
         return this;
     }
 
-    public JerseyDockerCmdExecFactory withBufferedRequestEntityProcessing() {
-        this.requestEntityProcessing = RequestEntityProcessing.BUFFERED;
+    public JerseyDockerCmdExecFactory withRequestEntityProcessing(RequestEntityProcessing requestEntityProcessing) {
+        this.requestEntityProcessing = requestEntityProcessing;
         return this;
     }
-
-    public JerseyDockerCmdExecFactory withChunkedRequestEntityProcessing() {
-        this.requestEntityProcessing = RequestEntityProcessing.CHUNKED;
-        return this;
-    }
-
 
     /**
      * release connections from the pool


### PR DESCRIPTION
ApacheConnector used by JerseyDockerCmdExecFactory can be configured also with sending content-length and avoid using chunked encoding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1033)
<!-- Reviewable:end -->
