### PR TITLE
remove Apache Commons Codec dependency

### DIFF
--- a/docker-java-api/pom.xml
+++ b/docker-java-api/pom.xml
@@ -26,11 +26,6 @@
 			<artifactId>commons-lang</artifactId>
 			<version>${commons-lang.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>commons-codec</groupId>
-			<artifactId>commons-codec</artifactId>
-			<version>${commons-codec.version}</version>
-		</dependency>
 
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/SecretSpec.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/SecretSpec.java
@@ -3,7 +3,6 @@ package com.github.dockerjava.api.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -11,6 +10,7 @@ import org.apache.commons.lang.builder.ToStringStyle;
 
 import javax.annotation.CheckForNull;
 import java.io.Serializable;
+import java.util.Base64;
 import java.util.Map;
 
 /**
@@ -65,7 +65,7 @@ public class SecretSpec implements Serializable {
      * @see #data
      */
     public SecretSpec withData(String data) {
-        this.data = Base64.encodeBase64String(data.getBytes());
+        this.data = Base64.getEncoder().encodeToString(data.getBytes());
         return this;
     }
 

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DockerConfigFile.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DockerConfigFile.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.AuthConfigurations;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -15,6 +14,7 @@ import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -204,7 +204,7 @@ public class DockerConfigFile {
             return;
         }
 
-        String str = new String(Base64.decodeBase64(config.getAuth()), StandardCharsets.UTF_8);
+        String str = new String(Base64.getDecoder().decode(config.getAuth()), StandardCharsets.UTF_8);
         String[] parts = str.split(":", 2);
         if (parts.length != 2) {
             throw new IOException("Invalid auth configuration file");

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/AbstrDockerCmd.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/AbstrDockerCmd.java
@@ -3,8 +3,8 @@ package com.github.dockerjava.core.command;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.IOException;
+import java.util.Base64;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.slf4j.Logger;
@@ -46,7 +46,7 @@ public abstract class AbstrDockerCmd<CMD_T extends DockerCmd<RES_T>, RES_T> impl
 
     protected String registryAuth(AuthConfig authConfig) {
         try {
-            return Base64.encodeBase64String(new ObjectMapper().writeValueAsString(authConfig).getBytes());
+            return Base64.getEncoder().encodeToString(new ObjectMapper().writeValueAsBytes(authConfig));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/docker-java/template.mf
+++ b/docker-java/template.mf
@@ -11,7 +11,6 @@ Import-Template:
  com.google.common.*;version="${guava.version:short}",
  io.netty.*;version="${netty.version:default}";resolution:=optional,
  javax.ws.rs.*;version="[2.0.0, 2.1.0)",
- org.apache.commons.codec.*;version="${commons-codec.version:short}",
  org.apache.commons.compress.*;version="${commons-compress.version:short}",
  org.apache.commons.io.*;version="${commons-io.version:short}",
  org.apache.commons.lang.*;version="${commons-lang.version:short}",


### PR DESCRIPTION
After #1249, we can use Java's built-in Base64 support and remove the codec dependency completely

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1256)
<!-- Reviewable:end -->
