### PR TITLE
Use JUnit TemporaryFolder rule in CompressArchiveUtilTest

### DIFF
--- a/src/test/java/com/github/dockerjava/core/CompressArchiveUtilTest.java
+++ b/src/test/java/com/github/dockerjava/core/CompressArchiveUtilTest.java
@@ -3,9 +3,10 @@ package com.github.dockerjava.core;
 import com.github.dockerjava.core.util.CompressArchiveUtil;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -22,30 +23,24 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CompressArchiveUtilTest {
 
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
     @Test
     public void testExecutableFlagIsPreserved() throws Exception {
-        File executableFile = createExecutableFile();
-        File archive = CompressArchiveUtil.archiveTARFiles(executableFile.getParentFile(), asList(executableFile),
+        File executableFile = tempFolder.newFile("executableFile.sh");
+        executableFile.setExecutable(true);
+        assertThat(executableFile.canExecute(), is(true));
+
+        File archive = CompressArchiveUtil.archiveTARFiles(tempFolder.getRoot(), asList(executableFile),
                 "archive");
         File expectedFile = extractFileByName(archive, "executableFile.sh", "executableFile.sh.result");
 
         assertThat("should be executable", expectedFile.canExecute());
-        expectedFile.delete();
-        archive.delete();
-    }
-
-    private File createExecutableFile() throws IOException {
-        File baseDir = new File(FileUtils.getTempDirectoryPath());
-        File executableFile = new File(baseDir, "executableFile.sh");
-        executableFile.createNewFile();
-        executableFile.setExecutable(true);
-        assertThat(executableFile.canExecute(), is(true));
-        return executableFile;
     }
 
     private File extractFileByName(File archive, String filenameToExtract, String outputName) throws IOException {
-        File baseDir = new File(FileUtils.getTempDirectoryPath());
-        File expectedFile = new File(baseDir, outputName);
+        File expectedFile = new File(tempFolder.newFolder(), outputName);
         expectedFile.delete();
         assertThat(expectedFile.exists(), is(false));
 
@@ -71,26 +66,23 @@ public class CompressArchiveUtilTest {
 
     @Test
     public void testSymbolicLinkDir() throws IOException {
-        Path uploadDir = Files.createTempDirectory("upload");
-        Path linkTarget = Files.createTempDirectory("ink-target");
+        Path uploadDir = tempFolder.newFolder("upload").toPath();
+        Path linkTarget = tempFolder.newFolder("link-target").toPath();
         Path tmpFile = Files.createTempFile(linkTarget, "link-dir", "rand");
         Files.createSymbolicLink(uploadDir.resolve("link-folder"), linkTarget);
-        Path tarGzFile = Files.createTempFile("docker-java", ".tar.gz");
+        Path tarGzFile = tempFolder.newFile("docker-java.tar.gz").toPath();
         //follow link only works for childrenOnly=false
         CompressArchiveUtil.tar(uploadDir, tarGzFile, true, false);
         File expectedFile = extractFileByName(tarGzFile.toFile(), tmpFile.toFile().getName(), "foo1");
         assertThat(expectedFile.canRead(), is(true));
-        uploadDir.toFile().delete();
-        linkTarget.toFile().delete();
-        tarGzFile.toFile().delete();
     }
 
     @Test
     public void testSymbolicLinkFile() throws IOException {
-        Path uploadDir = Files.createTempDirectory("upload");
-        Path tmpFile = Files.createTempFile("src", "");
+        Path uploadDir = tempFolder.newFolder("upload").toPath();
+        Path tmpFile = tempFolder.newFile("src").toPath();
         Files.createSymbolicLink(uploadDir.resolve("link-file"), tmpFile);
-        Path tarGzFile = Files.createTempFile("docker-java", ".tar.gz");
+        Path tarGzFile = tempFolder.newFile("docker-java.tar.gz").toPath();
         boolean childrenOnly = false;
         CompressArchiveUtil.tar(uploadDir, tarGzFile, true, childrenOnly);
         File expectedFile = extractFileByName(tarGzFile.toFile(), "link-file", "foo1");
@@ -99,8 +91,5 @@ public class CompressArchiveUtilTest {
         CompressArchiveUtil.tar(uploadDir, tarGzFile, true, childrenOnly);
         extractFileByName(tarGzFile.toFile(), "link-file", "foo1");
         assertThat(expectedFile.canRead(), is(true));
-        uploadDir.toFile().delete();
-        tmpFile.toFile().delete();
-        tarGzFile.toFile().delete();
     }
 }


### PR DESCRIPTION
Instead of delete files created by the test, make use of JUnit
TemporaryFolder rule which does exatly that. Not only it simplify the
code but also fixes the issue that files where not delete when test was
failing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1210)
<!-- Reviewable:end -->
