### PR TITLE
Change since parameter in LogContainerCmd to String

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/LogContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/LogContainerCmd.java
@@ -23,8 +23,8 @@ import com.github.dockerjava.api.model.Frame;
  * @param tail
  *            - `all` or `<number>`, Output specified number of lines at the end of logs
  * @param since
- *            - UNIX timestamp (integer) to filter logs. Specifying a timestamp will only output log-entries since that timestamp. Default:
- *            0 (unfiltered)
+ *            - UNIX timestamp, RFC 3339 date, or Go duration string to filter logs.
+ *            Specifying a timestamp will only output log-entries since that timestamp. Default: 0 (unfiltered)
  */
 public interface LogContainerCmd extends AsyncDockerCmd<LogContainerCmd, Frame> {
 
@@ -47,7 +47,7 @@ public interface LogContainerCmd extends AsyncDockerCmd<LogContainerCmd, Frame> 
     Boolean hasStderrEnabled();
 
     @CheckForNull
-    Integer getSince();
+    String getSince();
 
     LogContainerCmd withContainerId(@Nonnull String containerId);
 
@@ -67,7 +67,7 @@ public interface LogContainerCmd extends AsyncDockerCmd<LogContainerCmd, Frame> 
 
     LogContainerCmd withTail(Integer tail);
 
-    LogContainerCmd withSince(Integer since);
+    LogContainerCmd withSince(String since);
 
     /**
      * @throws com.github.dockerjava.api.NotFoundException

--- a/src/main/java/com/github/dockerjava/core/command/LogContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/LogContainerCmdImpl.java
@@ -22,8 +22,8 @@ import com.github.dockerjava.api.model.Frame;
  * @param tail
  *            - `all` or `<number>`, Output specified number of lines at the end of logs
  * @param since
- *            - UNIX timestamp (integer) to filter logs. Specifying a timestamp will only output log-entries since that timestamp. Default:
- *            0 (unfiltered)
+ *            - UNIX timestamp, RFC 3339 date, or Go duration string to filter logs.
+ *            Specifying a timestamp will only output log-entries since that timestamp. Default: 0 (unfiltered)
  */
 public class LogContainerCmdImpl extends AbstrAsyncDockerCmd<LogContainerCmd, Frame> implements LogContainerCmd {
 
@@ -31,7 +31,8 @@ public class LogContainerCmdImpl extends AbstrAsyncDockerCmd<LogContainerCmd, Fr
 
     private Boolean followStream, timestamps, stdout, stderr;
 
-    private Integer tail, since;
+    private Integer tail;
+    private String since;
 
     public LogContainerCmdImpl(LogContainerCmd.Exec exec, String containerId) {
         super(exec);
@@ -69,7 +70,7 @@ public class LogContainerCmdImpl extends AbstrAsyncDockerCmd<LogContainerCmd, Fr
     }
 
     @Override
-    public Integer getSince() {
+    public String getSince() {
         return since;
     }
 
@@ -117,7 +118,7 @@ public class LogContainerCmdImpl extends AbstrAsyncDockerCmd<LogContainerCmd, Fr
     }
 
     @Override
-    public LogContainerCmd withSince(Integer since) {
+    public LogContainerCmd withSince(String since) {
         this.since = since;
         return this;
     }

--- a/src/test/java/com/github/dockerjava/cmd/LogContainerCmdIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/LogContainerCmdIT.java
@@ -175,7 +175,7 @@ public class LogContainerCmdIT extends CmdIT {
         LOG.info("Created container: {}", container.toString());
         assertThat(container.getId(), not(isEmptyString()));
 
-        int timestamp = (int) (System.currentTimeMillis() / 1000);
+        String timestamp = String.valueOf(System.currentTimeMillis() / 1000);
 
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
 
@@ -190,6 +190,40 @@ public class LogContainerCmdIT extends CmdIT {
         dockerRule.getClient().logContainerCmd(container.getId())
                 .withStdErr(true)
                 .withStdOut(true)
+                .withSince(timestamp)
+                .exec(loggingCallback);
+
+        loggingCallback.awaitCompletion();
+
+        assertThat(loggingCallback.toString(), containsString(snippet));
+    }
+
+    @Test
+    public void asyncLogContainerWithSinceNanoseconds() throws Exception {
+        String snippet = "hello world";
+
+        CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox")
+                .withCmd("/bin/echo", snippet)
+                .exec();
+
+        LOG.info("Created container: {}", container.toString());
+        assertThat(container.getId(), not(isEmptyString()));
+
+        String timestamp = String.format("%.4f", System.currentTimeMillis() / 1000d);
+        dockerRule.getClient().startContainerCmd(container.getId()).exec();
+
+        int exitCode = dockerRule.getClient().waitContainerCmd(container.getId())
+                .exec(new WaitContainerResultCallback())
+                .awaitStatusCode();
+
+        assertThat(exitCode, equalTo(0));
+
+        LogContainerTestCallback loggingCallback = new LogContainerTestCallback();
+
+        dockerRule.getClient().logContainerCmd(container.getId())
+                .withStdErr(true)
+                .withStdOut(true)
+                .withTimestamps(true)
                 .withSince(timestamp)
                 .exec(loggingCallback);
 


### PR DESCRIPTION
The [`docker logs`-command](https://docs.docker.com/v17.12/engine/reference/commandline/logs/#options) takes on a variety of different formats for the `since` parameter.

This PR allows for more formats when using `since` parameter for the LogContainerCmd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1111)
<!-- Reviewable:end -->
