### PR TITLE
Use path from the configured docker host instead of hardcoded "/var/run/docker.sock" in netty factory

### DIFF
--- a/src/main/java/com/github/dockerjava/netty/NettyDockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/netty/NettyDockerCmdExecFactory.java
@@ -176,7 +176,10 @@ public class NettyDockerCmdExecFactory extends AbstractDockerCmdExecFactory impl
 
         @Override
         public DuplexChannel connect(Bootstrap bootstrap) throws InterruptedException {
-            return (DuplexChannel) bootstrap.connect(new DomainSocketAddress("/var/run/docker.sock")).sync().channel();
+            DockerClientConfig dockerClientConfig = getDockerClientConfig();
+            String path = dockerClientConfig.getDockerHost().getPath();
+
+            return (DuplexChannel) bootstrap.connect(new DomainSocketAddress(path)).sync().channel();
         }
     }
 


### PR DESCRIPTION
This should fix issue #1040 in master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1042)
<!-- Reviewable:end -->
