### PR TITLE
Fix #921, make AuthConfig compatible with indentitytoken

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/AuthConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/AuthConfig.java
@@ -42,6 +42,12 @@ public class AuthConfig implements Serializable {
     @JsonProperty("registrytoken")
     private String registrytoken;
 
+    /**
+     * @since {@link com.github.dockerjava.core.RemoteApiVersion#VERSION_1_23}
+     */
+    @JsonProperty("identitytoken")
+    private String identitytoken;
+
     public String getUsername() {
         return username;
     }
@@ -84,6 +90,20 @@ public class AuthConfig implements Serializable {
 
     public AuthConfig withAuth(String auth) {
         this.auth = auth;
+        return this;
+    }
+
+    /**
+     * @see #identitytoken
+     */
+    public String getIdentitytoken() {
+        return identitytoken;
+    }
+    /**
+     * @see #identitytoken
+     */
+    public AuthConfig withIdentityToken(String identitytoken) {
+        this.identitytoken = identitytoken;
         return this;
     }
 

--- a/src/test/java/com/github/dockerjava/api/model/AuthConfigTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/AuthConfigTest.java
@@ -61,4 +61,21 @@ public class AuthConfigTest {
 
         assertThat(authConfig1, equalTo(authConfig));
     }
+
+    @Test
+    public void compatibleWithIdentitytoken() throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+        final JavaType type = mapper.getTypeFactory().uncheckedSimpleType(AuthConfig.class);
+        final AuthConfig authConfig = testRoundTrip(RemoteApiVersion.VERSION_1_23,
+                "/other/AuthConfig/docs1.json",
+                type
+        );
+        String auth = "YWRtaW46";
+        String identitytoken = "1cba468e-8cbe-4c55-9098-2c2ed769e885";
+        assertThat(authConfig, notNullValue());
+        assertThat(authConfig.getAuth(), is(auth));
+        assertThat(authConfig.getIdentitytoken(), is(identitytoken));
+        final AuthConfig authConfig1 = new AuthConfig().withAuth(auth).withIdentityToken(identitytoken);
+        assertThat(authConfig1, equalTo(authConfig));
+    }
 }

--- a/src/test/resources/samples/1.23/other/AuthConfig/docs1.json
+++ b/src/test/resources/samples/1.23/other/AuthConfig/docs1.json
@@ -1,0 +1,4 @@
+{
+  "auth": "YWRtaW46",
+  "identitytoken": "1cba468e-8cbe-4c55-9098-2c2ed769e885"
+}


### PR DESCRIPTION
which was introduced in DOCKER API 1.23

This PR is based on the work done by @yaozhiqun in PR #1004 with review comments taken into account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1083)
<!-- Reviewable:end -->
