### PR TITLE
Revert breaking binary change of `CreateContainerCmd`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -450,6 +450,32 @@
 					</instructions>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<!-- use with "mvn -DskipTests clean package japicmp:cmp" -->
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<version>0.14.1</version>
+				<configuration>
+					<oldVersion>
+						<dependency>
+							<groupId>com.github.docker-java</groupId>
+							<artifactId>docker-java</artifactId>
+							<version>3.1.0-rc-4</version>
+							<type>jar</type>
+						</dependency>
+					</oldVersion>
+					<newVersion>
+						<file>
+							<path>${project.build.directory}/${project.artifactId}-${project.version}.jar</path>
+						</file>
+					</newVersion>
+					<parameter>
+						<accessModifier>public</accessModifier>
+						<onlyBinaryIncompatible>true</onlyBinaryIncompatible>
+					</parameter>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
+++ b/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
@@ -5,12 +5,17 @@ import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Capability;
+import com.github.dockerjava.api.model.Device;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.HealthCheck;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Link;
+import com.github.dockerjava.api.model.LogConfig;
+import com.github.dockerjava.api.model.LxcConf;
 import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.api.model.Ports;
+import com.github.dockerjava.api.model.RestartPolicy;
+import com.github.dockerjava.api.model.Ulimit;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.api.model.VolumesFrom;
 
@@ -365,6 +370,160 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
     HostConfig getHostConfig();
 
     CreateContainerCmd withHostConfig(HostConfig hostConfig);
+
+    // The following methods are deprecated and should be set on {@link #getHostConfig()} instead.
+    // TODO remove in the next big release
+
+    @Deprecated
+    @CheckForNull
+    Integer getBlkioWeight();
+
+    @CheckForNull
+    @Deprecated
+    String getCgroupParent();
+
+    @Deprecated
+    @CheckForNull
+    Integer getCpuPeriod();
+
+    @Deprecated
+    @CheckForNull
+    Integer getCpuShares();
+
+    @Deprecated
+    @CheckForNull
+    String getCpusetCpus();
+
+    @Deprecated
+    @CheckForNull
+    String getCpusetMems();
+
+    @Deprecated
+    @CheckForNull
+    Device[] getDevices();
+
+    @Deprecated
+    @CheckForNull
+    String[] getDns();
+
+    @Deprecated
+    @CheckForNull
+    String[] getDnsSearch();
+
+    @Deprecated
+    @CheckForNull
+    LogConfig getLogConfig();
+
+    @Deprecated
+    @CheckForNull
+    LxcConf[] getLxcConf();
+
+    @Deprecated
+    @CheckForNull
+    Boolean getOomKillDisable();
+
+    @Deprecated
+    @CheckForNull
+    String getPidMode();
+
+    @Deprecated
+    @CheckForNull
+    Boolean getReadonlyRootfs();
+
+    @Deprecated
+    @CheckForNull
+    RestartPolicy getRestartPolicy();
+
+    @Deprecated
+    @CheckForNull
+    Ulimit[] getUlimits();
+
+    @Deprecated
+    CreateContainerCmd withBlkioWeight(Integer blkioWeight);
+
+    @Deprecated
+    CreateContainerCmd withCgroupParent(String cgroupParent);
+
+    @Deprecated
+    CreateContainerCmd withContainerIDFile(String containerIDFile);
+
+    @Deprecated
+    CreateContainerCmd withCpuPeriod(Integer cpuPeriod);
+
+    @Deprecated
+    CreateContainerCmd withCpuShares(Integer cpuShares);
+
+    @Deprecated
+    CreateContainerCmd withCpusetCpus(String cpusetCpus);
+
+    @Deprecated
+    CreateContainerCmd withCpusetMems(String cpusetMems);
+
+    @Deprecated
+    CreateContainerCmd withDevices(Device... devices);
+
+    /**
+     * Add host devices to the container
+     */
+    @Deprecated
+    CreateContainerCmd withDevices(List<Device> devices);
+
+    /**
+     * Set custom DNS servers
+     */
+    @Deprecated
+    CreateContainerCmd withDns(String... dns);
+
+    /**
+     * Set custom DNS servers
+     */
+    @Deprecated
+    CreateContainerCmd withDns(List<String> dns);
+
+    /**
+     * Set custom DNS search domains
+     */
+    @Deprecated
+    CreateContainerCmd withDnsSearch(String... dnsSearch);
+
+    /**
+     * Set custom DNS search domains
+     */
+    @Deprecated
+    CreateContainerCmd withDnsSearch(List<String> dnsSearch);
+
+    @Deprecated
+    CreateContainerCmd withLogConfig(LogConfig logConfig);
+
+    @Deprecated
+    CreateContainerCmd withLxcConf(LxcConf... lxcConf);
+
+    @Deprecated
+    CreateContainerCmd withLxcConf(List<LxcConf> lxcConf);
+
+    @Deprecated
+    CreateContainerCmd withOomKillDisable(Boolean oomKillDisable);
+
+    /**
+     * Set the PID (Process) Namespace mode for the container, 'host': use the host's PID namespace inside the container
+     */
+    @Deprecated
+    CreateContainerCmd withPidMode(String pidMode);
+
+    @Deprecated
+    CreateContainerCmd withReadonlyRootfs(Boolean readonlyRootfs);
+
+    /**
+     * Set custom {@link RestartPolicy} for the container. Defaults to {@link RestartPolicy#noRestart()}
+     */
+    @Deprecated
+    CreateContainerCmd withRestartPolicy(RestartPolicy restartPolicy);
+
+    @Deprecated
+    CreateContainerCmd withUlimits(Ulimit... ulimits);
+
+    @Deprecated
+    CreateContainerCmd withUlimits(List<Ulimit> ulimits);
 
     /**
      * @throws NotFoundException No such container

--- a/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
@@ -12,13 +12,18 @@ import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Capability;
 import com.github.dockerjava.api.model.ContainerNetwork;
+import com.github.dockerjava.api.model.Device;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.ExposedPorts;
 import com.github.dockerjava.api.model.HealthCheck;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Link;
+import com.github.dockerjava.api.model.LogConfig;
+import com.github.dockerjava.api.model.LxcConf;
 import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.api.model.Ports;
+import com.github.dockerjava.api.model.RestartPolicy;
+import com.github.dockerjava.api.model.Ulimit;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.api.model.Volumes;
 import com.github.dockerjava.api.model.VolumesFrom;
@@ -171,6 +176,14 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
         return hostConfig.getBinds();
     }
 
+    @CheckForNull
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public Integer getBlkioWeight() {
+        return hostConfig.getBlkioWeight();
+    }
+
     @Override
     @Deprecated
     public CreateContainerCmd withBinds(Bind... binds) {
@@ -184,6 +197,13 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     public CreateContainerCmd withBinds(List<Bind> binds) {
         checkNotNull(binds, "binds was not specified");
         return withBinds(binds.toArray(new Bind[binds.size()]));
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withBlkioWeight(Integer blkioWeight) {
+        hostConfig.withBlkioWeight(blkioWeight);
+        return this;
     }
 
     @Override
@@ -205,6 +225,63 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
         return cmd;
     }
 
+    @CheckForNull
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public Integer getCpuPeriod() {
+        Long result = hostConfig.getCpuPeriod();
+        return result != null ? result.intValue() : null;
+    }
+
+    @CheckForNull
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public Integer getCpuShares() {
+        return hostConfig.getCpuShares();
+    }
+
+    @CheckForNull
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public String getCpusetCpus() {
+        return hostConfig.getCpusetCpus();
+    }
+
+    @CheckForNull
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public String getCpusetMems() {
+        return hostConfig.getCpusetMems();
+    }
+
+    @CheckForNull
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public Device[] getDevices() {
+        return hostConfig.getDevices();
+    }
+
+    @CheckForNull
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public String[] getDns() {
+        return hostConfig.getDns();
+    }
+
+    @CheckForNull
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public String[] getDnsSearch() {
+        return hostConfig.getDnsSearch();
+    }
+
     @Override
     public CreateContainerCmd withCmd(String... cmd) {
         checkNotNull(cmd, "cmd was not specified");
@@ -216,6 +293,83 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     public CreateContainerCmd withCmd(List<String> cmd) {
         checkNotNull(cmd, "cmd was not specified");
         return withCmd(cmd.toArray(new String[0]));
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withContainerIDFile(String containerIDFile) {
+        hostConfig.withContainerIDFile(containerIDFile);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withCpuPeriod(Integer cpuPeriod) {
+        hostConfig.withCpuPeriod(cpuPeriod != null ? cpuPeriod.longValue() : null);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withCpuShares(Integer cpuShares) {
+        hostConfig.withCpuShares(cpuShares);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withCpusetCpus(String cpusetCpus) {
+        hostConfig.withCpusetCpus(cpusetCpus);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withCpusetMems(String cpusetMems) {
+        hostConfig.withCpusetMems(cpusetMems);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withDevices(Device... devices) {
+        hostConfig.withDevices(devices);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withDevices(List<Device> devices) {
+        hostConfig.withDevices(devices);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withDns(String... dns) {
+        hostConfig.withDns(dns);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withDns(List<String> dns) {
+        hostConfig.withDns(dns);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withDnsSearch(String... dnsSearch) {
+        hostConfig.withDnsSearch(dnsSearch);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withDnsSearch(List<String> dnsSearch) {
+        hostConfig.withDnsSearch(dnsSearch);
+        return this;
     }
 
     @CheckForNull
@@ -323,6 +477,13 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     @Override
     public Integer getStopTimeout() {
         return stopTimeout;
+    }
+
+    @CheckForNull
+    @Override
+    @Deprecated
+    public Ulimit[] getUlimits() {
+        return hostConfig.getUlimits();
     }
 
     @Override
@@ -656,6 +817,20 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
         return this;
     }
 
+    @Override
+    @Deprecated
+    public CreateContainerCmd withUlimits(Ulimit... ulimits) {
+        hostConfig.withUlimits(ulimits);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withUlimits(List<Ulimit> ulimits) {
+        hostConfig.withUlimits(ulimits);
+        return this;
+    }
+
     @CheckForNull
     @Override
     @Deprecated
@@ -664,11 +839,41 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
         return hostConfig.getPublishAllPorts();
     }
 
+    @CheckForNull
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public Boolean getReadonlyRootfs() {
+        return hostConfig.getReadonlyRootfs();
+    }
+
+    @CheckForNull
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public RestartPolicy getRestartPolicy() {
+        return hostConfig.getRestartPolicy();
+    }
+
     @Override
     @Deprecated
     public CreateContainerCmd withPublishAllPorts(Boolean publishAllPorts) {
         checkNotNull(publishAllPorts, "no publishAllPorts was specified");
         this.hostConfig.withPublishAllPorts(publishAllPorts);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withReadonlyRootfs(Boolean readonlyRootfs) {
+        hostConfig.withReadonlyRootfs(readonlyRootfs);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withRestartPolicy(RestartPolicy restartPolicy) {
+        hostConfig.withRestartPolicy(restartPolicy);
         return this;
     }
 
@@ -726,6 +931,14 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
         return hostConfig.getCapDrop();
     }
 
+    @CheckForNull
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public String getCgroupParent() {
+        return hostConfig.getCgroupParent();
+    }
+
     @Override
     @Deprecated
     public CreateContainerCmd withCapDrop(Capability... capDrop) {
@@ -739,6 +952,13 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     public CreateContainerCmd withCapDrop(List<Capability> capDrop) {
         checkNotNull(capDrop, "capDrop was not specified");
         return withCapDrop(capDrop.toArray(new Capability[capDrop.size()]));
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withCgroupParent(String cgroupParent) {
+        hostConfig.withCgroupParent(cgroupParent);
+        return this;
     }
 
     @Override
@@ -772,6 +992,22 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
         return hostConfig.getLinks();
     }
 
+    @CheckForNull
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public LogConfig getLogConfig() {
+        return hostConfig.getLogConfig();
+    }
+
+    @CheckForNull
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public LxcConf[] getLxcConf() {
+        return hostConfig.getLxcConf();
+    }
+
     @Override
     @Deprecated
     public CreateContainerCmd withLinks(Link... links) {
@@ -785,6 +1021,25 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     public CreateContainerCmd withLinks(List<Link> links) {
         checkNotNull(links, "links was not specified");
         return withLinks(links.toArray(new Link[links.size()]));
+    }
+
+    @Override
+    public CreateContainerCmd withLogConfig(LogConfig logConfig) {
+        return null;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withLxcConf(LxcConf... lxcConf) {
+        hostConfig.withLxcConf(lxcConf);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withLxcConf(List<LxcConf> lxcConf) {
+        hostConfig.withLxcConf(lxcConf.toArray(new LxcConf[0]));
+        return this;
     }
 
     @Override
@@ -804,8 +1059,38 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
         return onBuild;
     }
 
+    @CheckForNull
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public Boolean getOomKillDisable() {
+        return hostConfig.getOomKillDisable();
+    }
+
+    @CheckForNull
+    @Override
+    @Deprecated
+    @JsonIgnore
+    public String getPidMode() {
+        return hostConfig.getPidMode();
+    }
+
     public CreateContainerCmdImpl withOnBuild(List<String> onBuild) {
         this.onBuild = onBuild;
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withOomKillDisable(Boolean oomKillDisable) {
+        hostConfig.withOomKillDisable(oomKillDisable);
+        return this;
+    }
+
+    @Override
+    @Deprecated
+    public CreateContainerCmd withPidMode(String pidMode) {
+        hostConfig.withPidMode(pidMode);
         return this;
     }
 

--- a/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
+++ b/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
@@ -482,6 +482,7 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     @CheckForNull
     @Override
     @Deprecated
+    @JsonIgnore
     public Ulimit[] getUlimits() {
         return hostConfig.getUlimits();
     }
@@ -1024,8 +1025,10 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     }
 
     @Override
+    @Deprecated
     public CreateContainerCmd withLogConfig(LogConfig logConfig) {
-        return null;
+        hostConfig.withLogConfig(logConfig);
+        return this;
     }
 
     @Override


### PR DESCRIPTION
The change was introduced in:
https://github.com/docker-java/docker-java/commit/580ea407cc

While it is a good change in a long term, 3.1.x should have introduced
a deprecation, so that the users have time to update their usages.

Japicmp of `CreateContainerCmd*` report before this change:
[docker-java_before.pdf](https://github.com/docker-java/docker-java/files/3414658/docker-java_before.pdf)

After:
[docker-java_after.pdf](https://github.com/docker-java/docker-java/files/3414659/docker-java_after.pdf)

This change will finally unblock Testcontainers and let it upgrade to the newer versions of Docker Java

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1225)
<!-- Reviewable:end -->
