### PR TITLE
Reverts create container cmd regression.

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
@@ -4,6 +4,7 @@ import com.github.dockerjava.api.exception.ConflictException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.Capability;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.HealthCheck;
 import com.github.dockerjava.api.model.HostConfig;
@@ -303,6 +304,43 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
      */
     @Deprecated
     CreateContainerCmd withExtraHosts(List<String> extraHosts);
+
+    @CheckForNull
+    @Deprecated
+    Capability[] getCapAdd();
+
+    /**
+     * Add linux <a href="http://man7.org/linux/man-pages/man7/capabilities.7.html">kernel capability</a> to the container. For example:
+     * adding {@link Capability#MKNOD} allows the container to create special files using the 'mknod' command.
+     */
+    @Deprecated
+    CreateContainerCmd withCapAdd(Capability... capAdd);
+
+    /**
+     * Add linux <a href="http://man7.org/linux/man-pages/man7/capabilities.7.html">kernel capability</a> to the container. For example:
+     * adding {@link Capability#MKNOD} allows the container to create special files using the 'mknod' command.
+     */
+    @Deprecated
+    CreateContainerCmd withCapAdd(List<Capability> capAdd);
+
+    @CheckForNull
+    @Deprecated
+    Capability[] getCapDrop();
+
+    /**
+     * Drop linux <a href="http://man7.org/linux/man-pages/man7/capabilities.7.html">kernel capability</a> from the container. For example:
+     * dropping {@link Capability#CHOWN} prevents the container from changing the owner of any files.
+     */
+    @Deprecated
+    CreateContainerCmd withCapDrop(Capability... capDrop);
+
+    /**
+     * Drop linux <a href="http://man7.org/linux/man-pages/man7/capabilities.7.html">kernel capability</a> from the container. For example:
+     * dropping {@link Capability#CHOWN} prevents the container from changing the owner of any files.
+     */
+    @Deprecated
+    CreateContainerCmd withCapDrop(List<Capability> capDrop);
+
 
     @CheckForNull
     List<String> getOnBuild();

--- a/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
@@ -3,10 +3,15 @@ package com.github.dockerjava.api.command;
 import com.github.dockerjava.api.exception.ConflictException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.AuthConfig;
+import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.HealthCheck;
 import com.github.dockerjava.api.model.HostConfig;
+import com.github.dockerjava.api.model.Link;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.Volume;
+import com.github.dockerjava.api.model.VolumesFrom;
 
 import javax.annotation.CheckForNull;
 import java.util.List;
@@ -28,6 +33,16 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
 
     @CheckForNull
     List<String> getAliases();
+
+    @Deprecated
+    @CheckForNull
+    Bind[] getBinds();
+
+    @Deprecated
+    CreateContainerCmd withBinds(Bind... binds);
+
+    @Deprecated
+    CreateContainerCmd withBinds(List<Bind> binds);
 
     /**
      * Add network-scoped alias for the container
@@ -111,6 +126,22 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
 
     CreateContainerCmd withIpv4Address(String ipv4Address);
 
+    @Deprecated
+    @CheckForNull
+    Link[] getLinks();
+
+    /**
+     * Add link to another container.
+     */
+    @Deprecated
+    CreateContainerCmd withLinks(Link... links);
+
+    /**
+     * Add link to another container.
+     */
+    @Deprecated
+    CreateContainerCmd withLinks(List<Link> links);
+
     @CheckForNull
     String getIpv6Address();
 
@@ -129,6 +160,49 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
     @CheckForNull
     String getName();
 
+    @Deprecated
+    @CheckForNull
+    String getNetworkMode();
+
+    /**
+     * Set the Network mode for the container
+     * <ul>
+     * <li>'bridge': creates a new network stack for the container on the docker bridge</li>
+     * <li>'none': no networking for this container</li>
+     * <li>'container:<name|id>': reuses another container network stack</li>
+     * <li>'host': use the host network stack inside the container. Note: the host mode gives the container full access to local system
+     * services such as D-bus and is therefore considered insecure.</li>
+     * </ul>
+     */
+    @Deprecated
+    CreateContainerCmd withNetworkMode(String networkMode);
+
+    @Deprecated
+    @CheckForNull
+    Ports getPortBindings();
+
+    /**
+     * Add one or more {@link PortBinding}s. This corresponds to the <code>--publish</code> (<code>-p</code>) option of the
+     * <code>docker run</code> CLI command.
+     */
+    @Deprecated
+    CreateContainerCmd withPortBindings(PortBinding... portBindings);
+
+    /**
+     * Add one or more {@link PortBinding}s. This corresponds to the <code>--publish</code> (<code>-p</code>) option of the
+     * <code>docker run</code> CLI command.
+     */
+    @Deprecated
+    CreateContainerCmd withPortBindings(List<PortBinding> portBindings);
+
+    /**
+     * Add the port bindings that are contained in the given {@link Ports} object.
+     *
+     * @see #withPortBindings(PortBinding...)
+     */
+    @Deprecated
+    CreateContainerCmd withPortBindings(Ports portBindings);
+
     CreateContainerCmd withName(String name);
 
     @CheckForNull
@@ -137,6 +211,13 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
     CreateContainerCmd withPortSpecs(String... portSpecs);
 
     CreateContainerCmd withPortSpecs(List<String> portSpecs);
+
+    @Deprecated
+    @CheckForNull
+    Boolean getPrivileged();
+
+    @Deprecated
+    CreateContainerCmd withPrivileged(Boolean privileged);
 
     @CheckForNull
     String getUser();
@@ -149,6 +230,16 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
     CreateContainerCmd withVolumes(Volume... volumes);
 
     CreateContainerCmd withVolumes(List<Volume> volumes);
+
+    @Deprecated
+    @CheckForNull
+    VolumesFrom[] getVolumesFrom();
+
+    @Deprecated
+    CreateContainerCmd withVolumesFrom(VolumesFrom... volumesFrom);
+
+    @Deprecated
+    CreateContainerCmd withVolumesFrom(List<VolumesFrom> volumesFrom);
 
     @CheckForNull
     String getWorkingDir();
@@ -189,6 +280,29 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
     Boolean isTty();
 
     CreateContainerCmd withTty(Boolean tty);
+
+    @Deprecated
+    @CheckForNull
+    Boolean getPublishAllPorts();
+
+    @Deprecated
+    CreateContainerCmd withPublishAllPorts(Boolean publishAllPorts);
+
+    @CheckForNull
+    @Deprecated
+    String[] getExtraHosts();
+
+    /**
+     * Add hostnames to /etc/hosts in the container
+     */
+    @Deprecated
+    CreateContainerCmd withExtraHosts(String... extraHosts);
+
+    /**
+     * Add hostnames to /etc/hosts in the container
+     */
+    @Deprecated
+    CreateContainerCmd withExtraHosts(List<String> extraHosts);
 
     @CheckForNull
     List<String> getOnBuild();

--- a/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
@@ -10,6 +10,7 @@ import com.github.dockerjava.api.exception.ConflictException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.Capability;
 import com.github.dockerjava.api.model.ContainerNetwork;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.ExposedPorts;
@@ -164,11 +165,13 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
 
     @CheckForNull
     @Override
+    @Deprecated
     public Bind[] getBinds() {
         return hostConfig.getBinds();
     }
 
     @Override
+    @Deprecated
     public CreateContainerCmd withBinds(Bind... binds) {
         checkNotNull(binds, "binds was not specified");
         hostConfig.setBinds(binds);
@@ -176,6 +179,7 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     }
 
     @Override
+    @Deprecated
     public CreateContainerCmd withBinds(List<Bind> binds) {
         checkNotNull(binds, "binds was not specified");
         return withBinds(binds.toArray(new Bind[binds.size()]));
@@ -382,11 +386,13 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
 
     @CheckForNull
     @Override
+    @Deprecated
     public String getNetworkMode() {
         return hostConfig.getNetworkMode();
     }
 
     @Override
+    @Deprecated
     public CreateContainerCmd withNetworkMode(String networkMode) {
         checkNotNull(networkMode, "networkMode was not specified");
         this.hostConfig.withNetworkMode(networkMode);
@@ -395,11 +401,13 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
 
     @CheckForNull
     @Override
+    @Deprecated
     public Ports getPortBindings() {
         return hostConfig.getPortBindings();
     }
 
     @Override
+    @Deprecated
     public CreateContainerCmd withPortBindings(PortBinding... portBindings) {
         checkNotNull(portBindings, "portBindings was not specified");
         this.hostConfig.withPortBindings(new Ports(portBindings));
@@ -407,12 +415,14 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     }
 
     @Override
+    @Deprecated
     public CreateContainerCmd withPortBindings(List<PortBinding> portBindings) {
         checkNotNull(portBindings, "portBindings was not specified");
         return withPortBindings(portBindings.toArray(new PortBinding[0]));
     }
 
     @Override
+    @Deprecated
     public CreateContainerCmd withPortBindings(Ports portBindings) {
         checkNotNull(portBindings, "portBindings was not specified");
         this.hostConfig.withPortBindings(portBindings);
@@ -446,11 +456,13 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
 
     @CheckForNull
     @Override
+    @Deprecated
     public Boolean getPrivileged() {
         return hostConfig.getPrivileged();
     }
 
     @Override
+    @Deprecated
     public CreateContainerCmd withPrivileged(Boolean privileged) {
         checkNotNull(privileged, "no privileged was specified");
         this.hostConfig.withPrivileged(privileged);
@@ -481,7 +493,6 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
         return this;
     }
 
-
     @Override
     public Boolean isAttachStdin() {
         return attachStdin;
@@ -494,7 +505,6 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
         return this;
     }
 
-
     @Override
     public Boolean isAttachStdout() {
         return attachStdout;
@@ -506,7 +516,6 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
         this.attachStdout = attachStdout;
         return this;
     }
-
 
     @Override
     @JsonIgnore
@@ -529,11 +538,13 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
 
     @CheckForNull
     @Override
+    @Deprecated
     public VolumesFrom[] getVolumesFrom() {
         return hostConfig.getVolumesFrom();
     }
 
     @Override
+    @Deprecated
     public CreateContainerCmd withVolumesFrom(VolumesFrom... volumesFrom) {
         checkNotNull(volumesFrom, "volumesFrom was not specified");
         this.hostConfig.withVolumesFrom(volumesFrom);
@@ -541,6 +552,7 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     }
 
     @Override
+    @Deprecated
     public CreateContainerCmd withVolumesFrom(List<VolumesFrom> volumesFrom) {
         checkNotNull(volumesFrom, "volumesFrom was not specified");
         return withVolumesFrom(volumesFrom.toArray(new VolumesFrom[volumesFrom.size()]));
@@ -610,11 +622,13 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
 
     @CheckForNull
     @Override
+    @Deprecated
     public Boolean getPublishAllPorts() {
         return hostConfig.getPublishAllPorts();
     }
 
     @Override
+    @Deprecated
     public CreateContainerCmd withPublishAllPorts(Boolean publishAllPorts) {
         checkNotNull(publishAllPorts, "no publishAllPorts was specified");
         this.hostConfig.withPublishAllPorts(publishAllPorts);
@@ -623,11 +637,13 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
 
     @CheckForNull
     @Override
+    @Deprecated
     public String[] getExtraHosts() {
         return hostConfig.getExtraHosts();
     }
 
     @Override
+    @Deprecated
     public CreateContainerCmd withExtraHosts(String... extraHosts) {
         checkNotNull(extraHosts, "extraHosts was not specified");
         this.hostConfig.withExtraHosts(extraHosts);
@@ -635,9 +651,54 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     }
 
     @Override
+    @Deprecated
     public CreateContainerCmd withExtraHosts(List<String> extraHosts) {
         checkNotNull(extraHosts, "extraHosts was not specified");
         return withExtraHosts(extraHosts.toArray(new String[extraHosts.size()]));
+    }
+
+    @CheckForNull
+    @Override
+    @Deprecated
+    public Capability[] getCapAdd() {
+        return hostConfig.getCapAdd();
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withCapAdd(Capability... capAdd) {
+        checkNotNull(capAdd, "capAdd was not specified");
+        hostConfig.withCapAdd(capAdd);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withCapAdd(List<Capability> capAdd) {
+        checkNotNull(capAdd, "capAdd was not specified");
+        return withCapAdd(capAdd.toArray(new Capability[capAdd.size()]));
+    }
+
+    @CheckForNull
+    @Override
+    @Deprecated
+    public Capability[] getCapDrop() {
+        return hostConfig.getCapDrop();
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withCapDrop(Capability... capDrop) {
+        checkNotNull(capDrop, "capDrop was not specified");
+        hostConfig.withCapDrop(capDrop);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withCapDrop(List<Capability> capDrop) {
+        checkNotNull(capDrop, "capDrop was not specified");
+        return withCapDrop(capDrop.toArray(new Capability[capDrop.size()]));
     }
 
     @Override
@@ -665,11 +726,13 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
 
     @CheckForNull
     @Override
+    @Deprecated
     public Link[] getLinks() {
         return hostConfig.getLinks();
     }
 
     @Override
+    @Deprecated
     public CreateContainerCmd withLinks(Link... links) {
         checkNotNull(links, "links was not specified");
         this.hostConfig.setLinks(links);
@@ -677,6 +740,7 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     }
 
     @Override
+    @Deprecated
     public CreateContainerCmd withLinks(List<Link> links) {
         checkNotNull(links, "links was not specified");
         return withLinks(links.toArray(new Link[links.size()]));

--- a/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
@@ -9,13 +9,18 @@ import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.exception.ConflictException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.AuthConfig;
+import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.ContainerNetwork;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.ExposedPorts;
 import com.github.dockerjava.api.model.HealthCheck;
 import com.github.dockerjava.api.model.HostConfig;
+import com.github.dockerjava.api.model.Link;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.api.model.Volumes;
+import com.github.dockerjava.api.model.VolumesFrom;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -155,6 +160,25 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     @JsonIgnore
     public List<String> getAliases() {
         return aliases;
+    }
+
+    @CheckForNull
+    @Override
+    public Bind[] getBinds() {
+        return hostConfig.getBinds();
+    }
+
+    @Override
+    public CreateContainerCmd withBinds(Bind... binds) {
+        checkNotNull(binds, "binds was not specified");
+        hostConfig.setBinds(binds);
+        return this;
+    }
+
+    @Override
+    public CreateContainerCmd withBinds(List<Bind> binds) {
+        checkNotNull(binds, "binds was not specified");
+        return withBinds(binds.toArray(new Bind[binds.size()]));
     }
 
     @Override
@@ -356,6 +380,45 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
         return name;
     }
 
+    @CheckForNull
+    @Override
+    public String getNetworkMode() {
+        return hostConfig.getNetworkMode();
+    }
+
+    @Override
+    public CreateContainerCmd withNetworkMode(String networkMode) {
+        checkNotNull(networkMode, "networkMode was not specified");
+        this.hostConfig.withNetworkMode(networkMode);
+        return this;
+    }
+
+    @CheckForNull
+    @Override
+    public Ports getPortBindings() {
+        return hostConfig.getPortBindings();
+    }
+
+    @Override
+    public CreateContainerCmd withPortBindings(PortBinding... portBindings) {
+        checkNotNull(portBindings, "portBindings was not specified");
+        this.hostConfig.withPortBindings(new Ports(portBindings));
+        return this;
+    }
+
+    @Override
+    public CreateContainerCmd withPortBindings(List<PortBinding> portBindings) {
+        checkNotNull(portBindings, "portBindings was not specified");
+        return withPortBindings(portBindings.toArray(new PortBinding[0]));
+    }
+
+    @Override
+    public CreateContainerCmd withPortBindings(Ports portBindings) {
+        checkNotNull(portBindings, "portBindings was not specified");
+        this.hostConfig.withPortBindings(portBindings);
+        return this;
+    }
+
     @Override
     public CreateContainerCmd withName(String name) {
         checkNotNull(name, "name was not specified");
@@ -381,6 +444,19 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
         return withPortSpecs(portSpecs.toArray(new String[0]));
     }
 
+    @CheckForNull
+    @Override
+    public Boolean getPrivileged() {
+        return hostConfig.getPrivileged();
+    }
+
+    @Override
+    public CreateContainerCmd withPrivileged(Boolean privileged) {
+        checkNotNull(privileged, "no privileged was specified");
+        this.hostConfig.withPrivileged(privileged);
+        return this;
+    }
+
     @Override
     public String getUser() {
         return user;
@@ -392,7 +468,6 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
         this.user = user;
         return this;
     }
-
 
     @Override
     public Boolean isAttachStderr() {
@@ -450,6 +525,25 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     public CreateContainerCmd withVolumes(List<Volume> volumes) {
         checkNotNull(volumes, "volumes was not specified");
         return withVolumes(volumes.toArray(new Volume[0]));
+    }
+
+    @CheckForNull
+    @Override
+    public VolumesFrom[] getVolumesFrom() {
+        return hostConfig.getVolumesFrom();
+    }
+
+    @Override
+    public CreateContainerCmd withVolumesFrom(VolumesFrom... volumesFrom) {
+        checkNotNull(volumesFrom, "volumesFrom was not specified");
+        this.hostConfig.withVolumesFrom(volumesFrom);
+        return this;
+    }
+
+    @Override
+    public CreateContainerCmd withVolumesFrom(List<VolumesFrom> volumesFrom) {
+        checkNotNull(volumesFrom, "volumesFrom was not specified");
+        return withVolumesFrom(volumesFrom.toArray(new VolumesFrom[volumesFrom.size()]));
     }
 
     @Override
@@ -514,6 +608,38 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
         return this;
     }
 
+    @CheckForNull
+    @Override
+    public Boolean getPublishAllPorts() {
+        return hostConfig.getPublishAllPorts();
+    }
+
+    @Override
+    public CreateContainerCmd withPublishAllPorts(Boolean publishAllPorts) {
+        checkNotNull(publishAllPorts, "no publishAllPorts was specified");
+        this.hostConfig.withPublishAllPorts(publishAllPorts);
+        return this;
+    }
+
+    @CheckForNull
+    @Override
+    public String[] getExtraHosts() {
+        return hostConfig.getExtraHosts();
+    }
+
+    @Override
+    public CreateContainerCmd withExtraHosts(String... extraHosts) {
+        checkNotNull(extraHosts, "extraHosts was not specified");
+        this.hostConfig.withExtraHosts(extraHosts);
+        return this;
+    }
+
+    @Override
+    public CreateContainerCmd withExtraHosts(List<String> extraHosts) {
+        checkNotNull(extraHosts, "extraHosts was not specified");
+        return withExtraHosts(extraHosts.toArray(new String[extraHosts.size()]));
+    }
+
     @Override
     public HostConfig getHostConfig() {
         return hostConfig;
@@ -535,6 +661,25 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
         checkNotNull(ipv4Address, "no ipv4Address was specified");
         this.ipv4Address = ipv4Address;
         return this;
+    }
+
+    @CheckForNull
+    @Override
+    public Link[] getLinks() {
+        return hostConfig.getLinks();
+    }
+
+    @Override
+    public CreateContainerCmd withLinks(Link... links) {
+        checkNotNull(links, "links was not specified");
+        this.hostConfig.setLinks(links);
+        return this;
+    }
+
+    @Override
+    public CreateContainerCmd withLinks(List<Link> links) {
+        checkNotNull(links, "links was not specified");
+        return withLinks(links.toArray(new Link[links.size()]));
     }
 
     @Override

--- a/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
@@ -166,6 +166,7 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     @CheckForNull
     @Override
     @Deprecated
+    @JsonIgnore
     public Bind[] getBinds() {
         return hostConfig.getBinds();
     }
@@ -387,6 +388,7 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     @CheckForNull
     @Override
     @Deprecated
+    @JsonIgnore
     public String getNetworkMode() {
         return hostConfig.getNetworkMode();
     }
@@ -402,6 +404,7 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     @CheckForNull
     @Override
     @Deprecated
+    @JsonIgnore
     public Ports getPortBindings() {
         return hostConfig.getPortBindings();
     }
@@ -457,6 +460,7 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     @CheckForNull
     @Override
     @Deprecated
+    @JsonIgnore
     public Boolean getPrivileged() {
         return hostConfig.getPrivileged();
     }
@@ -539,6 +543,7 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     @CheckForNull
     @Override
     @Deprecated
+    @JsonIgnore
     public VolumesFrom[] getVolumesFrom() {
         return hostConfig.getVolumesFrom();
     }
@@ -623,6 +628,7 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     @CheckForNull
     @Override
     @Deprecated
+    @JsonIgnore
     public Boolean getPublishAllPorts() {
         return hostConfig.getPublishAllPorts();
     }
@@ -638,6 +644,7 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     @CheckForNull
     @Override
     @Deprecated
+    @JsonIgnore
     public String[] getExtraHosts() {
         return hostConfig.getExtraHosts();
     }
@@ -660,6 +667,7 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     @CheckForNull
     @Override
     @Deprecated
+    @JsonIgnore
     public Capability[] getCapAdd() {
         return hostConfig.getCapAdd();
     }
@@ -682,6 +690,7 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     @CheckForNull
     @Override
     @Deprecated
+    @JsonIgnore
     public Capability[] getCapDrop() {
         return hostConfig.getCapDrop();
     }
@@ -727,6 +736,7 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     @CheckForNull
     @Override
     @Deprecated
+    @JsonIgnore
     public Link[] getLinks() {
         return hostConfig.getLinks();
     }


### PR DESCRIPTION
Summary:
Adds `Binds`, `Links`, `NetworkMode`, `PortBindings`, `Privileged`,  `VolumesFrom`, `PublishAllPorts`, `ExtraHosts`, `CapAdd` and `CapDrop` related methods to `CreateContainerCmd` interface and related implementation.

This was done so that the test-containers project can bump its docker-java dependency to support the latest docker version.
See https://github.com/testcontainers/testcontainers-java/pull/1340 for more.

Tested change by locally installing this branch of docker-java and running the updated test-containers codebase's gradle check process similarly to the [repo's CI ](https://travis-ci.org/testcontainers/testcontainers-java/jobs/547132992)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1203)
<!-- Reviewable:end -->
