### PR TITLE
Add withFilter methods in ListNetworksCmd & ListVolumesCmd

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/ListNetworksCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/ListNetworksCmd.java
@@ -5,6 +5,7 @@ import com.github.dockerjava.core.RemoteApiVersion;
 
 import javax.annotation.CheckForNull;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -21,6 +22,13 @@ public interface ListNetworksCmd extends SyncDockerCmd<List<Network>> {
     ListNetworksCmd withNameFilter(String... networkName);
 
     ListNetworksCmd withIdFilter(String... networkId);
+
+    /**
+     * @param filterName
+     * @param filterValues
+     *            - Show only networks where the filter matches the given values
+     */
+    ListNetworksCmd withFilter(String filterName, Collection<String> filterValues);
 
     interface Exec extends DockerCmdSyncExec<ListNetworksCmd, List<Network>> {
     }

--- a/src/main/java/com/github/dockerjava/api/command/ListVolumesCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/ListVolumesCmd.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.api.command;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -20,6 +21,13 @@ public interface ListVolumesCmd extends SyncDockerCmd<ListVolumesResponse> {
      *            - Show dangling volumes filter
      */
     ListVolumesCmd withDanglingFilter(Boolean dangling);
+
+    /**
+     * @param filterName
+     * @param filterValues
+     *            - Show only volumes where the filter matches the given values
+     */
+    ListVolumesCmd withFilter(String filterName, Collection<String> filterValues);
 
     interface Exec extends DockerCmdSyncExec<ListVolumesCmd, ListVolumesResponse> {
     }

--- a/src/main/java/com/github/dockerjava/core/command/ListNetworksCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ListNetworksCmdImpl.java
@@ -4,8 +4,11 @@ import com.github.dockerjava.api.command.ListNetworksCmd;
 import com.github.dockerjava.api.model.Network;
 import com.github.dockerjava.core.util.FiltersBuilder;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ListNetworksCmdImpl extends AbstrDockerCmd<ListNetworksCmd, List<Network>> implements ListNetworksCmd {
 
@@ -29,6 +32,13 @@ public class ListNetworksCmdImpl extends AbstrDockerCmd<ListNetworksCmd, List<Ne
     @Override
     public ListNetworksCmd withNameFilter(String... networkName) {
         this.filtersBuilder.withFilter("name", networkName);
+        return this;
+    }
+
+    @Override
+    public ListNetworksCmd withFilter(String filterName, Collection<String> filterValues) {
+        checkNotNull(filterValues, filterName + " was not specified");
+        this.filtersBuilder.withFilter(filterName, filterValues);
         return this;
     }
 }

--- a/src/main/java/com/github/dockerjava/core/command/ListVolumesCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ListVolumesCmdImpl.java
@@ -2,6 +2,7 @@ package com.github.dockerjava.core.command;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -31,6 +32,13 @@ public class ListVolumesCmdImpl extends AbstrDockerCmd<ListVolumesCmd, ListVolum
     public ListVolumesCmd withDanglingFilter(Boolean dangling) {
         checkNotNull(dangling, "dangling have not been specified");
         this.filters.withFilter("dangling", dangling.toString());
+        return this;
+    }
+
+    @Override
+    public ListVolumesCmd withFilter(String filterName, Collection<String> filterValues) {
+        checkNotNull(filterValues, filterName + " was not specified");
+        this.filters.withFilter(filterName, filterValues);
         return this;
     }
 }


### PR DESCRIPTION
Currently it's impossible to use custom filters to query networks & volumes.
It's required to support Windows containers in `testcontainers` library (https://github.com/testcontainers/testcontainers-java/issues/870)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1100)
<!-- Reviewable:end -->
