### PR TITLE
Reverts create container cmd regression.

### DIFF
--- a/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
@@ -126,6 +126,20 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
 
     CreateContainerCmd withMacAddress(String macAddress);
 
+    @Deprecated
+    @CheckForNull
+    Long getMemory();
+
+    @Deprecated
+    CreateContainerCmd withMemory(Long memory);
+
+    @Deprecated
+    @CheckForNull
+    Long getMemorySwap();
+
+    @Deprecated
+    CreateContainerCmd withMemorySwap(Long memorySwap);
+
     @CheckForNull
     String getName();
 

--- a/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
@@ -351,6 +351,37 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
         return this;
     }
 
+    @Deprecated
+    @Override
+    @JsonIgnore
+    public Long getMemory() {
+        return hostConfig.getMemory();
+    }
+
+    @Deprecated
+    @Override
+    public CreateContainerCmd withMemory(Long memory) {
+        checkNotNull(memory, "memory was not specified");
+        hostConfig.withMemory(memory);
+        return this;
+    }
+
+    @Deprecated
+    @Override
+    @JsonIgnore
+    public Long getMemorySwap() {
+        return hostConfig.getMemorySwap();
+    }
+
+    @Deprecated
+    @Override
+    public CreateContainerCmd withMemorySwap(Long memorySwap) {
+        checkNotNull(memorySwap, "memorySwap was not specified");
+        hostConfig.withMemorySwap(memorySwap);
+        return this;
+    }
+
+
     @Override
     public String getName() {
         return name;


### PR DESCRIPTION
Summary:
- Adds Memory and MemorySwap related methods to CreateContainerCmd interface and related interface.

This was done so that the test-containers project can bump its docker-java dependency for support to the latest docker version.

See https://github.com/testcontainers/testcontainers-java/pull/1340 for more.

Note that this commit is a continuation of https://github.com/docker-java/docker-java/pull/1203, wherein I failed to see that these two methods were not reverted back.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1219)
<!-- Reviewable:end -->
