### PR TITLE
support "rollback" as value for UpdateFailureAction

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/UpdateFailureAction.java
+++ b/src/main/java/com/github/dockerjava/api/model/UpdateFailureAction.java
@@ -12,6 +12,9 @@ public enum UpdateFailureAction {
     PAUSE,
 
     @JsonProperty("continue")
-    CONTINUE
+    CONTINUE,
+
+    @JsonProperty("rollback")
+    ROLLBACK
 
 }


### PR DESCRIPTION
Since API v1.28, "rollback" is also a valid value for FailureAction on services.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1062)
<!-- Reviewable:end -->
