### PR TITLE
fix: resolve #1125

### DIFF
--- a/src/main/java/com/github/dockerjava/core/command/AbstrDockerCmd.java
+++ b/src/main/java/com/github/dockerjava/core/command/AbstrDockerCmd.java
@@ -31,7 +31,6 @@ public abstract class AbstrDockerCmd<CMD_T extends DockerCmd<RES_T>, RES_T> impl
     @Override
     @SuppressWarnings("unchecked")
     public RES_T exec() throws DockerException {
-        LOGGER.debug("Cmd: {}", this);
         return execution.exec((CMD_T) this);
     }
 


### PR DESCRIPTION
This fix is a quick workaround to #1125. It is probably the case that DEBUG should not be the default log level, but, on the other hand, logging the entire object is not great also.