### PR TITLE
Add missing import line for BuildImageResultCallback into DockerfileFixture.java

### DIFF
--- a/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
+++ b/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
@@ -4,6 +4,7 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.exception.InternalServerErrorException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Image;
+import com.github.dockerjava.core.command.BuildImageResultCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
I've tried to use the fixture and found out a missing import there. So there is a little fix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1122)
<!-- Reviewable:end -->
