### PR TITLE
upgrade common-compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<jersey.version>2.27</jersey.version>
 		<jackson-jaxrs.version>2.9.8</jackson-jaxrs.version>
 		<httpclient.version>4.5.6</httpclient.version><!-- 4.5.1-4.5.2 broken -->
-		<commons-compress.version>1.18</commons-compress.version>
+		<commons-compress.version>1.19</commons-compress.version>
 		<commons-codec.version>1.11</commons-codec.version>
 		<commons-io.version>2.6</commons-io.version>
 		<commons-lang.version>2.6</commons-lang.version>
@@ -528,7 +528,7 @@
 							<failOnViolation>true</failOnViolation>
 							<logViolationsToConsole>true</logViolationsToConsole>
 							<linkXRef>false</linkXRef>
-							<!-- if some IDE has integration and requires other place, propose 
+							<!-- if some IDE has integration and requires other place, propose
 								it -->
 							<configLocation>
 								src/test/resources/checkstyle/checkstyle-config.xml


### PR DESCRIPTION
need to use `common-compress` `1.19` and above due to Denial of Service (DoS) due to Uncontrolled Resource Consumption vulnerability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1238)
<!-- Reviewable:end -->
