### PR TITLE
follow symbolic links when walking dir

### DIFF
--- a/src/main/java/com/github/dockerjava/core/util/CompressArchiveUtil.java
+++ b/src/main/java/com/github/dockerjava/core/util/CompressArchiveUtil.java
@@ -1,6 +1,7 @@
 package com.github.dockerjava.core.util;
 
 import static com.github.dockerjava.core.util.FilePathUtil.relativize;
+import static java.nio.file.FileVisitOption.FOLLOW_LINKS;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -12,6 +13,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.EnumSet;
 import java.util.zip.GZIPOutputStream;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -78,7 +80,8 @@ public class CompressArchiveUtil {
                     // In order to have the dossier as the root entry
                     sourcePath = inputPath.getParent();
                 }
-                Files.walkFileTree(inputPath, new TarDirWalker(sourcePath, tarArchiveOutputStream));
+                Files.walkFileTree(inputPath, EnumSet.of(FOLLOW_LINKS), Integer.MAX_VALUE,
+                        new TarDirWalker(sourcePath, tarArchiveOutputStream));
             }
             tarArchiveOutputStream.flush();
         }

--- a/src/main/java/com/github/dockerjava/core/util/TarDirWalker.java
+++ b/src/main/java/com/github/dockerjava/core/util/TarDirWalker.java
@@ -33,9 +33,12 @@ public class TarDirWalker extends SimpleFileVisitor<Path> {
 
     @Override
     public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+        if (attrs.isSymbolicLink()) { // symbolic link to folder
+            return FileVisitResult.CONTINUE;
+        }
         TarArchiveEntry tarEntry = new TarArchiveEntry(FilePathUtil.relativize(basePath, file));
         if (file.toFile().canExecute()) {
-                tarEntry.setMode(tarEntry.getMode() | 0755);
+            tarEntry.setMode(tarEntry.getMode() | 0755);
         }
         CompressArchiveUtil.putTarEntry(tarArchiveOutputStream, tarEntry, file);
         return FileVisitResult.CONTINUE;

--- a/src/test/java/com/github/dockerjava/core/CompressArchiveUtilTest.java
+++ b/src/test/java/com/github/dockerjava/core/CompressArchiveUtilTest.java
@@ -12,10 +12,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.zip.GZIPInputStream;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -26,9 +27,11 @@ public class CompressArchiveUtilTest {
         File executableFile = createExecutableFile();
         File archive = CompressArchiveUtil.archiveTARFiles(executableFile.getParentFile(), asList(executableFile),
                 "archive");
-        File expectedFile = extractFileByName(archive, "executableFile.sh.result");
+        File expectedFile = extractFileByName(archive, "executableFile.sh", "executableFile.sh.result");
 
         assertThat("should be executable", expectedFile.canExecute());
+        expectedFile.delete();
+        archive.delete();
     }
 
     private File createExecutableFile() throws IOException {
@@ -40,25 +43,64 @@ public class CompressArchiveUtilTest {
         return executableFile;
     }
 
-    private File extractFileByName(File archive, String filenameToExtract) throws IOException {
+    private File extractFileByName(File archive, String filenameToExtract, String outputName) throws IOException {
         File baseDir = new File(FileUtils.getTempDirectoryPath());
-        File expectedFile = new File(baseDir, filenameToExtract);
+        File expectedFile = new File(baseDir, outputName);
         expectedFile.delete();
         assertThat(expectedFile.exists(), is(false));
 
         TarArchiveInputStream tarArchiveInputStream = new TarArchiveInputStream(new GZIPInputStream(
                 new BufferedInputStream(new FileInputStream(archive))));
         TarArchiveEntry entry;
+        boolean found = false;
         while ((entry = tarArchiveInputStream.getNextTarEntry()) != null) {
             String individualFiles = entry.getName();
-            // there should be only one file in this archive
-            assertThat(individualFiles, equalTo("executableFile.sh"));
-            IOUtils.copy(tarArchiveInputStream, new FileOutputStream(expectedFile));
-            if ((entry.getMode() & 0755) == 0755) {
-                expectedFile.setExecutable(true);
+            if (individualFiles.equals(filenameToExtract) || individualFiles.endsWith("/" + filenameToExtract)) {
+                found = true;
+                IOUtils.copy(tarArchiveInputStream, new FileOutputStream(expectedFile));
+                if ((entry.getMode() & 0755) == 0755) {
+                    expectedFile.setExecutable(true);
+                }
+                break;
             }
         }
+        assertThat("should extracted the file", found);
         tarArchiveInputStream.close();
         return expectedFile;
+    }
+
+    @Test
+    public void testSymbolicLinkDir() throws IOException {
+        Path uploadDir = Files.createTempDirectory("upload");
+        Path linkTarget = Files.createTempDirectory("ink-target");
+        Path tmpFile = Files.createTempFile(linkTarget, "link-dir", "rand");
+        Files.createSymbolicLink(uploadDir.resolve("link-folder"), linkTarget);
+        Path tarGzFile = Files.createTempFile("docker-java", ".tar.gz");
+        //follow link only works for childrenOnly=false
+        CompressArchiveUtil.tar(uploadDir, tarGzFile, true, false);
+        File expectedFile = extractFileByName(tarGzFile.toFile(), tmpFile.toFile().getName(), "foo1");
+        assertThat(expectedFile.canRead(), is(true));
+        uploadDir.toFile().delete();
+        linkTarget.toFile().delete();
+        tarGzFile.toFile().delete();
+    }
+
+    @Test
+    public void testSymbolicLinkFile() throws IOException {
+        Path uploadDir = Files.createTempDirectory("upload");
+        Path tmpFile = Files.createTempFile("src", "");
+        Files.createSymbolicLink(uploadDir.resolve("link-file"), tmpFile);
+        Path tarGzFile = Files.createTempFile("docker-java", ".tar.gz");
+        boolean childrenOnly = false;
+        CompressArchiveUtil.tar(uploadDir, tarGzFile, true, childrenOnly);
+        File expectedFile = extractFileByName(tarGzFile.toFile(), "link-file", "foo1");
+        assertThat(expectedFile.canRead(), is(true));
+        childrenOnly = true;
+        CompressArchiveUtil.tar(uploadDir, tarGzFile, true, childrenOnly);
+        extractFileByName(tarGzFile.toFile(), "link-file", "foo1");
+        assertThat(expectedFile.canRead(), is(true));
+        uploadDir.toFile().delete();
+        tmpFile.toFile().delete();
+        tarGzFile.toFile().delete();
     }
 }


### PR DESCRIPTION
follow symbolic links when walking dir, ref: https://docs.oracle.com/javase/tutorial/essential/io/walk.html

```
java.io.IOException: Is a directory
	at sun.nio.ch.FileDispatcherImpl.read0(Native Method)
	at sun.nio.ch.FileDispatcherImpl.read(FileDispatcherImpl.java:46)
	at sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:223)
	at sun.nio.ch.IOUtil.read(IOUtil.java:197)
	at sun.nio.ch.FileChannelImpl.read(FileChannelImpl.java:159)
	at sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:65)
	at sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:109)
	at sun.nio.ch.ChannelInputStream.read(ChannelInputStream.java:103)
	at java.io.BufferedInputStream.read1(BufferedInputStream.java:284)
	at java.io.BufferedInputStream.read(BufferedInputStream.java:345)
	at java.io.FilterInputStream.read(FilterInputStream.java:107)
	at google.common.io.ByteStreams.copy(ByteStreams.java:110)
	at github.dockerjava.core.util.CompressArchiveUtil.putTarEntry(CompressArchiveUtil.java:34)
	at github.dockerjava.core.util.TarDirWalker.visitFile(TarDirWalker.java:40)
	at github.dockerjava.core.util.TarDirWalker.visitFile(TarDirWalker.java:14)
	at java.nio.file.Files.walkFileTree(Files.java:2670)
	at java.nio.file.Files.walkFileTree(Files.java:2742)
	at github.dockerjava.core.util.CompressArchiveUtil.tar(CompressArchiveUtil.java:81)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1043)
<!-- Reviewable:end -->
