### PR TITLE
Allow netty to handle compressed response bodies

### DIFF
--- a/src/main/java/com/github/dockerjava/netty/NettyDockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/netty/NettyDockerCmdExecFactory.java
@@ -39,6 +39,7 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.channel.unix.UnixChannel;
 import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpContentDecompressor;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleState;
@@ -158,6 +159,7 @@ public class NettyDockerCmdExecFactory extends AbstractDockerCmdExecFactory impl
                 @Override
                 protected void initChannel(final UnixChannel channel) throws Exception {
                     channel.pipeline().addLast(new HttpClientCodec());
+                    channel.pipeline().addLast(new HttpContentDecompressor());
                 }
             });
             return epollEventLoopGroup;
@@ -172,6 +174,7 @@ public class NettyDockerCmdExecFactory extends AbstractDockerCmdExecFactory impl
                         protected void initChannel(final KQueueDomainSocketChannel channel) throws Exception {
                             channel.pipeline().addLast(new LoggingHandler(getClass()));
                             channel.pipeline().addLast(new HttpClientCodec());
+                            channel.pipeline().addLast(new HttpContentDecompressor());
                         }
                     });
 
@@ -212,6 +215,7 @@ public class NettyDockerCmdExecFactory extends AbstractDockerCmdExecFactory impl
                             // channel.pipeline().addLast(new
                             // HttpProxyHandler(proxyAddress));
                             channel.pipeline().addLast(new HttpClientCodec());
+                            channel.pipeline().addLast(new HttpContentDecompressor());
                         }
                     });
 


### PR DESCRIPTION
Fixes #1079

This change touches a few different places in the same file, but I don't see a single place where it would make sense to add as a one-liner.

This change will apply the `HttpContentDecompressor` to all requests, but it should be a no-op most of the time. It will only have an effect when docker returns an HTTP response with gzip/deflate compression.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1082)
<!-- Reviewable:end -->
