### PR TITLE
remove stuff after tests run

### DIFF
--- a/src/test/java/com/github/dockerjava/cmd/BuildImageCmdIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/BuildImageCmdIT.java
@@ -195,7 +195,7 @@ public class BuildImageCmdIT extends CmdIT {
 
     @Test
     public void fromPrivateRegistry() throws Exception {
-        AuthConfig authConfig = RegistryUtils.runPrivateRegistry(dockerRule.getClient());
+        AuthConfig authConfig = dockerRule.runPrivateRegistry();
         String imgName = authConfig.getRegistryAddress() + "/testuser/busybox";
 
         File dockerfile = folder.newFile("Dockerfile");

--- a/src/test/java/com/github/dockerjava/cmd/CreateContainerCmdIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/CreateContainerCmdIT.java
@@ -840,9 +840,9 @@ public class CreateContainerCmdIT extends CmdIT {
     public void createContainerFromPrivateRegistryWithValidAuth() throws Exception {
         DockerAssume.assumeSwarm(dockerRule.getClient());
 
-        AuthConfig authConfig = RegistryUtils.runPrivateRegistry(dockerRule.getClient());
+        AuthConfig authConfig = dockerRule.runPrivateRegistry();
 
-        String imgName = RegistryUtils.createPrivateImage(dockerRule, "create-container-with-valid-auth");
+        String imgName = dockerRule.createPrivateImage( "create-container-with-valid-auth");
 
         CreateContainerResponse container = dockerRule.getClient().createContainerCmd(imgName)
                 .withAuthConfig(authConfig)
@@ -853,9 +853,9 @@ public class CreateContainerCmdIT extends CmdIT {
 
     @Test
     public void createContainerFromPrivateRegistryWithNoAuth() throws Exception {
-        AuthConfig authConfig = RegistryUtils.runPrivateRegistry(dockerRule.getClient());
+        AuthConfig authConfig = dockerRule.runPrivateRegistry();
 
-        String imgName = RegistryUtils.createPrivateImage(dockerRule, "create-container-with-no-auth");
+        String imgName = dockerRule.createPrivateImage( "create-container-with-no-auth");
 
         if (TestUtils.isSwarm(dockerRule.getClient())) {
             exception.expect(instanceOf(InternalServerErrorException.class));

--- a/src/test/java/com/github/dockerjava/cmd/PullImageCmdIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/PullImageCmdIT.java
@@ -100,9 +100,9 @@ public class PullImageCmdIT extends CmdIT {
 
     @Test
     public void testPullImageWithValidAuth() throws Exception {
-        AuthConfig authConfig = RegistryUtils.runPrivateRegistry(dockerRule.getClient());
+        AuthConfig authConfig = dockerRule.runPrivateRegistry();
 
-        String imgName = RegistryUtils.createPrivateImage(dockerRule, "pull-image-with-valid-auth");
+        String imgName = dockerRule.createPrivateImage( "pull-image-with-valid-auth");
 
         // stream needs to be fully read in order to close the underlying connection
         dockerRule.getClient().pullImageCmd(imgName)
@@ -113,9 +113,9 @@ public class PullImageCmdIT extends CmdIT {
 
     @Test
     public void testPullImageWithNoAuth() throws Exception {
-        RegistryUtils.runPrivateRegistry(dockerRule.getClient());
+      dockerRule.runPrivateRegistry();
 
-        String imgName = RegistryUtils.createPrivateImage(dockerRule, "pull-image-with-no-auth");
+        String imgName = dockerRule.createPrivateImage( "pull-image-with-no-auth");
 
         if (isNotSwarm(dockerRule.getClient()) && getVersion(dockerRule.getClient())
                 .isGreaterOrEqual(RemoteApiVersion.VERSION_1_30)) {
@@ -132,7 +132,7 @@ public class PullImageCmdIT extends CmdIT {
 
     @Test
     public void testPullImageWithInvalidAuth() throws Exception {
-        AuthConfig validAuthConfig = RegistryUtils.runPrivateRegistry(dockerRule.getClient());
+        AuthConfig validAuthConfig = dockerRule.runPrivateRegistry();
 
         AuthConfig authConfig = new AuthConfig()
                 .withUsername("testuser")
@@ -140,7 +140,7 @@ public class PullImageCmdIT extends CmdIT {
                 .withEmail("foo@bar.de")
                 .withRegistryAddress(validAuthConfig.getRegistryAddress());
 
-        String imgName = RegistryUtils.createPrivateImage(dockerRule, "pull-image-with-invalid-auth");
+        String imgName = dockerRule.createPrivateImage( "pull-image-with-invalid-auth");
 
         if (isNotSwarm(dockerRule.getClient()) && getVersion(dockerRule.getClient())
                 .isGreaterOrEqual(RemoteApiVersion.VERSION_1_30)) {

--- a/src/test/java/com/github/dockerjava/cmd/PushImageCmdIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/PushImageCmdIT.java
@@ -115,7 +115,7 @@ public class PushImageCmdIT extends CmdIT {
                 .withEmail("foo@bar.de")
                 .withRegistryAddress(authConfig.getRegistryAddress());
 
-        String imgName = RegistryUtils.createTestImage(dockerRule, "push-image-with-invalid-auth");
+        String imgName = dockerRule.createTestImage("push-image-with-invalid-auth");
 
         exception.expect(DockerClientException.class);
 

--- a/src/test/java/com/github/dockerjava/cmd/PushImageCmdIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/PushImageCmdIT.java
@@ -36,7 +36,7 @@ public class PushImageCmdIT extends CmdIT {
     @Before
     public void beforeTest() throws Exception {
         username = dockerRule.getClient().authConfig().getUsername();
-        authConfig = RegistryUtils.runPrivateRegistry(dockerRule.getClient());
+        authConfig = dockerRule.runPrivateRegistry();
     }
 
     @Test
@@ -86,7 +86,7 @@ public class PushImageCmdIT extends CmdIT {
 
     @Test
     public void testPushImageWithValidAuth() throws Exception {
-        String imgName = RegistryUtils.createTestImage(dockerRule, "push-image-with-valid-auth");
+        String imgName = dockerRule.createTestImage( "push-image-with-valid-auth");
 
         // stream needs to be fully read in order to close the underlying connection
         dockerRule.getClient().pushImageCmd(imgName)
@@ -97,7 +97,7 @@ public class PushImageCmdIT extends CmdIT {
 
     @Test
     public void testPushImageWithNoAuth() throws Exception {
-        String imgName = RegistryUtils.createTestImage(dockerRule, "push-image-with-no-auth");
+        String imgName = dockerRule.createTestImage( "push-image-with-no-auth");
 
         exception.expect(DockerClientException.class);
 

--- a/src/test/java/com/github/dockerjava/junit/DockerRule.java
+++ b/src/test/java/com/github/dockerjava/junit/DockerRule.java
@@ -31,6 +31,9 @@ import static org.hamcrest.core.IsNull.notNullValue;
  * @author Kanstantsin Shautsou
  */
 public class DockerRule extends ExternalResource {
+  
+    private RegistryUtils registryUtils= new RegistryUtils();
+    
     public static final Logger LOG = LoggerFactory.getLogger(DockerRule.class);
     public static final String DEFAULT_IMAGE = "busybox:latest";
 
@@ -38,10 +41,8 @@ public class DockerRule extends ExternalResource {
     private DockerClient jerseyClient;
 
     private CmdIT cmdIT;
-    private Object cmdExecFactory;
     
     private TestDockerCmdExecFactory testDockerCmdExecFactory;
-
 
     public DockerRule(CmdIT cmdIT) {
         this.cmdIT = cmdIT;
@@ -109,14 +110,15 @@ public class DockerRule extends ExternalResource {
             for (String string : testDockerCmdExecFactory.getNetworkIds()) {
                 ensureNetworkRemoved(string);
             }
+            ensurePrivateRegistryRemoved();
         }
     }
 
-    private static DefaultDockerClientConfig config() {
+    private DefaultDockerClientConfig config() {
         return config(null);
     }
 
-    public static DefaultDockerClientConfig config(String password) {
+    public DefaultDockerClientConfig config(String password) {
         DefaultDockerClientConfig.Builder builder = DefaultDockerClientConfig.createDefaultConfigBuilder()
                 .withRegistryUrl("https://index.docker.io/v1/");
         if (password != null) {
@@ -181,14 +183,18 @@ public class DockerRule extends ExternalResource {
     }
     
     public AuthConfig runPrivateRegistry() throws Exception {
-        return RegistryUtils.runPrivateRegistry(getClient());
+        return registryUtils.runPrivateRegistry(getClient());
+    }
+    
+    public void ensurePrivateRegistryRemoved() {
+      registryUtils.removePrivateRegistry(getClient());
     }
 
     public String createPrivateImage(String tagName) throws InterruptedException {
-        return RegistryUtils.createPrivateImage(this, tagName);
+        return registryUtils.createPrivateImage(this, tagName);
     }
 
     public String createTestImage(String tagName) {
-        return RegistryUtils.createTestImage(this, tagName);
+        return registryUtils.createTestImage(this, tagName);
     }
 }


### PR DESCRIPTION
I cannot rerun tests because of not removal of some docker entities at the end of tests. I must remove network interfaces and also containers before.
I think that we can achieve this by just reusing an existing class: TestDockerCmdExecFactory
I added the registry functions into the dockerRule in order to add simplicity to the final user.

What do you think?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1070)
<!-- Reviewable:end -->
