### PR TITLE
support rollback_completed value in ServiceUpdateState

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/ServiceUpdateState.java
+++ b/src/main/java/com/github/dockerjava/api/model/ServiceUpdateState.java
@@ -14,5 +14,8 @@ public enum ServiceUpdateState {
     PAUSED,
 
     @JsonProperty("completed")
-    COMPLETED
+    COMPLETED,
+
+    @JsonProperty("rollback_completed")
+    ROLLBACK_COMPLETED
 }


### PR DESCRIPTION
"rollback_completed" is als a valid value for ServiceUpdateState since docker API 1.28

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1066)
<!-- Reviewable:end -->
