### PR TITLE
avoid warnings about illegal reflective access

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 
 		<!-- test dependencies -->
 		<logback.version>1.2.3</logback.version>
-		<netty.version>4.1.14.Final</netty.version>
+		<netty.version>4.1.25.Final</netty.version>
 		<hamcrest.library.version>1.3</hamcrest.library.version>
 		<hamcrest.jpa-matchers>1.8</hamcrest.jpa-matchers>
 		<lambdaj.version>2.3.3</lambdaj.version>


### PR DESCRIPTION
Upgrades the netty dependency, all tests are green for me locally, there is still a warning about the same thing from guice and it seems like guice haven't released a fixed version yet, there is an open bug about it here: https://github.com/google/guice/issues/1133

bug reference: #1037

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1038)
<!-- Reviewable:end -->
