### PR TITLE
Add HostConfig.StorageOpt and ExecCreateCmd.Env

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/ExecCreateCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/ExecCreateCmd.java
@@ -1,5 +1,7 @@
 package com.github.dockerjava.api.command;
 
+import java.util.List;
+
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
@@ -21,6 +23,9 @@ public interface ExecCreateCmd extends SyncDockerCmd<ExecCreateCmdResponse> {
     Boolean hasTtyEnabled();
 
     @CheckForNull
+    List<String> getEnv();
+
+    @CheckForNull
     String getUser();
 
     @CheckForNull
@@ -36,6 +41,8 @@ public interface ExecCreateCmd extends SyncDockerCmd<ExecCreateCmdResponse> {
     ExecCreateCmd withAttachStdout(Boolean attachStdout);
 
     ExecCreateCmd withCmd(String... cmd);
+
+    ExecCreateCmd withEnv(List<String> env);
 
     ExecCreateCmd withContainerId(@Nonnull String containerId);
 

--- a/src/main/java/com/github/dockerjava/api/model/HostConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/HostConfig.java
@@ -174,6 +174,12 @@ public class HostConfig implements Serializable {
     @JsonProperty("RestartPolicy")
     private RestartPolicy restartPolicy;
 
+    /**
+     * @since {@link RemoteApiVersion#VERSION_1_24}
+     */
+    @JsonProperty("StorageOpt")
+    private Map<String, String> storageOpt;
+
     @JsonProperty("Ulimits")
     private Ulimit[] ulimits;
 
@@ -842,6 +848,21 @@ public class HostConfig implements Serializable {
      */
     public HostConfig withRestartPolicy(RestartPolicy restartPolicy) {
         this.restartPolicy = restartPolicy;
+        return this;
+    }
+
+    /**
+     * @see #storageOpt
+     */
+    public Map<String, String> getStorageOpt() {
+        return storageOpt;
+    }
+
+    /**
+     * @see #storageOpt
+     */
+    public HostConfig withStorageOpt(Map<String, String> storageOpt) {
+        this.storageOpt = storageOpt;
         return this;
     }
 

--- a/src/main/java/com/github/dockerjava/core/command/ExecCreateCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/ExecCreateCmdImpl.java
@@ -2,6 +2,8 @@ package com.github.dockerjava.core.command;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -40,6 +42,12 @@ public class ExecCreateCmdImpl extends AbstrDockerCmd<ExecCreateCmd, ExecCreateC
 
     @JsonProperty("Cmd")
     private String[] cmd;
+
+    /**
+     * @since {@link com.github.dockerjava.core.RemoteApiVersion#VERSION_1_25}
+     */
+    @JsonProperty("Env")
+    private List<String> env;
 
     /**
      * @since {@link com.github.dockerjava.core.RemoteApiVersion#VERSION_1_35}
@@ -96,6 +104,12 @@ public class ExecCreateCmdImpl extends AbstrDockerCmd<ExecCreateCmd, ExecCreateC
     }
 
     @Override
+    public ExecCreateCmd withEnv(List<String> env) {
+        this.env = env;
+        return this;
+    }
+
+    @Override
     public ExecCreateCmd withPrivileged(Boolean privileged) {
         this.privileged = privileged;
         return this;
@@ -130,6 +144,11 @@ public class ExecCreateCmdImpl extends AbstrDockerCmd<ExecCreateCmd, ExecCreateC
     @Override
     public Boolean hasTtyEnabled() {
         return tty;
+    }
+
+    @Override
+    public List<String> getEnv() {
+        return env;
     }
 
     @Override


### PR DESCRIPTION
#### Add HostConfig.StorageOpt

API v1.24: "POST /containers/create now takes StorageOpt field."

#### Add ExecCreateCmd.Env

API v1.25: "POST /containers/(id or name)/exec now accepts an Env field,
which holds a list of environment variables to be set in the context of
the command execution."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1112)
<!-- Reviewable:end -->
