### PR TITLE
Use path from the configured docker host instead of hardcoded "/var/run/docker.sock" in netty factory

### DIFF
--- a/src/main/java/com/github/dockerjava/netty/NettyDockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/netty/NettyDockerCmdExecFactory.java
@@ -273,7 +273,9 @@ public class NettyDockerCmdExecFactory implements DockerCmdExecFactory {
 
         @Override
         public DuplexChannel connect(Bootstrap bootstrap) throws InterruptedException {
-            return (DuplexChannel) bootstrap.connect(new DomainSocketAddress("/var/run/docker.sock")).sync().channel();
+            String path = dockerClientConfig.getDockerHost().getPath();
+
+            return (DuplexChannel) bootstrap.connect(new DomainSocketAddress(path)).sync().channel();
         }
     }
 


### PR DESCRIPTION
This should fix issue #1040 in 3.0.x.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1041)
<!-- Reviewable:end -->
