### PR TITLE
BuildImageCmdImpl: Fix an exception message

### DIFF
--- a/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/BuildImageCmdImpl.java
@@ -327,7 +327,7 @@ public class BuildImageCmdImpl extends AbstrAsyncDockerCmd<BuildImageCmd, BuildR
             throw new IllegalArgumentException("Dockerfile does not exist");
         }
         if (!dockerfile.isFile()) {
-            throw new IllegalArgumentException("Not a directory");
+            throw new IllegalArgumentException("Dockerfile is not a file");
         }
 
         if (baseDirectory == null) {


### PR DESCRIPTION
The exception is thrown is if "dockerFile" is not a file, not if it is
not a directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1178)
<!-- Reviewable:end -->
