### PR TITLE
Remove `JacksonJaxbJsonProvider` from `FiltersEncoder`

### DIFF
--- a/src/main/java/com/github/dockerjava/core/util/FiltersEncoder.java
+++ b/src/main/java/com/github/dockerjava/core/util/FiltersEncoder.java
@@ -3,11 +3,8 @@ package com.github.dockerjava.core.util;
 import java.util.List;
 import java.util.Map;
 
-import javax.ws.rs.core.MediaType;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 
 /**
  * JSON Encoder for docker filters.
@@ -19,7 +16,7 @@ public class FiltersEncoder {
     private FiltersEncoder() {
     }
 
-    private static final ObjectMapper MAPPER = new JacksonJaxbJsonProvider().locateMapper(Map.class, MediaType.APPLICATION_JSON_TYPE);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     public static String jsonEncode(Map<String, List<String>> mapStringListString) {
         try {


### PR DESCRIPTION
To avoid a dependency on JAX-RS, `JacksonJaxbJsonProvider` should not be used
where a standard `ObjectMapper` instance is enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1179)
<!-- Reviewable:end -->
