### PR TITLE
Allow configuration of restart policy when updating containers.

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/UpdateContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/UpdateContainerCmd.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.api.command;
 
+import com.github.dockerjava.api.model.RestartPolicy;
 import com.github.dockerjava.api.model.UpdateContainerResponse;
 import com.github.dockerjava.core.RemoteApiVersion;
 
@@ -65,6 +66,11 @@ public interface UpdateContainerCmd extends SyncDockerCmd<UpdateContainerRespons
     Long getMemorySwap();
 
     UpdateContainerCmd withMemorySwap(Long memorySwap);
+
+    @CheckForNull
+    RestartPolicy getRestartPolicy();
+
+    UpdateContainerCmd withRestartPolicy(RestartPolicy restartPolicy);
 
     interface Exec extends DockerCmdSyncExec<UpdateContainerCmd, UpdateContainerResponse> {
     }

--- a/src/main/java/com/github/dockerjava/api/model/RestartPolicy.java
+++ b/src/main/java/com/github/dockerjava/api/model/RestartPolicy.java
@@ -35,7 +35,7 @@ public class RestartPolicy implements Serializable {
     private Integer maximumRetryCount = 0;
 
     @JsonProperty("Name")
-    private String name = "";
+    private String name = "no";
 
     public RestartPolicy() {
     }
@@ -131,8 +131,7 @@ public class RestartPolicy implements Serializable {
      */
     @Override
     public String toString() {
-        String result = name.isEmpty() ? "no" : name;
-        return maximumRetryCount > 0 ? result + ":" + maximumRetryCount : result;
+        return maximumRetryCount > 0 ? name + ":" + maximumRetryCount : name;
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/core/command/UpdateContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/UpdateContainerCmdImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.dockerjava.api.command.UpdateContainerCmd;
 import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.RestartPolicy;
 import com.github.dockerjava.api.model.UpdateContainerResponse;
 import com.github.dockerjava.core.RemoteApiVersion;
 import org.apache.commons.lang.builder.EqualsBuilder;
@@ -54,6 +55,9 @@ public class UpdateContainerCmdImpl extends AbstrDockerCmd<UpdateContainerCmd, U
 
     @JsonProperty("KernelMemory")
     private Long kernelMemory;
+
+    @JsonProperty("RestartPolicy")
+    private RestartPolicy restartPolicy;
 
     public UpdateContainerCmdImpl(UpdateContainerCmd.Exec exec, String containerId) {
         super(exec);
@@ -233,6 +237,22 @@ public class UpdateContainerCmdImpl extends AbstrDockerCmd<UpdateContainerCmd, U
      */
     public UpdateContainerCmd withMemorySwap(Long memorySwap) {
         this.memorySwap = memorySwap;
+        return this;
+    }
+
+    /**
+     * @see #restartPolicy
+     */
+    @CheckForNull
+    public RestartPolicy getRestartPolicy() {
+        return restartPolicy;
+    }
+
+    /**
+     * @see #restartPolicy
+     */
+    public UpdateContainerCmd withRestartPolicy(RestartPolicy restartPolicy) {
+        this.restartPolicy = restartPolicy;
         return this;
     }
 


### PR DESCRIPTION
The Docker API allows clients to configure the restart policy ("no", "always", etc.) when updating containers. This pull request exposes that functionality through the docker-java API.

There are no breaking changes, and this is fully backwards-compatible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1196)
<!-- Reviewable:end -->
