### PR TITLE
Relax email requirement in auth config

### DIFF
--- a/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
+++ b/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
@@ -252,8 +252,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
 
     private AuthConfig getAuthConfig() {
         AuthConfig authConfig = null;
-        if (getRegistryUsername() != null && getRegistryPassword() != null && getRegistryEmail() != null
-                && getRegistryUrl() != null) {
+        if (getRegistryUsername() != null && getRegistryPassword() != null && getRegistryUrl() != null) {
             authConfig = new AuthConfig()
                     .withUsername(getRegistryUsername())
                     .withPassword(getRegistryPassword())

--- a/src/test/java/com/github/dockerjava/cmd/PullImageCmdIT.java
+++ b/src/test/java/com/github/dockerjava/cmd/PullImageCmdIT.java
@@ -112,6 +112,20 @@ public class PullImageCmdIT extends CmdIT {
     }
 
     @Test
+    public void testPullImageWithValidAuthAndEmail() throws Exception {
+        AuthConfig authConfig = RegistryUtils.runPrivateRegistry(dockerRule.getClient())
+                .withEmail("foo@bar.de");
+
+        String imgName = RegistryUtils.createPrivateImage(dockerRule, "pull-image-with-valid-auth");
+
+        // stream needs to be fully read in order to close the underlying connection
+        dockerRule.getClient().pullImageCmd(imgName)
+                .withAuthConfig(authConfig)
+                .exec(new PullImageResultCallback())
+                .awaitCompletion(30, TimeUnit.SECONDS);
+    }
+
+    @Test
     public void testPullImageWithNoAuth() throws Exception {
         RegistryUtils.runPrivateRegistry(dockerRule.getClient());
 
@@ -129,6 +143,7 @@ public class PullImageCmdIT extends CmdIT {
                 .exec(new PullImageResultCallback())
                 .awaitCompletion(30, TimeUnit.SECONDS);
     }
+
 
     @Test
     public void testPullImageWithInvalidAuth() throws Exception {

--- a/src/test/java/com/github/dockerjava/utils/RegistryUtils.java
+++ b/src/test/java/com/github/dockerjava/utils/RegistryUtils.java
@@ -81,7 +81,6 @@ public class RegistryUtils {
             privateRegistryAuthConfig = new AuthConfig()
                     .withUsername("testuser")
                     .withPassword("testpassword")
-                    .withEmail("foo@bar.de")
                     .withRegistryAddress("localhost:" + port);
         }
 


### PR DESCRIPTION
The email field is deprected in the api and was removed from the cli in v17.06

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1207)
<!-- Reviewable:end -->
