### PR TITLE
ugly fix for failure with latest docker client on mac

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/AuthConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/AuthConfig.java
@@ -48,6 +48,12 @@ public class AuthConfig implements Serializable {
     @JsonProperty("identitytoken")
     private String identitytoken;
 
+    /**
+     * @since {@link com.github.dockerjava.core.RemoteApiVersion#VERSION_1_25}
+     */
+    @JsonProperty("stackOrchestrator")
+    private String stackOrchestrator;
+
     public String getUsername() {
         return username;
     }
@@ -121,6 +127,20 @@ public class AuthConfig implements Serializable {
     public AuthConfig withRegistrytoken(String registrytoken) {
         this.registrytoken = registrytoken;
         return this;
+    }
+
+    /**
+     * @see #stackOrchestrator
+     */
+    public String getStackOrchestrator() {
+        return stackOrchestrator;
+    }
+
+    /**
+     * @see #stackOrchestrator
+     */
+    public void setStackOrchestrator(String stackOrchestrator) {
+        this.stackOrchestrator = stackOrchestrator;
     }
 
     @Override

--- a/src/test/java/com/github/dockerjava/api/model/AuthConfigTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/AuthConfigTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import static com.github.dockerjava.test.serdes.JSONSamples.testRoundTrip;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
@@ -78,4 +79,18 @@ public class AuthConfigTest {
         final AuthConfig authConfig1 = new AuthConfig().withAuth(auth).withIdentityToken(identitytoken);
         assertThat(authConfig1, equalTo(authConfig));
     }
+
+    @Test
+    public void shouldNotFailWithStackOrchestratorInConfig() throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+        final JavaType type = mapper.getTypeFactory().uncheckedSimpleType(AuthConfig.class);
+        final AuthConfig authConfig = testRoundTrip(RemoteApiVersion.VERSION_1_25,
+                "/other/AuthConfig/orchestrators.json",
+                type
+        );
+        assertThat(authConfig, notNullValue());
+        assertThat(authConfig.getAuth(), is(nullValue()));
+        assertThat(authConfig.getStackOrchestrator(), is("kubernetes"));
+    }
+
 }

--- a/src/test/resources/samples/1.25/other/AuthConfig/orchestrators.json
+++ b/src/test/resources/samples/1.25/other/AuthConfig/orchestrators.json
@@ -1,0 +1,3 @@
+{
+  "stackOrchestrator" : "kubernetes"
+}


### PR DESCRIPTION
Code isn't great, but it no longer blows up when config has a 'stackOrchestrator' name in the ~/.docker/config.json file.

#1080

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1087)
<!-- Reviewable:end -->
