### PR TITLE
Support network mode as part of the docker build

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
@@ -125,6 +125,12 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
     @CheckForNull
     Map<String, String> getLabels();
 
+    /**
+     * @since {@link RemoteApiVersion#VERSION_1_25}
+     */
+    @CheckForNull
+    String getNetworkMode();
+
     // setters
 
     /**
@@ -187,6 +193,11 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
     *@since {@link RemoteApiVersion#VERSION_1_23}
     */
     BuildImageCmd withLabels(Map<String, String> labels);
+
+    /**
+     *@since {@link RemoteApiVersion#VERSION_1_25}
+     */
+    BuildImageCmd withNetworkMode(String networkMode);
 
     interface Exec extends DockerCmdAsyncExec<BuildImageCmd, BuildResponseItem> {
     }

--- a/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
@@ -66,6 +66,8 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
 
     private Map<String, String> labels;
 
+    private String networkMode;
+
     public BuildImageCmdImpl(BuildImageCmd.Exec exec) {
         super(exec);
     }
@@ -175,6 +177,11 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
     @Override
     public Map<String, String> getLabels() {
         return labels;
+    }
+
+    @Override
+    public String getNetworkMode() {
+        return networkMode;
     }
 
     // getter lib specific
@@ -360,6 +367,12 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
     @Override
     public BuildImageCmd withLabels(Map<String, String> labels) {
         this.labels = labels;
+        return this;
+    }
+
+    @Override
+    public BuildImageCmd withNetworkMode(String networkMode) {
+        this.networkMode = networkMode;
         return this;
     }
 

--- a/src/main/java/com/github/dockerjava/core/exec/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/core/exec/BuildImageCmdExec.java
@@ -102,6 +102,10 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
             webTarget = webTarget.queryParamsJsonMap("labels", command.getLabels());
         }
 
+        if (command.getNetworkMode() != null) {
+            webTarget = webTarget.queryParam("networkmode", command.getNetworkMode());
+        }
+
         LOGGER.trace("POST: {}", webTarget);
 
         InvocationBuilder builder = resourceWithOptionalAuthConfig(command, webTarget.request())

--- a/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
@@ -121,6 +121,10 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
 
         webTarget = writeMap(webTarget, "labels", command.getLabels());
 
+        if (command.getNetworkMode() != null) {
+            webTarget = webTarget.queryParam("networkmode", command.getNetworkMode());
+        }
+
         webTarget.property(ClientProperties.REQUEST_ENTITY_PROCESSING, RequestEntityProcessing.CHUNKED);
         webTarget.property(ClientProperties.CHUNKED_ENCODING_SIZE, 1024 * 1024);
 


### PR DESCRIPTION
This exposes the `networkmode` query parameter that was added to be
specified as part of the image build in the Docker API 1.25.

closes #1060

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1061)
<!-- Reviewable:end -->
