### PR TITLE
class TaskSpec to support GenericResource

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/DiscreteResourceSpec.java
+++ b/src/main/java/com/github/dockerjava/api/model/DiscreteResourceSpec.java
@@ -2,6 +2,6 @@ package com.github.dockerjava.api.model;
 
 import java.io.Serializable;
 
-public class DiscreteResourceSpec extends GenericResource<String> implements Serializable {
+public class DiscreteResourceSpec extends GenericResource<Integer> implements Serializable {
     private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/com/github/dockerjava/api/model/DiscreteResourceSpec.java
+++ b/src/main/java/com/github/dockerjava/api/model/DiscreteResourceSpec.java
@@ -2,6 +2,11 @@ package com.github.dockerjava.api.model;
 
 import java.io.Serializable;
 
+/**
+ *
+ * since 1.24 generic type is String
+ * since 1.39 generic type is Integer
+ */
 public class DiscreteResourceSpec extends GenericResource<Integer> implements Serializable {
     private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/com/github/dockerjava/api/model/GenericResource.java
+++ b/src/main/java/com/github/dockerjava/api/model/GenericResource.java
@@ -1,6 +1,10 @@
 package com.github.dockerjava.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang.builder.ToStringStyle;
 
 import java.io.Serializable;
 
@@ -28,5 +32,20 @@ public abstract class GenericResource<T> implements Serializable {
     public GenericResource withValue(T value) {
         this.value = value;
         return this;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
     }
 }

--- a/src/main/java/com/github/dockerjava/api/model/GenericResourceWrapper.java
+++ b/src/main/java/com/github/dockerjava/api/model/GenericResourceWrapper.java
@@ -9,60 +9,50 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 
-import javax.annotation.CheckForNull;
 import java.io.Serializable;
-import java.util.List;
 
 /**
- * @since {@link RemoteApiVersion#VERSION_1_24}
- * type of reservations changed at 1.39 from ResourceSpecs to ResourceReservation .
+ * @since {@link RemoteApiVersion#VERSION_1_39}
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ResourceRequirements implements Serializable {
+public class GenericResourceWrapper implements Serializable {
     public static final Long serialVersionUID = 1L;
-
-    /**
-     * @since 1.24
-     */
-    @JsonProperty("Limits")
-    private ResourceSpecs limits;
 
     /**
      * @since 1.39
      */
-    @JsonProperty("Reservations")
-    private ResourceReservation reservations;
+    @JsonProperty("DiscreteResourceSpec")
+    private DiscreteResourceSpec discreteResourceSpec;
 
     /**
-     * @see #limits
+     * @see #discreteResourceSpec
      */
-    @CheckForNull
-    public ResourceSpecs getLimits() {
-        return limits;
+    public DiscreteResourceSpec getDiscreteResourceSpec() {
+        return discreteResourceSpec;
     }
 
     /**
-     * @see #limits
+     * @see #discreteResourceSpec
      */
-    public ResourceRequirements withLimits(ResourceSpecs limits) {
-        this.limits = limits;
+    public GenericResourceWrapper withDiscreteResourceSpec(DiscreteResourceSpec discreteResourceSpec) {
+        this.discreteResourceSpec = discreteResourceSpec;
         return this;
     }
 
-    /**
-     * @see #reservations
-     */
-    @CheckForNull
-    public ResourceReservation getReservations() {
-        return reservations;
+    public GenericResourceWrapper withKind(String kind) {
+        if (this.discreteResourceSpec == null) {
+            this.discreteResourceSpec = new DiscreteResourceSpec();
+        }
+        discreteResourceSpec.withKind(kind);
+        return this;
     }
 
-    /**
-     * @see #reservations
-     */
-    public ResourceRequirements withReservations(ResourceReservation reservations) {
-        this.reservations = reservations;
+    public GenericResourceWrapper withValue(String value) {
+        if (this.discreteResourceSpec == null) {
+            this.discreteResourceSpec = new DiscreteResourceSpec();
+        }
+        discreteResourceSpec.withValue(value);
         return this;
     }
 
@@ -80,5 +70,4 @@ public class ResourceRequirements implements Serializable {
     public int hashCode() {
         return HashCodeBuilder.reflectionHashCode(this);
     }
-
 }

--- a/src/main/java/com/github/dockerjava/api/model/GenericResourceWrapper.java
+++ b/src/main/java/com/github/dockerjava/api/model/GenericResourceWrapper.java
@@ -48,7 +48,7 @@ public class GenericResourceWrapper implements Serializable {
         return this;
     }
 
-    public GenericResourceWrapper withValue(String value) {
+    public GenericResourceWrapper withValue(int value) {
         if (this.discreteResourceSpec == null) {
             this.discreteResourceSpec = new DiscreteResourceSpec();
         }

--- a/src/main/java/com/github/dockerjava/api/model/ResourceRequirements.java
+++ b/src/main/java/com/github/dockerjava/api/model/ResourceRequirements.java
@@ -11,7 +11,6 @@ import org.apache.commons.lang.builder.ToStringStyle;
 
 import javax.annotation.CheckForNull;
 import java.io.Serializable;
-import java.util.List;
 
 /**
  * @since {@link RemoteApiVersion#VERSION_1_24}

--- a/src/main/java/com/github/dockerjava/api/model/ResourceReservation.java
+++ b/src/main/java/com/github/dockerjava/api/model/ResourceReservation.java
@@ -14,55 +14,29 @@ import java.io.Serializable;
 import java.util.List;
 
 /**
- * @since {@link RemoteApiVersion#VERSION_1_24}
- * type of reservations changed at 1.39 from ResourceSpecs to ResourceReservation .
+ * @since {@link RemoteApiVersion#VERSION_1_39}
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ResourceRequirements implements Serializable {
+public class ResourceReservation implements Serializable {
     public static final Long serialVersionUID = 1L;
-
-    /**
-     * @since 1.24
-     */
-    @JsonProperty("Limits")
-    private ResourceSpecs limits;
 
     /**
      * @since 1.39
      */
-    @JsonProperty("Reservations")
-    private ResourceReservation reservations;
+    @JsonProperty("GenericResources")
+    private List<GenericResourceWrapper> genericResources;
 
     /**
-     * @see #limits
+     * @see #genericResources
      */
     @CheckForNull
-    public ResourceSpecs getLimits() {
-        return limits;
+    public List<GenericResourceWrapper> getGenericResources() {
+        return genericResources;
     }
 
-    /**
-     * @see #limits
-     */
-    public ResourceRequirements withLimits(ResourceSpecs limits) {
-        this.limits = limits;
-        return this;
-    }
-
-    /**
-     * @see #reservations
-     */
-    @CheckForNull
-    public ResourceReservation getReservations() {
-        return reservations;
-    }
-
-    /**
-     * @see #reservations
-     */
-    public ResourceRequirements withReservations(ResourceReservation reservations) {
-        this.reservations = reservations;
+    public ResourceReservation withGenericResources(List<GenericResourceWrapper> genericResources) {
+        this.genericResources = genericResources;
         return this;
     }
 

--- a/src/main/java/com/github/dockerjava/api/model/ResourceReservation.java
+++ b/src/main/java/com/github/dockerjava/api/model/ResourceReservation.java
@@ -22,10 +22,58 @@ public class ResourceReservation implements Serializable {
     public static final Long serialVersionUID = 1L;
 
     /**
+     * 100M at docker-compose equals to 104857600 of MemoryBytes.
+     *
+     * @since 1.24
+     */
+    @JsonProperty("MemoryBytes")
+    private Long memoryBytes;
+
+    /**
+     * '0.50' at docker-compose equals to 500000000 of NanoCPUs.
+     *
+     * @since 1.24
+     */
+    @JsonProperty("NanoCPUs")
+    private Long nanoCPUs;
+
+    /**
      * @since 1.39
      */
     @JsonProperty("GenericResources")
     private List<GenericResourceWrapper> genericResources;
+
+    /**
+     * @see #memoryBytes
+     */
+    @CheckForNull
+    public Long getMemoryBytes() {
+        return memoryBytes;
+    }
+
+    /**
+     * @see #memoryBytes
+     */
+    public ResourceReservation withMemoryBytes(long memoryBytes) {
+        this.memoryBytes = memoryBytes;
+        return this;
+    }
+
+    /**
+     * @see #nanoCPUs
+     */
+    @CheckForNull
+    public Long getNanoCPUs() {
+        return nanoCPUs;
+    }
+
+    /**
+     * @see #nanoCPUs
+     */
+    public ResourceReservation withNanoCPUs(long nanoCPUs) {
+        this.nanoCPUs = nanoCPUs;
+        return this;
+    }
 
     /**
      * @see #genericResources

--- a/src/main/java/com/github/dockerjava/api/model/TaskSpec.java
+++ b/src/main/java/com/github/dockerjava/api/model/TaskSpec.java
@@ -192,13 +192,14 @@ public class TaskSpec implements Serializable {
 
     /**
      * excluding the field runtime, since on creation of service its value is null, and after inspection value is "container".
-     * if leave it unexcluded tests will fail (for example: com.github.dockerjava.cmd.swarm.CreateServiceCmdExecIT#testCreateServiceWithNetworks
+     * if leave it unexcluded tests will fail
+     * ( for example: com.github.dockerjava.cmd.swarm.CreateServiceCmdExecIT#testCreateServiceWithNetworks )
      */
-    private static final String[] excludeEqualsFieldArray = new String[]{"runtime"};
+    private static final String[] EXCLUDE_EQUALS_FIELD_ARRAY = new String[]{"runtime"};
 
     @Override
     public boolean equals(Object o) {
-        return EqualsBuilder.reflectionEquals(this, o, excludeEqualsFieldArray);
+        return EqualsBuilder.reflectionEquals(this, o, EXCLUDE_EQUALS_FIELD_ARRAY);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/api/model/TaskSpec.java
+++ b/src/main/java/com/github/dockerjava/api/model/TaskSpec.java
@@ -190,9 +190,15 @@ public class TaskSpec implements Serializable {
         return ToStringBuilder.reflectionToString(this, ToStringStyle.SHORT_PREFIX_STYLE);
     }
 
+    /**
+     * excluding the field runtime, since on creation of service its value is null, and after inspection value is "container".
+     * if leave it unexcluded tests will fail (for example: com.github.dockerjava.cmd.swarm.CreateServiceCmdExecIT#testCreateServiceWithNetworks
+     */
+    private static final String[] excludeEqualsFieldArray = new String[]{"runtime"};
+
     @Override
     public boolean equals(Object o) {
-        return EqualsBuilder.reflectionEquals(this, o);
+        return EqualsBuilder.reflectionEquals(this, o, excludeEqualsFieldArray);
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/core/RemoteApiVersion.java
+++ b/src/main/java/com/github/dockerjava/core/RemoteApiVersion.java
@@ -89,6 +89,7 @@ public class RemoteApiVersion implements Serializable {
     public static final RemoteApiVersion VERSION_1_36 = RemoteApiVersion.create(1, 36);
     public static final RemoteApiVersion VERSION_1_37 = RemoteApiVersion.create(1, 37);
     public static final RemoteApiVersion VERSION_1_38 = RemoteApiVersion.create(1, 38);
+    public static final RemoteApiVersion VERSION_1_39 = RemoteApiVersion.create(1, 39);
 
 
     /**

--- a/src/test/java/com/github/dockerjava/cmd/swarm/CreateServiceCmdExecIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/swarm/CreateServiceCmdExecIT.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.cmd.swarm;
 
+import com.github.dockerjava.api.command.CreateServiceResponse;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.ContainerSpec;
 import com.github.dockerjava.api.model.EndpointResolutionMode;
@@ -83,8 +84,12 @@ public class CreateServiceCmdExecIT extends SwarmCmdIT {
                                 .withReservations(new ResourceReservation()
                                         .withGenericResources(Lists.newArrayList(
                                                 new GenericResourceWrapper()
-                                                        .withKind("abc")
-                                                        .withValue("567")
+                                                        .withKind("gpu")
+                                                        .withValue(2)
+                                                ,
+                                                new GenericResourceWrapper()
+                                                        .withKind("cpu")
+                                                        .withValue(7)
                                                 )
                                         )
                                 )
@@ -107,7 +112,9 @@ public class CreateServiceCmdExecIT extends SwarmCmdIT {
                                 .withProtocol(PortConfigProtocol.TCP)
                         )));
 
-        dockerRule.getClient().createServiceCmd(spec).exec();
+        CreateServiceResponse createServiceResponse = dockerRule.getClient().createServiceCmd(spec).exec();
+
+        //Service inspectedService = dockerRule.getClient().inspectServiceCmd(createServiceResponse.getId()).exec();
 
         List<Service> services = dockerRule.getClient().listServicesCmd()
                 .withNameFilter(Lists.newArrayList(SERVICE_NAME))

--- a/src/test/java/com/github/dockerjava/cmd/swarm/CreateServiceCmdExecIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/swarm/CreateServiceCmdExecIT.java
@@ -13,6 +13,7 @@ import com.github.dockerjava.api.model.PortConfig;
 import com.github.dockerjava.api.model.PortConfigProtocol;
 import com.github.dockerjava.api.model.ResourceRequirements;
 import com.github.dockerjava.api.model.ResourceReservation;
+import com.github.dockerjava.api.model.ResourceSpecs;
 import com.github.dockerjava.api.model.Service;
 import com.github.dockerjava.api.model.ServiceModeConfig;
 import com.github.dockerjava.api.model.ServiceReplicatedModeOptions;
@@ -81,7 +82,13 @@ public class CreateServiceCmdExecIT extends SwarmCmdIT {
                         .withContainerSpec(new ContainerSpec()
                                 .withImage("busybox"))
                         .withResources(new ResourceRequirements()
+                                .withLimits(new ResourceSpecs()
+                                        .withMemoryBytes(524_288_000) // 500M
+                                        .withNanoCPUs(250000000) // '0.25'
+                                )
                                 .withReservations(new ResourceReservation()
+                                        .withMemoryBytes(104_857_600) // 100M
+                                        .withNanoCPUs(500000000) // '0.50'
                                         .withGenericResources(Lists.newArrayList(
                                                 new GenericResourceWrapper()
                                                         .withKind("gpu")

--- a/src/test/java/com/github/dockerjava/cmd/swarm/CreateServiceCmdExecIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/swarm/CreateServiceCmdExecIT.java
@@ -4,12 +4,14 @@ import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.ContainerSpec;
 import com.github.dockerjava.api.model.EndpointResolutionMode;
 import com.github.dockerjava.api.model.EndpointSpec;
+import com.github.dockerjava.api.model.GenericResourceWrapper;
 import com.github.dockerjava.api.model.Mount;
-import com.github.dockerjava.api.model.MountType;
 import com.github.dockerjava.api.model.Network;
 import com.github.dockerjava.api.model.NetworkAttachmentConfig;
 import com.github.dockerjava.api.model.PortConfig;
 import com.github.dockerjava.api.model.PortConfigProtocol;
+import com.github.dockerjava.api.model.ResourceRequirements;
+import com.github.dockerjava.api.model.ResourceReservation;
 import com.github.dockerjava.api.model.Service;
 import com.github.dockerjava.api.model.ServiceModeConfig;
 import com.github.dockerjava.api.model.ServiceReplicatedModeOptions;
@@ -77,6 +79,16 @@ public class CreateServiceCmdExecIT extends SwarmCmdIT {
                         .withForceUpdate(0)
                         .withContainerSpec(new ContainerSpec()
                                 .withImage("busybox"))
+                        .withResources(new ResourceRequirements()
+                                .withReservations(new ResourceReservation()
+                                        .withGenericResources(Lists.newArrayList(
+                                                new GenericResourceWrapper()
+                                                        .withKind("abc")
+                                                        .withValue("567")
+                                                )
+                                        )
+                                )
+                        )
                 )
                 .withNetworks(Lists.newArrayList(
                         new NetworkAttachmentConfig()

--- a/src/test/java/com/github/dockerjava/cmd/swarm/CreateServiceCmdExecIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/swarm/CreateServiceCmdExecIT.java
@@ -84,11 +84,11 @@ public class CreateServiceCmdExecIT extends SwarmCmdIT {
                         .withResources(new ResourceRequirements()
                                 .withLimits(new ResourceSpecs()
                                         .withMemoryBytes(524_288_000) // 500M
-                                        .withNanoCPUs(250000000) // '0.25'
+                                        .withNanoCPUs(500000000) // '0.50'
                                 )
                                 .withReservations(new ResourceReservation()
                                         .withMemoryBytes(104_857_600) // 100M
-                                        .withNanoCPUs(500000000) // '0.50'
+                                        .withNanoCPUs(250000000) // '0.25'
                                         .withGenericResources(Lists.newArrayList(
                                                 new GenericResourceWrapper()
                                                         .withKind("gpu")


### PR DESCRIPTION
Affected commands:
1) Create Service
2) Inspect Service 
3) Update Service 
4) List Service
5) List Task

Note 1: class **DiscreteResourceSpec** type has changed from **String** to **Integer**. (as docker states)
Note 2: class **ResourceRequirements** type of field name reservations been modified from **ResourceSpecs** to **ResourceReservation**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1153)
<!-- Reviewable:end -->
