### PR TITLE
Fix double-marshalling of cachefrom

### DIFF
--- a/src/main/java/com/github/dockerjava/core/exec/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/core/exec/BuildImageCmdExec.java
@@ -9,7 +9,7 @@ import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.InvocationBuilder;
 import com.github.dockerjava.core.MediaType;
 import com.github.dockerjava.core.WebTarget;
-import com.google.common.base.Joiner;
+import com.github.dockerjava.core.util.CacheFromEncoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +59,7 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
         }
 
         if (command.getCacheFrom() != null && !command.getCacheFrom().isEmpty()) {
-            webTarget = webTarget.queryParam("cachefrom", "[\"" + Joiner.on("\",\"").join(command.getCacheFrom()) + "\"]");
+            webTarget = webTarget.queryParam("cachefrom", CacheFromEncoder.jsonEncode(command.getCacheFrom()));
         }
 
         if (command.getRemote() != null) {

--- a/src/main/java/com/github/dockerjava/core/exec/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/core/exec/BuildImageCmdExec.java
@@ -1,8 +1,5 @@
 package com.github.dockerjava.core.exec;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.BuildImageCmd;
@@ -12,6 +9,9 @@ import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.InvocationBuilder;
 import com.github.dockerjava.core.MediaType;
 import com.github.dockerjava.core.WebTarget;
+import com.google.common.base.Joiner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
@@ -59,7 +59,7 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
         }
 
         if (command.getCacheFrom() != null && !command.getCacheFrom().isEmpty()) {
-            webTarget = webTarget.queryParamsSet("cachefrom", command.getCacheFrom());
+            webTarget = webTarget.queryParam("cachefrom", "[\"" + Joiner.on("\",\"").join(command.getCacheFrom()) + "\"]");
         }
 
         if (command.getRemote() != null) {

--- a/src/main/java/com/github/dockerjava/core/util/CacheFromEncoder.java
+++ b/src/main/java/com/github/dockerjava/core/util/CacheFromEncoder.java
@@ -1,0 +1,27 @@
+package com.github.dockerjava.core.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+
+import javax.ws.rs.core.MediaType;
+import java.util.Collection;
+
+/**
+ * JSON Encoder for the docker --cache-from parameter.
+ */
+public class CacheFromEncoder {
+    private CacheFromEncoder() {
+    }
+
+    private static final ObjectMapper OBJECT_MAPPER = new JacksonJaxbJsonProvider().locateMapper(Collection.class,
+            MediaType.APPLICATION_JSON_TYPE);
+
+    public static String jsonEncode(Collection<String> imageIds) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(imageIds);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
@@ -7,9 +7,10 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import com.google.common.base.Joiner;
+import com.github.dockerjava.core.util.CacheFromEncoder;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.RequestEntityProcessing;
 import org.slf4j.Logger;
@@ -77,7 +78,7 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
         }
 
         if (command.getCacheFrom() != null && !command.getCacheFrom().isEmpty()) {
-            webTarget = webTarget.queryParam("cachefrom", "[\"" + Joiner.on("\",\"").join(command.getCacheFrom()) + "\"]");
+            webTarget = webTarget.queryParam("cachefrom", CacheFromEncoder.jsonEncode(command.getCacheFrom()));
         }
 
         if (command.getRemote() != null) {

--- a/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.MediaType;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.google.common.base.Joiner;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.RequestEntityProcessing;
 import org.slf4j.Logger;
@@ -75,10 +76,8 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
             webTarget = webTarget.queryParam("t", command.getTag());
         }
 
-        if (command.getCacheFrom() != null) {
-            for (String c: command.getCacheFrom()) {
-               webTarget = webTarget.queryParam("cachefrom", c);
-            }
+        if (command.getCacheFrom() != null && !command.getCacheFrom().isEmpty()) {
+            webTarget = webTarget.queryParam("cachefrom", "[\"" + Joiner.on("\",\"").join(command.getCacheFrom()) + "\"]");
         }
 
         if (command.getRemote() != null) {

--- a/src/test/java/com/github/dockerjava/cmd/BuildImageCmdIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/BuildImageCmdIT.java
@@ -302,8 +302,7 @@ public class BuildImageCmdIT extends CmdIT {
         assertThat(inspectImageResponse1, not(nullValue()));
 
         File baseDir2 = fileFromBuildTestResource("CacheFrom/test2");
-        String cacheImage = String.format("[\"%s\"]", imageId1);
-        String imageId2 = dockerRule.getClient().buildImageCmd(baseDir2).withCacheFrom(new HashSet<>(Arrays.asList(cacheImage)))
+        String imageId2 = dockerRule.getClient().buildImageCmd(baseDir2).withCacheFrom(new HashSet<>(Arrays.asList(imageId1)))
                 .exec(new BuildImageResultCallback())
                 .awaitImageId();
         InspectImageResponse inspectImageResponse2 = dockerRule.getClient().inspectImageCmd(imageId2).exec();


### PR DESCRIPTION
The API for setting the --cache-from argument is:

```java
BuildImageCmd withCacheFrom(Set<String> cacheFrom);
```
which intuitively indicates that the set of strings passed in should be the imageIds to use for the cache. However this is not the case, and instead users have to "wrap" the arguments in an additional '[]', as illustrated by an existing test `BuildImageCmdIT.cacheFrom`:
```java
        String cacheImage = String.format("[\"%s\"]", imageId1);
        String imageId2 = dockerRule.getClient().buildImageCmd(baseDir2).withCacheFrom(new HashSet<>(Arrays.asList(cacheImage)))
```

As stated in the docker API https://docs.docker.com/engine/api/v1.37/#operation/ImageBuild
the `cachefrom` parameter is a
> JSON array of images used for build cache resolution.

however the current implementation takes the set of strings, where each string itself is an array, and creates a "cachefrom" parameter for each. In other words it seems to require another layer of marshalling.

I *think* the original intention for this API was to take the set of strings where each string is an image id and serialize these into a JSON array automatically. This PR does this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1086)
<!-- Reviewable:end -->
