### PR TITLE
Remove duplicated code to add a file to a tar

### DIFF
--- a/src/main/java/com/github/dockerjava/core/util/TarDirWalker.java
+++ b/src/main/java/com/github/dockerjava/core/util/TarDirWalker.java
@@ -36,11 +36,7 @@ public class TarDirWalker extends SimpleFileVisitor<Path> {
         if (attrs.isSymbolicLink()) { // symbolic link to folder
             return FileVisitResult.CONTINUE;
         }
-        TarArchiveEntry tarEntry = new TarArchiveEntry(FilePathUtil.relativize(basePath, file));
-        if (file.toFile().canExecute()) {
-            tarEntry.setMode(tarEntry.getMode() | 0755);
-        }
-        CompressArchiveUtil.putTarEntry(tarArchiveOutputStream, tarEntry, file);
+        CompressArchiveUtil.addFileToTar(tarArchiveOutputStream, file, FilePathUtil.relativize(basePath, file));
         return FileVisitResult.CONTINUE;
     }
 


### PR DESCRIPTION
This remove the duplicated code to handle executable file and copy of
the file content into the archive. It will also allow to fix the symlink
without duplicating the fix in 3 places.

Related to issue https://github.com/docker-java/docker-java/issues/532

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1217)
<!-- Reviewable:end -->
