### PR TITLE
! [api/healthcheck] startPeriod is now a long

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
+++ b/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
@@ -56,7 +56,7 @@ public class HealthCheck implements Serializable {
      * @since 1.26
      */
     @JsonProperty("StartPeriod")
-    private Integer startPeriod;
+    private Long startPeriod;
 
     public Long getInterval() {
         return interval;
@@ -94,11 +94,11 @@ public class HealthCheck implements Serializable {
         return this;
     }
 
-    public Integer getStartPeriod() {
+    public Long getStartPeriod() {
         return startPeriod;
     }
 
-    public HealthCheck withStartPeriod(Integer startPeriod) {
+    public HealthCheck withStartPeriod(Long startPeriod) {
         this.startPeriod = startPeriod;
         return this;
     }


### PR DESCRIPTION
As it is saved in nanoseconds, int is to small to save sensible values

PR as requested in #1143

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1152)
<!-- Reviewable:end -->
