### PR TITLE
Provide Exception message for wrong Scheme

### DIFF
--- a/src/main/java/com/github/dockerjava/core/NameParser.java
+++ b/src/main/java/com/github/dockerjava/core/NameParser.java
@@ -100,8 +100,7 @@ public class NameParser {
 
     public static HostnameReposName resolveRepositoryName(String reposName) {
         if (reposName.contains("://")) {
-            // It cannot contain a scheme!
-            throw new InvalidRepositoryNameException();
+            throw new InvalidRepositoryNameException("RepositoryName shouldn't contain a scheme");
         }
 
         String[] nameParts = reposName.split("/", 2);


### PR DESCRIPTION
When a user provides a schema in the RespositoryName he receives the InvalidRepositoryNameException without an meaningful explanation. This leads to confusion. I had to look up the source to understand why this exception was thrown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1201)
<!-- Reviewable:end -->
