### PR TITLE
remove duplicate jackson json provider registration

### DIFF
--- a/src/main/java/com/github/dockerjava/jaxrs/JerseyDockerCmdExecFactory.java
+++ b/src/main/java/com/github/dockerjava/jaxrs/JerseyDockerCmdExecFactory.java
@@ -155,7 +155,6 @@ public class JerseyDockerCmdExecFactory implements DockerCmdExecFactory {
         }
         clientConfig.register(ResponseStatusExceptionFilter.class);
         clientConfig.register(JsonClientFilter.class);
-        clientConfig.register(JacksonJsonProvider.class);
         RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
 
         ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
Remove duplicate provider registration (existing registration is 5 lines further down in this file). This removes the following warning output regarding duplicate registrations:

>  org.glassfish.jersey.internal.Errors logErrors
WARNING: The following warnings have been detected: HINT: Cannot create new registration for component type class com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider: Existing previous registration found for the type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1202)
<!-- Reviewable:end -->
