### PR TITLE
Ignore exception while closing stream to let awaitCompletion finish before time-out

### DIFF
--- a/src/main/java/com/github/dockerjava/core/async/ResultCallbackTemplate.java
+++ b/src/main/java/com/github/dockerjava/core/async/ResultCallbackTemplate.java
@@ -74,14 +74,13 @@ public abstract class ResultCallbackTemplate<RC_T extends ResultCallback<A_RES_T
     public void close() throws IOException {
         if (!closed) {
            closed = true;
-           if (stream != null) {
-               try {
+           try {
+               if (stream != null) {
                    stream.close();
-               } catch (IOException e) {
-                   LOGGER.debug("Error closing stream", e);
                }
+           } finally {
+               completed.countDown();
            }
-           completed.countDown();
         }
     }
 

--- a/src/main/java/com/github/dockerjava/core/async/ResultCallbackTemplate.java
+++ b/src/main/java/com/github/dockerjava/core/async/ResultCallbackTemplate.java
@@ -75,7 +75,11 @@ public abstract class ResultCallbackTemplate<RC_T extends ResultCallback<A_RES_T
         if (!closed) {
            closed = true;
            if (stream != null) {
-               stream.close();
+               try {
+                   stream.close();
+               } catch (IOException e) {
+                   LOGGER.debug("Error closing stream", e);
+               }
            }
            completed.countDown();
         }


### PR DESCRIPTION
Currently, any exception thrown by stream.close in ResultCallbackTemplate#close causes CountDownLatch complete to not being counted down and awaitCompletion to never end (or to wait until time-out).

This pull request ensures that calling LogContainerResultCallback#close will really close despite any errors thrown from stream.close() and let awaitCompletion finish before time-out. In this PR this exception will be logged on debug level and ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1149)
<!-- Reviewable:end -->
