### PR TITLE
Support missing Engine APIs

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
@@ -131,6 +131,14 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
     @CheckForNull
     String getNetworkMode();
 
+    /**
+     * "platform" in API
+     *
+     * @since {@link RemoteApiVersion#VERSION_1_32}
+     */
+    @CheckForNull
+    String getPlatform();
+
     // setters
 
     /**
@@ -198,6 +206,11 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
      *@since {@link RemoteApiVersion#VERSION_1_25}
      */
     BuildImageCmd withNetworkMode(String networkMode);
+
+    /**
+     *@since {@link RemoteApiVersion#VERSION_1_32}
+     */
+    BuildImageCmd withPlatform(String platform);
 
     interface Exec extends DockerCmdAsyncExec<BuildImageCmd, BuildResponseItem> {
     }

--- a/src/main/java/com/github/dockerjava/api/command/CreateImageCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/CreateImageCmd.java
@@ -14,6 +14,9 @@ public interface CreateImageCmd extends SyncDockerCmd<CreateImageResponse> {
     String getTag();
 
     @CheckForNull
+    String getPlatform();
+
+    @CheckForNull
     InputStream getImageStream();
 
     /**
@@ -34,6 +37,12 @@ public interface CreateImageCmd extends SyncDockerCmd<CreateImageResponse> {
      * @deprecated use repo:tag format for repository
      */
     CreateImageCmd withTag(String tag);
+
+    /**
+     * @param platform
+     *            the platform for this image
+     */
+    CreateImageCmd withPlatform(String platform);
 
     interface Exec extends DockerCmdSyncExec<CreateImageCmd, CreateImageResponse> {
     }

--- a/src/main/java/com/github/dockerjava/api/command/ExecCreateCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/ExecCreateCmd.java
@@ -26,6 +26,9 @@ public interface ExecCreateCmd extends SyncDockerCmd<ExecCreateCmdResponse> {
     @CheckForNull
     Boolean getPrivileged();
 
+    @CheckForNull
+    String getWorkingDir();
+
     ExecCreateCmd withAttachStderr(Boolean attachStderr);
 
     ExecCreateCmd withAttachStdin(Boolean attachStdin);
@@ -41,6 +44,8 @@ public interface ExecCreateCmd extends SyncDockerCmd<ExecCreateCmdResponse> {
     ExecCreateCmd withUser(String user);
 
     ExecCreateCmd withPrivileged(Boolean isPrivileged);
+
+    ExecCreateCmd withWorkingDir(String workingDir);
 
     interface Exec extends DockerCmdSyncExec<ExecCreateCmd, ExecCreateCmdResponse> {
     }

--- a/src/main/java/com/github/dockerjava/api/command/GraphData.java
+++ b/src/main/java/com/github/dockerjava/api/command/GraphData.java
@@ -28,6 +28,9 @@ public class GraphData {
     @JsonProperty("DeviceSize")
     private String deviceSize;
 
+    @JsonProperty("dir")
+    private String dir;
+
     /**
      * @see #rootDir
      */
@@ -89,6 +92,22 @@ public class GraphData {
      */
     public GraphData withDeviceSize(String deviceSize) {
         this.deviceSize = deviceSize;
+        return this;
+    }
+
+    /**
+     * @see #dir
+     */
+    @CheckForNull
+    public String getDir() {
+        return dir;
+    }
+
+    /**
+     * @see #dir
+     */
+    public GraphData withDir(String dir) {
+        this.dir = dir;
         return this;
     }
 

--- a/src/main/java/com/github/dockerjava/api/command/InspectImageResponse.java
+++ b/src/main/java/com/github/dockerjava/api/command/InspectImageResponse.java
@@ -49,6 +49,12 @@ public class InspectImageResponse {
     @JsonProperty("Os")
     private String os;
 
+    /**
+     * @since {@link com.github.dockerjava.core.RemoteApiVersion#VERSION_1_25}
+     */
+    @JsonProperty("OsVersion")
+    private String osVersion;
+
     @JsonProperty("Parent")
     private String parent;
 
@@ -72,6 +78,9 @@ public class InspectImageResponse {
      */
     @JsonProperty("GraphDriver")
     private GraphDriver graphDriver;
+
+    @JsonProperty("RootFS")
+    private RootFS rootFS;
 
     /**
      * @see #arch
@@ -237,6 +246,22 @@ public class InspectImageResponse {
     }
 
     /**
+     * @see #osVersion
+     */
+    @CheckForNull
+    public String getOsVersion() {
+        return osVersion;
+    }
+
+    /**
+     * @see #osVersion
+     */
+    public InspectImageResponse withOsVersion(String osVersion) {
+        this.osVersion = osVersion;
+        return this;
+    }
+
+    /**
      * @see #parent
      */
     @CheckForNull
@@ -329,6 +354,22 @@ public class InspectImageResponse {
      */
     public InspectImageResponse withVirtualSize(Long virtualSize) {
         this.virtualSize = virtualSize;
+        return this;
+    }
+
+    /**
+     * @see #rootFS
+     */
+    @CheckForNull
+    public RootFS getRootFS() {
+        return rootFS;
+    }
+
+    /**
+     * @see #rootFS
+     */
+    public InspectImageResponse withRootFS(RootFS rootFS) {
+        this.rootFS = rootFS;
         return this;
     }
 

--- a/src/main/java/com/github/dockerjava/api/command/PullImageCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/PullImageCmd.java
@@ -20,6 +20,9 @@ public interface PullImageCmd extends AsyncDockerCmd<PullImageCmd, PullResponseI
     String getTag();
 
     @CheckForNull
+    String getPlatform();
+
+    @CheckForNull
     String getRegistry();
 
     @CheckForNull
@@ -28,6 +31,11 @@ public interface PullImageCmd extends AsyncDockerCmd<PullImageCmd, PullResponseI
     PullImageCmd withRepository(@Nonnull String repository);
 
     PullImageCmd withTag(String tag);
+
+    /**
+     * @since {@link com.github.dockerjava.core.RemoteApiVersion#VERSION_1_32}
+     */
+    PullImageCmd withPlatform(String tag);
 
     PullImageCmd withRegistry(String registry);
 

--- a/src/main/java/com/github/dockerjava/api/command/RootFS.java
+++ b/src/main/java/com/github/dockerjava/api/command/RootFS.java
@@ -1,0 +1,72 @@
+package com.github.dockerjava.api.command;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+import javax.annotation.CheckForNull;
+import java.util.List;
+
+/**
+ * Part of {@link InspectImageResponse}
+ *
+ * @author Dmitry Tretyakov
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RootFS {
+
+    @JsonProperty("Type")
+    private String type;
+
+    @JsonProperty("Layers")
+    private List<String> layers;
+
+    /**
+     * @see #type
+     */
+    @CheckForNull
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @see #type
+     */
+    public RootFS withType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     * @see #layers
+     */
+    @CheckForNull
+    public List<String> getLayers() {
+        return layers;
+    }
+
+    /**
+     * @see #layers
+     */
+    public RootFS withLayers(List<String> layers) {
+        this.layers = layers;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+}

--- a/src/main/java/com/github/dockerjava/api/model/Info.java
+++ b/src/main/java/com/github/dockerjava/api/model/Info.java
@@ -231,6 +231,12 @@ public class Info implements Serializable {
     private SwarmInfo swarm;
 
     /**
+     * @since {@link com.github.dockerjava.core.RemoteApiVersion#VERSION_1_25}
+     */
+    @JsonProperty("Isolation")
+    private String isolation;
+
+    /**
      * @see #architecture
      */
     @CheckForNull
@@ -1043,6 +1049,22 @@ public class Info implements Serializable {
      */
     public Info withSwarm(SwarmInfo swarm) {
         this.swarm = swarm;
+        return this;
+    }
+
+    /**
+     * @see #isolation
+     */
+    @CheckForNull
+    public String getIsolation() {
+        return isolation;
+    }
+
+    /**
+     * @see #isolation
+     */
+    public Info withIsolation(String isolation) {
+        this.isolation = isolation;
         return this;
     }
 

--- a/src/main/java/com/github/dockerjava/api/model/Version.java
+++ b/src/main/java/com/github/dockerjava/api/model/Version.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 
 import javax.annotation.CheckForNull;
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * Used for `/version`
@@ -53,6 +54,24 @@ public class Version implements Serializable {
     @JsonProperty("Experimental")
     private Boolean experimental;
 
+    /**
+     * @since ~{@link com.github.dockerjava.core.RemoteApiVersion#VERSION_1_25}
+     */
+    @JsonProperty("MinAPIVersion")
+    private String minAPIVersion;
+
+    /**
+     * @since {@link com.github.dockerjava.core.RemoteApiVersion#VERSION_1_35}
+     */
+    @JsonProperty("Platform")
+    private VersionPlatform platform;
+
+    /**
+     * @since {@link com.github.dockerjava.core.RemoteApiVersion#VERSION_1_35}
+     */
+    @JsonProperty("Components")
+    private List<VersionComponent> components;
+
     public String getVersion() {
         return version;
     }
@@ -95,6 +114,30 @@ public class Version implements Serializable {
     @CheckForNull
     public Boolean getExperimental() {
         return experimental;
+    }
+
+    /**
+     * @see #minAPIVersion
+     */
+    @CheckForNull
+    public String getMinAPIVersion() {
+        return minAPIVersion;
+    }
+
+    /**
+     * @see #platform
+     */
+    @CheckForNull
+    public VersionPlatform getPlatform() {
+        return platform;
+    }
+
+    /**
+     * @see #components
+     */
+    @CheckForNull
+    public List<VersionComponent> getComponents() {
+        return components;
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/api/model/VersionComponent.java
+++ b/src/main/java/com/github/dockerjava/api/model/VersionComponent.java
@@ -1,0 +1,91 @@
+package com.github.dockerjava.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+import javax.annotation.CheckForNull;
+import java.util.Map;
+
+/**
+ * Part of {@link Version}
+ *
+ * @author Dmitry Tretyakov
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VersionComponent {
+
+    @JsonProperty("Details")
+    private Map<String, String> details;
+
+    @JsonProperty("Name")
+    private String name;
+
+    @JsonProperty("Version")
+    private String version;
+
+    /**
+     * @see #details
+     */
+    @CheckForNull
+    public Map<String, String> getDetails() {
+        return details;
+    }
+
+    /**
+     * @see #details
+     */
+    public VersionComponent withDetails(Map<String, String> details) {
+        this.details = details;
+        return this;
+    }
+
+    /**
+     * @see #name
+     */
+    @CheckForNull
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @see #name
+     */
+    public VersionComponent withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * @see #version
+     */
+    @CheckForNull
+    public String getVersion() {
+        return version;
+    }
+
+    /**
+     * @see #version
+     */
+    public VersionComponent withVersion(String version) {
+        this.version = version;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+}

--- a/src/main/java/com/github/dockerjava/api/model/VersionPlatform.java
+++ b/src/main/java/com/github/dockerjava/api/model/VersionPlatform.java
@@ -1,0 +1,52 @@
+package com.github.dockerjava.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+import javax.annotation.CheckForNull;
+
+/**
+ * Part of {@link Version}
+ *
+ * @author Dmitry Tretyakov
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VersionPlatform {
+
+    @JsonProperty("Name")
+    private String name;
+
+    /**
+     * @see #name
+     */
+    @CheckForNull
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @see #name
+     */
+    public VersionPlatform withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+}

--- a/src/main/java/com/github/dockerjava/core/RemoteApiVersion.java
+++ b/src/main/java/com/github/dockerjava/core/RemoteApiVersion.java
@@ -87,6 +87,8 @@ public class RemoteApiVersion implements Serializable {
     public static final RemoteApiVersion VERSION_1_34 = RemoteApiVersion.create(1, 34);
     public static final RemoteApiVersion VERSION_1_35 = RemoteApiVersion.create(1, 35);
     public static final RemoteApiVersion VERSION_1_36 = RemoteApiVersion.create(1, 36);
+    public static final RemoteApiVersion VERSION_1_37 = RemoteApiVersion.create(1, 37);
+    public static final RemoteApiVersion VERSION_1_38 = RemoteApiVersion.create(1, 38);
 
 
     /**

--- a/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
@@ -68,6 +68,8 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
 
     private String networkMode;
 
+    private String platform;
+
     public BuildImageCmdImpl(BuildImageCmd.Exec exec) {
         super(exec);
     }
@@ -182,6 +184,11 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
     @Override
     public String getNetworkMode() {
         return networkMode;
+    }
+
+    @Override
+    public String getPlatform() {
+        return platform;
     }
 
     // getter lib specific
@@ -373,6 +380,12 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
     @Override
     public BuildImageCmd withNetworkMode(String networkMode) {
         this.networkMode = networkMode;
+        return this;
+    }
+
+    @Override
+    public BuildImageCmd withPlatform(String platform) {
+        this.platform = platform;
         return this;
     }
 

--- a/src/main/java/com/github/dockerjava/core/command/CreateImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CreateImageCmdImpl.java
@@ -12,7 +12,7 @@ import com.github.dockerjava.api.command.CreateImageResponse;
  */
 public class CreateImageCmdImpl extends AbstrDockerCmd<CreateImageCmd, CreateImageResponse> implements CreateImageCmd {
 
-    private String repository, tag;
+    private String repository, tag, platform;
 
     private InputStream imageStream;
 
@@ -36,6 +36,11 @@ public class CreateImageCmdImpl extends AbstrDockerCmd<CreateImageCmd, CreateIma
     @Override
     public String getTag() {
         return tag;
+    }
+
+    @Override
+    public String getPlatform() {
+        return platform;
     }
 
     @Override
@@ -73,6 +78,15 @@ public class CreateImageCmdImpl extends AbstrDockerCmd<CreateImageCmd, CreateIma
     public CreateImageCmdImpl withTag(String tag) {
         checkNotNull(tag, "tag was not specified");
         this.tag = tag;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CreateImageCmd withPlatform(String platform) {
+        this.platform = platform;
         return this;
     }
 }

--- a/src/main/java/com/github/dockerjava/core/command/ExecCreateCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ExecCreateCmdImpl.java
@@ -33,13 +33,19 @@ public class ExecCreateCmdImpl extends AbstrDockerCmd<ExecCreateCmd, ExecCreateC
     private Boolean privileged;
 
     /**
-     * @since {@link RemoteApiVersion#VERSION_1_19}
+     * @since {@link com.github.dockerjava.core.RemoteApiVersion#VERSION_1_19}
      */
     @JsonProperty("User")
     private String user;
 
     @JsonProperty("Cmd")
     private String[] cmd;
+
+    /**
+     * @since {@link com.github.dockerjava.core.RemoteApiVersion#VERSION_1_35}
+     */
+    @JsonProperty("WorkingDir")
+    private String workingDir;
 
     public ExecCreateCmdImpl(ExecCreateCmd.Exec exec, String containerId) {
         super(exec);
@@ -96,6 +102,12 @@ public class ExecCreateCmdImpl extends AbstrDockerCmd<ExecCreateCmd, ExecCreateC
     }
 
     @Override
+    public ExecCreateCmd withWorkingDir(String workingDir) {
+        this.workingDir = workingDir;
+        return this;
+    }
+
+    @Override
     public String getContainerId() {
         return containerId;
     }
@@ -128,6 +140,11 @@ public class ExecCreateCmdImpl extends AbstrDockerCmd<ExecCreateCmd, ExecCreateC
     @Override
     public String getUser() {
         return user;
+    }
+
+    @Override
+    public String getWorkingDir() {
+        return workingDir;
     }
 
     /**

--- a/src/main/java/com/github/dockerjava/core/command/PullImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/PullImageCmdImpl.java
@@ -13,7 +13,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class PullImageCmdImpl extends AbstrAsyncDockerCmd<PullImageCmd, PullResponseItem> implements PullImageCmd {
 
-    private String repository, tag, registry;
+    private String repository, tag, platform, registry;
 
     private AuthConfig authConfig;
 
@@ -43,6 +43,11 @@ public class PullImageCmdImpl extends AbstrAsyncDockerCmd<PullImageCmd, PullResp
     }
 
     @Override
+    public String getPlatform() {
+        return platform;
+    }
+
+    @Override
     public String getRegistry() {
         return registry;
     }
@@ -58,6 +63,12 @@ public class PullImageCmdImpl extends AbstrAsyncDockerCmd<PullImageCmd, PullResp
     public PullImageCmd withTag(String tag) {
         checkNotNull(tag, "tag was not specified");
         this.tag = tag;
+        return this;
+    }
+
+    @Override
+    public PullImageCmd withPlatform(String platform) {
+        this.platform = platform;
         return this;
     }
 

--- a/src/main/java/com/github/dockerjava/core/exec/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/core/exec/BuildImageCmdExec.java
@@ -106,6 +106,10 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
             webTarget = webTarget.queryParam("networkmode", command.getNetworkMode());
         }
 
+        if (command.getPlatform() != null) {
+            webTarget = webTarget.queryParam("platform", command.getPlatform());
+        }
+
         LOGGER.trace("POST: {}", webTarget);
 
         InvocationBuilder builder = resourceWithOptionalAuthConfig(command, webTarget.request())

--- a/src/main/java/com/github/dockerjava/core/exec/CreateImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/core/exec/CreateImageCmdExec.java
@@ -24,6 +24,10 @@ public class CreateImageCmdExec extends AbstrSyncDockerCmdExec<CreateImageCmd, C
         WebTarget webResource = getBaseResource().path("/images/create").queryParam("repo", command.getRepository())
                 .queryParam("tag", command.getTag()).queryParam("fromSrc", "-");
 
+        if (command.getPlatform() != null) {
+            webResource = webResource.queryParam("platform", command.getPlatform());
+        }
+
         LOGGER.trace("POST: {}", webResource);
         return webResource.request().accept(MediaType.APPLICATION_OCTET_STREAM)
                 .post(new TypeReference<CreateImageResponse>() {

--- a/src/main/java/com/github/dockerjava/core/exec/PullImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/core/exec/PullImageCmdExec.java
@@ -25,6 +25,10 @@ public class PullImageCmdExec extends AbstrAsyncDockerCmdExec<PullImageCmd, Pull
         WebTarget webResource = getBaseResource().path("/images/create").queryParam("tag", command.getTag())
                 .queryParam("fromImage", command.getRepository()).queryParam("registry", command.getRegistry());
 
+        if (command.getPlatform() != null) {
+            webResource = webResource.queryParam("platform", command.getPlatform());
+        }
+
         LOGGER.trace("POST: {}", webResource);
         resourceWithOptionalAuthConfig(command.getAuthConfig(), webResource.request()).accept(MediaType.APPLICATION_OCTET_STREAM).post(
                 null, new TypeReference<PullResponseItem>() {

--- a/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/BuildImageCmdExec.java
@@ -125,6 +125,10 @@ public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, Bu
             webTarget = webTarget.queryParam("networkmode", command.getNetworkMode());
         }
 
+        if (command.getPlatform() != null) {
+            webTarget = webTarget.queryParam("platform", command.getPlatform());
+        }
+
         webTarget.property(ClientProperties.REQUEST_ENTITY_PROCESSING, RequestEntityProcessing.CHUNKED);
         webTarget.property(ClientProperties.CHUNKED_ENCODING_SIZE, 1024 * 1024);
 

--- a/src/main/java/com/github/dockerjava/jaxrs/CreateImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/CreateImageCmdExec.java
@@ -26,6 +26,10 @@ public class CreateImageCmdExec extends AbstrSyncDockerCmdExec<CreateImageCmd, C
         WebTarget webResource = getBaseResource().path("/images/create").queryParam("repo", command.getRepository())
                 .queryParam("tag", command.getTag()).queryParam("fromSrc", "-");
 
+        if (command.getPlatform() != null) {
+            webResource = webResource.queryParam("platform", command.getPlatform());
+        }
+
         LOGGER.trace("POST: {}", webResource);
         return webResource.request().accept(MediaType.APPLICATION_OCTET_STREAM_TYPE)
                 .post(entity(command.getImageStream(), MediaType.APPLICATION_OCTET_STREAM), CreateImageResponse.class);

--- a/src/main/java/com/github/dockerjava/jaxrs/PullImageCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/PullImageCmdExec.java
@@ -32,6 +32,10 @@ public class PullImageCmdExec extends AbstrAsyncDockerCmdExec<PullImageCmd, Pull
         WebTarget webResource = getBaseResource().path("/images/create").queryParam("tag", command.getTag())
                 .queryParam("fromImage", command.getRepository()).queryParam("registry", command.getRegistry());
 
+        if (command.getPlatform() != null) {
+            webResource = webResource.queryParam("platform", command.getPlatform());
+        }
+
         LOGGER.trace("POST: {}", webResource);
         Builder builder = resourceWithOptionalAuthConfig(command.getAuthConfig(), webResource.request()).accept(
                 MediaType.APPLICATION_OCTET_STREAM_TYPE);

--- a/src/test/java/com/github/dockerjava/api/model/InfoTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/InfoTest.java
@@ -3,10 +3,12 @@ package com.github.dockerjava.api.model;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.model.InfoRegistryConfig.IndexConfig;
+import com.github.dockerjava.core.RemoteApiVersion;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -326,5 +328,40 @@ public class InfoTest {
                 ;
 
         assertThat(info, is(withInfo));
+    }
+
+    @Test
+    public void info_1_38() throws IOException {
+        final ObjectMapper mapper = new ObjectMapper();
+        final JavaType type = mapper.getTypeFactory().constructType(Info.class);
+
+        final Info info = testRoundTrip(RemoteApiVersion.VERSION_1_38,
+                "info/lcow.json",
+                type
+        );
+
+        assertThat(info, notNullValue());
+        assertThat(info.getArchitecture(), is("x86_64"));
+        assertThat(info.getDockerRootDir(), is("C:\\ProgramData\\Docker"));
+        assertThat(info.getDriver(), is("windowsfilter (windows) lcow (linux)"));
+
+        assertThat(info.getDriverStatuses(), equalTo(Arrays.asList(
+                Arrays.asList("Windows", ""),
+                Arrays.asList("LCOW", "")
+        )));
+
+        assertThat(info.getIsolation(), is("hyperv"));
+        assertThat(info.getKernelVersion(), is("10.0 17134 (17134.1.amd64fre.rs4_release.180410-1804)"));
+        assertThat(info.getOsType(), is("windows"));
+        assertThat(info.getOperatingSystem(), is("Windows 10 Pro Version 1803 (OS Build 17134.228)"));
+
+        final Map<String, List<String>> plugins = new LinkedHashMap<>();
+        plugins.put("Authorization", null);
+        plugins.put("Log", asList("awslogs", "etwlogs", "fluentd", "gelf", "json-file", "logentries", "splunk", "syslog"));
+        plugins.put("Network", asList("ics", "l2bridge", "l2tunnel", "nat", "null", "overlay", "transparent"));
+        plugins.put("Volume", singletonList("local"));
+        assertThat(info.getPlugins(), equalTo(plugins));
+
+        assertThat(info.getServerVersion(), is("18.06.1-ce"));
     }
 }

--- a/src/test/java/com/github/dockerjava/api/model/VersionTest.java
+++ b/src/test/java/com/github/dockerjava/api/model/VersionTest.java
@@ -5,9 +5,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.core.RemoteApiVersion;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import static com.github.dockerjava.test.serdes.JSONSamples.testRoundTrip;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
 /**
@@ -37,4 +43,46 @@ public class VersionTest {
         assertThat(version.getBuildTime(), is("2016-02-11T20:39:58.688092588+00:00"));
     }
 
+    @Test
+    public void version_1_38() throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        final JavaType type = mapper.getTypeFactory().uncheckedSimpleType(Version.class);
+
+        final Version version = testRoundTrip(RemoteApiVersion.VERSION_1_38,
+                "/version/lcow.json",
+                type
+        );
+
+        assertThat(version, notNullValue());
+        assertThat(version.getApiVersion(), is("1.38"));
+        assertThat(version.getArch(), is("amd64"));
+        assertThat(version.getBuildTime(), is("2018-08-21T17:36:40.000000000+00:00"));
+
+        Map<String, String> details = new LinkedHashMap<>();
+        details.put("ApiVersion", "1.38");
+        details.put("Arch", "amd64");
+        details.put("BuildTime", "2018-08-21T17:36:40.000000000+00:00");
+        details.put("Experimental", "true");
+        details.put("GitCommit", "e68fc7a");
+        details.put("GoVersion", "go1.10.3");
+        details.put("KernelVersion", "10.0 17134 (17134.1.amd64fre.rs4_release.180410-1804)");
+        details.put("MinAPIVersion", "1.24");
+        details.put("Os", "windows");
+
+        List<VersionComponent> components = Collections.singletonList(new VersionComponent()
+                .withDetails(details)
+                .withName("Engine")
+                .withVersion("18.06.1-ce")
+        );
+        assertThat(version.getComponents(), equalTo(components));
+
+        assertThat(version.getExperimental(), is(true));
+        assertThat(version.getGitCommit(), is("e68fc7a"));
+        assertThat(version.getGoVersion(), is("go1.10.3"));
+        assertThat(version.getKernelVersion(), is("10.0 17134 (17134.1.amd64fre.rs4_release.180410-1804)"));
+        assertThat(version.getMinAPIVersion(), is("1.24"));
+        assertThat(version.getOperatingSystem(), is("windows"));
+        assertThat(version.getPlatform(), equalTo(new VersionPlatform().withName("")));
+        assertThat(version.getVersion(), is("18.06.1-ce"));
+    }
 }

--- a/src/test/resources/samples/1.25/images/windowsImage/doc.json
+++ b/src/test/resources/samples/1.25/images/windowsImage/doc.json
@@ -1,0 +1,72 @@
+{
+  "Id": "sha256:105d76d0f40e38427c63023ffe649bf36fa85058d3469551e43e4dcc2431fb31",
+  "RepoTags": [
+    "microsoft/nanoserver:latest"
+  ],
+  "RepoDigests": [
+    "microsoft/nanoserver@sha256:aee7d4330fe3dc5987c808f647441c16ed2fa1c7d9c6ef49d6498e5c9860b50b"
+  ],
+  "Parent": "",
+  "Comment": "",
+  "Created": "2016-09-22T02:39:30.9154862-07:00",
+  "Container": "",
+  "ContainerConfig": {
+    "Hostname": "",
+    "Domainname": "",
+    "User": "",
+    "AttachStdin": false,
+    "AttachStdout": false,
+    "AttachStderr": false,
+    "Tty": false,
+    "OpenStdin": false,
+    "StdinOnce": false,
+    "Env": null,
+    "Cmd": null,
+    "Image": "",
+    "Volumes": null,
+    "WorkingDir": "",
+    "Entrypoint": null,
+    "OnBuild": null,
+    "Labels": null
+  },
+  "DockerVersion": "",
+  "Author": "",
+  "Config": {
+    "Hostname": "",
+    "Domainname": "",
+    "User": "",
+    "AttachStdin": false,
+    "AttachStdout": false,
+    "AttachStderr": false,
+    "Tty": false,
+    "OpenStdin": false,
+    "StdinOnce": false,
+    "Env": null,
+    "Cmd": [
+      "c:\\windows\\system32\\cmd.exe"
+    ],
+    "Image": "",
+    "Volumes": null,
+    "WorkingDir": "",
+    "Entrypoint": null,
+    "OnBuild": null,
+    "Labels": null
+  },
+  "Architecture": "",
+  "Os": "windows",
+  "OsVersion": "10.0.14393",
+  "Size": 651862727,
+  "VirtualSize": 651862727,
+  "GraphDriver": {
+    "Name": "windowsfilter",
+    "Data": {
+      "dir": "C:\\control\\windowsfilter\\6fe6a289b98276a6a5ca0345156ca61d7b38f3da6bb49ef95af1d0f1ac37e5bf"
+    }
+  },
+  "RootFS": {
+    "Type": "layers",
+    "Layers": [
+      "sha256:342d4e407550c52261edd20cd901b5ce438f0b1e940336de3978210612365063"
+    ]
+  }
+}

--- a/src/test/resources/samples/1.38/info/lcow.json
+++ b/src/test/resources/samples/1.38/info/lcow.json
@@ -1,0 +1,93 @@
+{
+  "Architecture": "x86_64",
+  "BridgeNfIp6tables": true,
+  "BridgeNfIptables": true,
+  "CPUSet": false,
+  "CPUShares": false,
+  "CgroupDriver": "",
+  "ClusterAdvertise": "",
+  "ClusterStore": "",
+  "ContainerdCommit": {
+    "Expected": "",
+    "ID": ""
+  },
+  "Containers": 3,
+  "ContainersPaused": 0,
+  "ContainersRunning": 0,
+  "ContainersStopped": 3,
+  "CpuCfsPeriod": false,
+  "CpuCfsQuota": false,
+  "Debug": true,
+  "DefaultRuntime": "",
+  "DockerRootDir": "C:\\ProgramData\\Docker",
+  "Driver": "windowsfilter (windows) lcow (linux)",
+  "DriverStatus": [["Windows", ""], ["LCOW", ""]],
+  "ExperimentalBuild": true,
+  "GenericResources": null,
+  "HttpProxy": "",
+  "HttpsProxy": "",
+  "ID": "ZOGT:VB24:YEPZ:Y7HU:JHPB:WNUE:UYQG:7YRY:VLZV:FLWV:R65B:ICZG",
+  "IPv4Forwarding": true,
+  "Images": 2,
+  "IndexServerAddress": "https://index.docker.io/v1/",
+  "InitBinary": "",
+  "InitCommit": {
+    "Expected": "",
+    "ID": ""
+  },
+  "Isolation": "hyperv",
+  "KernelMemory": false,
+  "KernelVersion": "10.0 17134 (17134.1.amd64fre.rs4_release.180410-1804)",
+  "Labels": [],
+  "LiveRestoreEnabled": false,
+  "LoggingDriver": "json-file",
+  "MemTotal": 68684476416,
+  "MemoryLimit": false,
+  "NCPU": 8,
+  "NEventsListener": 1,
+  "NFd": -1,
+  "NGoroutines": 28,
+  "Name": "somename",
+  "NoProxy": "",
+  "OSType": "windows",
+  "OomKillDisable": false,
+  "OperatingSystem": "Windows 10 Pro Version 1803 (OS Build 17134.228)",
+  "Plugins": {
+    "Authorization": null,
+    "Log": ["awslogs", "etwlogs", "fluentd", "gelf", "json-file", "logentries", "splunk", "syslog"],
+    "Network": ["ics", "l2bridge", "l2tunnel", "nat", "null", "overlay", "transparent"],
+    "Volume": ["local"]
+  },
+  "RegistryConfig": {
+    "AllowNondistributableArtifactsCIDRs": [],
+    "AllowNondistributableArtifactsHostnames": [],
+    "IndexConfigs": {
+      "docker.io": {
+        "Mirrors": [],
+        "Name": "docker.io",
+        "Official": true,
+        "Secure": true
+      }
+    },
+    "InsecureRegistryCIDRs": ["127.0.0.0/8"],
+    "Mirrors": []
+  },
+  "RuncCommit": {
+    "Expected": "",
+    "ID": ""
+  },
+  "Runtimes": null,
+  "SecurityOptions": [],
+  "ServerVersion": "18.06.1-ce",
+  "SwapLimit": false,
+  "Swarm": {
+    "ControlAvailable": false,
+    "Error": "",
+    "LocalNodeState": "inactive",
+    "NodeAddr": "",
+    "NodeID": "",
+    "RemoteManagers": null
+  },
+  "SystemStatus": null,
+  "SystemTime": "2018-09-14T09:40:05.1369294+02:00"
+}

--- a/src/test/resources/samples/1.38/version/lcow.json
+++ b/src/test/resources/samples/1.38/version/lcow.json
@@ -1,0 +1,31 @@
+{
+  "ApiVersion": "1.38",
+  "Arch": "amd64",
+  "BuildTime": "2018-08-21T17:36:40.000000000+00:00",
+  "Components": [{
+    "Details": {
+      "ApiVersion": "1.38",
+      "Arch": "amd64",
+      "BuildTime": "2018-08-21T17:36:40.000000000+00:00",
+      "Experimental": "true",
+      "GitCommit": "e68fc7a",
+      "GoVersion": "go1.10.3",
+      "KernelVersion": "10.0 17134 (17134.1.amd64fre.rs4_release.180410-1804)",
+      "MinAPIVersion": "1.24",
+      "Os": "windows"
+    },
+    "Name": "Engine",
+    "Version": "18.06.1-ce"
+  }
+  ],
+  "Experimental": true,
+  "GitCommit": "e68fc7a",
+  "GoVersion": "go1.10.3",
+  "KernelVersion": "10.0 17134 (17134.1.amd64fre.rs4_release.180410-1804)",
+  "MinAPIVersion": "1.24",
+  "Os": "windows",
+  "Platform": {
+    "Name": ""
+  },
+  "Version": "18.06.1-ce"
+}


### PR DESCRIPTION
This changes brings support of the following features:
* Docker Engine since 1.32 supports `platform` option for image build & pull commands
* Image inspect response now returns missing `OSVersion` & `RootFS` properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1099)
<!-- Reviewable:end -->
