### PR TITLE
Fix serialVersionUID type

### DIFF
--- a/src/main/java/com/github/dockerjava/api/model/ClusterInfo.java
+++ b/src/main/java/com/github/dockerjava/api/model/ClusterInfo.java
@@ -23,7 +23,7 @@ import java.util.Date;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ClusterInfo implements Serializable {
 
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/ContainerSpec.java
+++ b/src/main/java/com/github/dockerjava/api/model/ContainerSpec.java
@@ -22,7 +22,7 @@ import java.util.Map;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ContainerSpec implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/Endpoint.java
+++ b/src/main/java/com/github/dockerjava/api/model/Endpoint.java
@@ -14,7 +14,7 @@ import java.io.Serializable;
  * @since {@link RemoteApiVersion#VERSION_1_24}
  */
 public class Endpoint implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/EndpointSpec.java
+++ b/src/main/java/com/github/dockerjava/api/model/EndpointSpec.java
@@ -19,7 +19,7 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class EndpointSpec implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/EndpointVirtualIP.java
+++ b/src/main/java/com/github/dockerjava/api/model/EndpointVirtualIP.java
@@ -14,7 +14,7 @@ import java.io.Serializable;
  * @since {@link RemoteApiVersion#VERSION_1_24}
  */
 public class EndpointVirtualIP implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/ExternalCA.java
+++ b/src/main/java/com/github/dockerjava/api/model/ExternalCA.java
@@ -20,7 +20,7 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ExternalCA implements Serializable {
 
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/NetworkAttachmentConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/NetworkAttachmentConfig.java
@@ -19,7 +19,7 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class NetworkAttachmentConfig implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/PeerNode.java
+++ b/src/main/java/com/github/dockerjava/api/model/PeerNode.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PeerNode implements Serializable {
 
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/PortConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/PortConfig.java
@@ -14,7 +14,7 @@ import java.io.Serializable;
  * @since {@link RemoteApiVersion#VERSION_1_24}
  */
 public class PortConfig implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/ResourceRequirements.java
+++ b/src/main/java/com/github/dockerjava/api/model/ResourceRequirements.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ResourceRequirements implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/ResourceSpecs.java
+++ b/src/main/java/com/github/dockerjava/api/model/ResourceSpecs.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ResourceSpecs implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/ResourceVersion.java
+++ b/src/main/java/com/github/dockerjava/api/model/ResourceVersion.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ResourceVersion implements Serializable {
 
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/Service.java
+++ b/src/main/java/com/github/dockerjava/api/model/Service.java
@@ -22,7 +22,7 @@ import java.util.Date;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_NULL)
 public class Service implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/ServiceGlobalModeOptions.java
+++ b/src/main/java/com/github/dockerjava/api/model/ServiceGlobalModeOptions.java
@@ -12,7 +12,7 @@ import java.io.Serializable;
  * @since {@link RemoteApiVersion#VERSION_1_24}
  */
 public class ServiceGlobalModeOptions implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     // Intentionally left blank, there are no options for this mode
 

--- a/src/main/java/com/github/dockerjava/api/model/ServicePlacement.java
+++ b/src/main/java/com/github/dockerjava/api/model/ServicePlacement.java
@@ -19,7 +19,7 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ServicePlacement implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/ServiceRestartPolicy.java
+++ b/src/main/java/com/github/dockerjava/api/model/ServiceRestartPolicy.java
@@ -14,7 +14,7 @@ import java.io.Serializable;
  * @since {@link RemoteApiVersion#VERSION_1_24}
  */
 public class ServiceRestartPolicy implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/ServiceSpec.java
+++ b/src/main/java/com/github/dockerjava/api/model/ServiceSpec.java
@@ -20,7 +20,7 @@ import java.util.Map;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ServiceSpec implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/ServiceUpdateStatus.java
+++ b/src/main/java/com/github/dockerjava/api/model/ServiceUpdateStatus.java
@@ -15,7 +15,7 @@ import java.util.Date;
  * @since {@link RemoteApiVersion#VERSION_1_24}
  */
 public class ServiceUpdateStatus implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/Swarm.java
+++ b/src/main/java/com/github/dockerjava/api/model/Swarm.java
@@ -9,7 +9,7 @@ import java.util.Date;
  * @since 1.24
  */
 public class Swarm extends ClusterInfo {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmCAConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmCAConfig.java
@@ -20,7 +20,7 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwarmCAConfig implements Serializable {
 
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmDispatcherConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmDispatcherConfig.java
@@ -20,7 +20,7 @@ import java.io.Serializable;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwarmDispatcherConfig implements Serializable {
 
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmJoinTokens.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmJoinTokens.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwarmJoinTokens implements Serializable {
 
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmNode.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmNode.java
@@ -22,7 +22,7 @@ import java.util.Date;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwarmNode implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmNodeDescription.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmNodeDescription.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwarmNodeDescription implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmNodeEngineDescription.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmNodeEngineDescription.java
@@ -20,7 +20,7 @@ import java.util.Map;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwarmNodeEngineDescription implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmNodeManagerStatus.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmNodeManagerStatus.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwarmNodeManagerStatus implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmNodePlatform.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmNodePlatform.java
@@ -15,7 +15,7 @@ import java.io.Serializable;
  * @since {@link RemoteApiVersion#VERSION_1_24}
  */
 public class SwarmNodePlatform implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmNodePluginDescription.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmNodePluginDescription.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwarmNodePluginDescription implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmNodeResources.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmNodeResources.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwarmNodeResources implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmNodeSpec.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmNodeSpec.java
@@ -20,7 +20,7 @@ import java.util.Map;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwarmNodeSpec implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmNodeStatus.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmNodeStatus.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwarmNodeStatus implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmNodeVersion.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmNodeVersion.java
@@ -20,7 +20,7 @@ import java.io.Serializable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwarmNodeVersion implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmOrchestration.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmOrchestration.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwarmOrchestration implements Serializable {
 
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmRaftConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmRaftConfig.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwarmRaftConfig implements Serializable {
 
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmSpec.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmSpec.java
@@ -20,7 +20,7 @@ import java.io.Serializable;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwarmSpec implements Serializable {
 
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/SwarmVersion.java
+++ b/src/main/java/com/github/dockerjava/api/model/SwarmVersion.java
@@ -19,7 +19,7 @@ import java.io.Serializable;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SwarmVersion implements Serializable {
 
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/TaskDefaults.java
+++ b/src/main/java/com/github/dockerjava/api/model/TaskDefaults.java
@@ -20,7 +20,7 @@ import java.io.Serializable;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TaskDefaults implements Serializable {
 
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/TaskSpec.java
+++ b/src/main/java/com/github/dockerjava/api/model/TaskSpec.java
@@ -19,7 +19,7 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TaskSpec implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/UpdateConfig.java
+++ b/src/main/java/com/github/dockerjava/api/model/UpdateConfig.java
@@ -14,7 +14,7 @@ import java.io.Serializable;
  * @since {@link RemoteApiVersion#VERSION_1_24}
  */
 public class UpdateConfig implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     /**
      * @since 1.24

--- a/src/main/java/com/github/dockerjava/api/model/VersionComponent.java
+++ b/src/main/java/com/github/dockerjava/api/model/VersionComponent.java
@@ -19,7 +19,7 @@ import java.util.Map;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class VersionComponent implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     @JsonProperty("Details")
     private Map<String, String> details;

--- a/src/main/java/com/github/dockerjava/api/model/VersionPlatform.java
+++ b/src/main/java/com/github/dockerjava/api/model/VersionPlatform.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class VersionPlatform implements Serializable {
-    public static final Long serialVersionUID = 1L;
+    public static final long serialVersionUID = 1L;
 
     @JsonProperty("Name")
     private String name;


### PR DESCRIPTION
Java serialization expect a serialVersionUID which is of primitive type
long[1]. Change the type from Long to long to prevent unnecessary
unboxing and also to fix a warning in Eclipse.

[1]https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/Serializable.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1216)
<!-- Reviewable:end -->
