### PR TITLE
Add support for specifying UsernsMode when creating containers

### DIFF
--- a/docker-java/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
+++ b/docker-java/src/main/java/com/github/dockerjava/api/command/CreateContainerCmd.java
@@ -256,6 +256,10 @@ public interface CreateContainerCmd extends SyncDockerCmd<CreateContainerRespons
 
     CreateContainerCmd withUser(String user);
 
+    String getUsernsMode();
+
+    CreateContainerCmd withUsernsMode(String usernsMode);
+
     @CheckForNull
     Volume[] getVolumes();
 

--- a/docker-java/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
+++ b/docker-java/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
@@ -679,6 +679,18 @@ public class CreateContainerCmdImpl extends AbstrDockerCmd<CreateContainerCmd, C
     }
 
     @Override
+    public String getUsernsMode() {
+        return user;
+    }
+
+    @Override
+    public CreateContainerCmd withUsernsMode(String usernsMode) {
+        checkNotNull(usernsMode, "usernsMode was not specified");
+        this.hostConfig.withUsernsMode(usernsMode);
+        return this;
+    }
+
+    @Override
     public Boolean isAttachStderr() {
         return attachStderr;
     }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CreateContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CreateContainerCmdIT.java
@@ -829,6 +829,23 @@ public class CreateContainerCmdIT extends CmdIT {
     }
 
     @Test
+    public void createContainerWithUsernsMode() throws DockerException {
+
+        CreateContainerResponse container = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE).withCmd("true")
+                .withHostConfig(newHostConfig()
+                        .withUsernsMode("host"))
+                .exec();
+
+        LOG.info("Created container {}", container.toString());
+
+        assertThat(container.getId(), not(isEmptyString()));
+
+        InspectContainerResponse inspectContainerResponse = dockerRule.getClient().inspectContainerCmd(container.getId()).exec();
+
+        assertThat(inspectContainerResponse.getHostConfig().getUsernsMode(), is(equalTo("host")));
+    }
+
+    @Test
     public void createContainerWithLabels() throws DockerException {
 
         Map<String, String> labels = new HashMap<String, String>();


### PR DESCRIPTION
This allows us to e.g. create privileged containers alongside namespace remapping.

See e.g. https://github.com/docker-java/docker-java/issues/815

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1243)
<!-- Reviewable:end -->
