### PR TITLE
Remove Guava from the API module

### DIFF
--- a/docker-java-api/pom.xml
+++ b/docker-java-api/pom.xml
@@ -33,12 +33,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>${guava.version}</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>${slf4j-api.version}</version>

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/async/ResultCallbackTemplate.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/async/ResultCallbackTemplate.java
@@ -3,7 +3,6 @@
  */
 package com.github.dockerjava.api.async;
 
-import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -134,8 +133,13 @@ public abstract class ResultCallbackTemplate<RC_T extends ResultCallback<A_RES_T
      */
     protected void throwFirstError() {
         if (firstError != null) {
-            // this call throws a RuntimeException
-            Throwables.propagate(firstError);
+            if (firstError instanceof Error) {
+              throw (Error) firstError;
+            }
+            if (firstError instanceof RuntimeException) {
+              throw (RuntimeException) firstError;
+            }
+            throw new RuntimeException(firstError);
         }
     }
 }

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/TopContainerResponse.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/TopContainerResponse.java
@@ -2,7 +2,6 @@ package com.github.dockerjava.api.command;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Joiner;
 
 /**
  *
@@ -28,14 +27,19 @@ public class TopContainerResponse {
 
     @Override
     public String toString() {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder("TopContainerResponse{");
+        buffer.append("titles=");
+        buffer.append(String.join("; ", titles));
+        buffer.append(", processes=");
         buffer.append("[");
         for (String[] fields : processes) {
-            buffer.append("[" + Joiner.on("; ").skipNulls().join(fields) + "]");
+            buffer.append("[")
+                    .append(String.join("; ", fields))
+                    .append("]");
         }
         buffer.append("]");
+        buffer.append("}");
 
-        return "TopContainerResponse{" + "titles=" + Joiner.on("; ").skipNulls().join(titles) + ", processes="
-                + buffer.toString() + '}';
+        return buffer.toString();
     }
 }

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Device.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Device.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.api.model;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang.BooleanUtils.isNotTrue;
 import static org.apache.commons.lang.StringUtils.isEmpty;
 
@@ -34,9 +34,9 @@ public class Device implements Serializable {
     }
 
     public Device(String cGroupPermissions, String pathInContainer, String pathOnHost) {
-        checkNotNull(cGroupPermissions, "cGroupPermissions is null");
-        checkNotNull(pathInContainer, "pathInContainer is null");
-        checkNotNull(pathOnHost, "pathOnHost is null");
+        requireNonNull(cGroupPermissions, "cGroupPermissions is null");
+        requireNonNull(pathInContainer, "pathInContainer is null");
+        requireNonNull(pathOnHost, "pathOnHost is null");
         this.cGroupPermissions = cGroupPermissions;
         this.pathInContainer = pathInContainer;
         this.pathOnHost = pathOnHost;

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/HostConfig.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/HostConfig.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Used in `/containers/create`, and in inspect container.
@@ -573,13 +573,13 @@ public class HostConfig implements Serializable {
     }
 
     public HostConfig withBinds(Bind... binds) {
-        checkNotNull(binds, "binds was not specified");
+        requireNonNull(binds, "binds was not specified");
         setBinds(binds);
         return this;
     }
 
     public HostConfig withBinds(List<Bind> binds) {
-        checkNotNull(binds, "binds was not specified");
+        requireNonNull(binds, "binds was not specified");
         return withBinds(binds.toArray(new Bind[binds.size()]));
     }
 
@@ -712,7 +712,7 @@ public class HostConfig implements Serializable {
     }
 
     public HostConfig withDevices(List<Device> devices) {
-        checkNotNull(devices, "devices was not specified");
+        requireNonNull(devices, "devices was not specified");
         return withDevices(devices.toArray(new Device[0]));
     }
 
@@ -733,7 +733,7 @@ public class HostConfig implements Serializable {
     }
 
     public HostConfig withDns(List<String> dns) {
-        checkNotNull(dns, "dns was not specified");
+        requireNonNull(dns, "dns was not specified");
         return withDns(dns.toArray(new String[0]));
     }
 
@@ -746,7 +746,7 @@ public class HostConfig implements Serializable {
     }
 
     public HostConfig withDnsSearch(List<String> dnsSearch) {
-        checkNotNull(dnsSearch, "dnsSearch was not specified");
+        requireNonNull(dnsSearch, "dnsSearch was not specified");
         return withDnsSearch(dnsSearch.toArray(new String[0]));
     }
 
@@ -775,13 +775,13 @@ public class HostConfig implements Serializable {
     }
 
     public HostConfig withLinks(Link... links) {
-        checkNotNull(links, "links was not specified");
+        requireNonNull(links, "links was not specified");
         setLinks(links);
         return this;
     }
 
     public HostConfig withLinks(List<Link> links) {
-        checkNotNull(links, "links was not specified");
+        requireNonNull(links, "links was not specified");
         return withLinks(links.toArray(new Link[0]));
     }
 
@@ -894,13 +894,13 @@ public class HostConfig implements Serializable {
     }
 
     public HostConfig withPortBindings(PortBinding... portBindings) {
-        checkNotNull(portBindings, "portBindings was not specified");
+        requireNonNull(portBindings, "portBindings was not specified");
         withPortBindings(new Ports(portBindings));
         return this;
     }
 
     public HostConfig withPortBindings(List<PortBinding> portBindings) {
-        checkNotNull(portBindings, "portBindings was not specified");
+        requireNonNull(portBindings, "portBindings was not specified");
         return withPortBindings(portBindings.toArray(new PortBinding[0]));
     }
 
@@ -985,7 +985,7 @@ public class HostConfig implements Serializable {
     }
 
     public HostConfig withUlimits(List<Ulimit> ulimits) {
-        checkNotNull(ulimits, "no ulimits was specified");
+        requireNonNull(ulimits, "no ulimits was specified");
         return withUlimits(ulimits.toArray(new Ulimit[0]));
     }
 
@@ -1006,7 +1006,7 @@ public class HostConfig implements Serializable {
     }
 
     public HostConfig withVolumesFrom(List<VolumesFrom> volumesFrom) {
-        checkNotNull(volumesFrom, "volumesFrom was not specified");
+        requireNonNull(volumesFrom, "volumesFrom was not specified");
         return withVolumesFrom(volumesFrom.toArray(new VolumesFrom[0]));
     }
 

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Identifier.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Identifier.java
@@ -1,9 +1,7 @@
 package com.github.dockerjava.api.model;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Optional;
-
 import java.io.Serializable;
+import java.util.Optional;
 
 /**
  * @author magnayn
@@ -18,11 +16,7 @@ public class Identifier implements Serializable {
     public Identifier(Repository repository, String tag) {
         this.repository = repository;
 
-        if (tag == null) {
-            this.tag = Optional.absent();
-        } else {
-            this.tag = Optional.of(tag);
-        }
+        this.tag = Optional.ofNullable(tag);
     }
 
     /**
@@ -55,6 +49,9 @@ public class Identifier implements Serializable {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("repository", repository).add("tag", tag).toString();
+        return "Identifier{" +
+                "repository=" + repository +
+                ", tag=" + tag +
+                '}';
     }
 }

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Repository.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Repository.java
@@ -4,8 +4,6 @@ import java.io.Serializable;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import com.google.common.base.MoreObjects;
-
 /**
  * A repository or image name.
  */
@@ -36,7 +34,9 @@ public class Repository implements Serializable {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("name", name).toString();
+        return "Repository{" +
+                "name='" + name + '\'' +
+                '}';
     }
 
     public String getPath() {

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/RestartPolicy.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/RestartPolicy.java
@@ -1,13 +1,13 @@
 package com.github.dockerjava.api.model;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Container restart policy
@@ -41,7 +41,7 @@ public class RestartPolicy implements Serializable {
     }
 
     private RestartPolicy(int maximumRetryCount, String name) {
-        checkNotNull(name, "name is null");
+        requireNonNull(name, "name is null");
         this.maximumRetryCount = maximumRetryCount;
         this.name = name;
     }

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Ulimit.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Ulimit.java
@@ -1,13 +1,13 @@
 package com.github.dockerjava.api.model;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * @author Vangie Du (duwan@live.com)
@@ -28,7 +28,7 @@ public class Ulimit implements Serializable {
     }
 
     public Ulimit(String name, int soft, int hard) {
-        checkNotNull(name, "Name is null");
+        requireNonNull(name, "Name is null");
         this.name = name;
         this.soft = soft;
         this.hard = hard;

--- a/docker-java-core/pom.xml
+++ b/docker-java-core/pom.xml
@@ -41,6 +41,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>${guava.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpkix-jdk15on</artifactId>
 			<version>${bouncycastle.version}</version>


### PR DESCRIPTION
⚠️ Warning! This is a binary incompatible change since `Identifier` was using Guava's `Optional` as field's type. The constructor, however, was accepting a regular Java type as it's parameter. So it will only break if somebody was accessing `Identifier#tag` field, which is unlikely a regular case.

 ℹ️ Note that Guava isn't gone (yet), but moved to the core module for later removal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1255)
<!-- Reviewable:end -->
