### PR TITLE
Use Base64Url instead of Base64

### DIFF
--- a/src/main/java/com/github/dockerjava/core/exec/AbstrDockerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/core/exec/AbstrDockerCmdExec.java
@@ -42,7 +42,7 @@ public abstract class AbstrDockerCmdExec {
 
     protected String registryAuth(@Nonnull AuthConfig authConfig) {
         try {
-            return Base64.encodeBase64String(new ObjectMapper().writeValueAsString(authConfig).getBytes());
+            return Base64.encodeBase64URLSafeString(new ObjectMapper().writeValueAsString(authConfig).getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -66,7 +66,7 @@ public abstract class AbstrDockerCmdExec {
                 json = objectMapper.writeValueAsString(authConfigs);
             }
 
-            return Base64.encodeBase64String(json.getBytes());
+            return Base64.encodeBase64URLSafeString(json.getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/github/dockerjava/core/exec/AbstrDockerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/core/exec/AbstrDockerCmdExec.java
@@ -8,7 +8,7 @@ import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.InvocationBuilder;
 import com.github.dockerjava.core.RemoteApiVersion;
 import com.github.dockerjava.core.WebTarget;
-import org.apache.commons.codec.binary.Base64;
+import com.google.common.io.BaseEncoding;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -42,7 +42,7 @@ public abstract class AbstrDockerCmdExec {
 
     protected String registryAuth(@Nonnull AuthConfig authConfig) {
         try {
-            return Base64.encodeBase64URLSafeString(new ObjectMapper().writeValueAsString(authConfig).getBytes());
+            return BaseEncoding.base64Url().encode(new ObjectMapper().writeValueAsString(authConfig).getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -65,8 +65,7 @@ public abstract class AbstrDockerCmdExec {
             } else {
                 json = objectMapper.writeValueAsString(authConfigs);
             }
-
-            return Base64.encodeBase64URLSafeString(json.getBytes());
+            return BaseEncoding.base64Url().encode(json.getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/github/dockerjava/jaxrs/AbstrDockerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/AbstrDockerCmdExec.java
@@ -6,7 +6,7 @@ import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.AuthConfigurations;
 import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.RemoteApiVersion;
-import org.apache.commons.codec.binary.Base64;
+import com.google.common.io.BaseEncoding;
 
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
@@ -39,7 +39,7 @@ public abstract class AbstrDockerCmdExec {
 
     protected String registryAuth(AuthConfig authConfig) {
         try {
-            return Base64.encodeBase64URLSafeString(new ObjectMapper().writeValueAsString(authConfig).getBytes());
+            return BaseEncoding.base64Url().encode(new ObjectMapper().writeValueAsString(authConfig).getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -74,7 +74,7 @@ public abstract class AbstrDockerCmdExec {
                 json = objectMapper.writeValueAsString(authConfigs);
             }
 
-            return Base64.encodeBase64URLSafeString(json.getBytes());
+            return BaseEncoding.base64Url().encode(json.getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/github/dockerjava/jaxrs/AbstrDockerCmdExec.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/AbstrDockerCmdExec.java
@@ -39,7 +39,7 @@ public abstract class AbstrDockerCmdExec {
 
     protected String registryAuth(AuthConfig authConfig) {
         try {
-            return Base64.encodeBase64String(new ObjectMapper().writeValueAsString(authConfig).getBytes());
+            return Base64.encodeBase64URLSafeString(new ObjectMapper().writeValueAsString(authConfig).getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -74,7 +74,7 @@ public abstract class AbstrDockerCmdExec {
                 json = objectMapper.writeValueAsString(authConfigs);
             }
 
-            return Base64.encodeBase64String(json.getBytes());
+            return Base64.encodeBase64URLSafeString(json.getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Docker is using Base64Url to encode `X-Registry-Auth` header. It isn't documented anywhere, but we could check it in source code (for example here: https://github.com/docker/docker-ce/blob/10e40bd1548f69354a803a15fde1b672cc024b91/components/cli/cli/command/registry.go#L47).

Currently some passwords doesn't work with this library. For example password `a!?testpassword` will be encoded to `YSE/dGVzdHBhc3N3b3Jk` and will be rejected by Docker registry (because it should be encoded to `YSE_dGVzdHBhc3N3b3Jk`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1146)
<!-- Reviewable:end -->
