### PR TITLE
Synchronous container stats command

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/DockerClient.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/DockerClient.java
@@ -60,6 +60,7 @@ import com.github.dockerjava.api.command.SearchImagesCmd;
 import com.github.dockerjava.api.command.StartContainerCmd;
 import com.github.dockerjava.api.command.StatsCmd;
 import com.github.dockerjava.api.command.StopContainerCmd;
+import com.github.dockerjava.api.command.SyncStatsCmd;
 import com.github.dockerjava.api.command.TagImageCmd;
 import com.github.dockerjava.api.command.TopContainerCmd;
 import com.github.dockerjava.api.command.UnpauseContainerCmd;
@@ -254,6 +255,8 @@ public interface DockerClient extends Closeable {
     EventsCmd eventsCmd();
 
     StatsCmd statsCmd(String containerId);
+
+    SyncStatsCmd syncStatsCmd(String containerId);
 
     CreateVolumeCmd createVolumeCmd();
 

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/DockerCmdExecFactory.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/DockerCmdExecFactory.java
@@ -92,6 +92,8 @@ public interface DockerCmdExecFactory extends Closeable {
 
     StatsCmd.Exec createStatsCmdExec();
 
+    SyncStatsCmd.Exec createSyncStatsCmdExec();
+
     CreateVolumeCmd.Exec createCreateVolumeCmdExec();
 
     InspectVolumeCmd.Exec createInspectVolumeCmdExec();

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/SyncStatsCmd.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/SyncStatsCmd.java
@@ -1,0 +1,20 @@
+package com.github.dockerjava.api.command;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import com.github.dockerjava.api.model.Statistics;
+
+/**
+ * Get container stats.
+ */
+public interface SyncStatsCmd extends SyncDockerCmd<Statistics> {
+
+    @CheckForNull
+    String getContainerId();
+
+    SyncStatsCmd withContainerId(@Nonnull String containerId);
+
+    interface Exec extends DockerCmdSyncExec<SyncStatsCmd, Statistics> {
+    }
+}

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/SyncStatsResponse.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/SyncStatsResponse.java
@@ -1,0 +1,24 @@
+package com.github.dockerjava.api.command;
+
+import java.util.List;
+
+import org.apache.commons.lang.builder.ToStringBuilder;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SyncStatsResponse {
+
+    @JsonProperty("Volumes")
+    private List<InspectVolumeResponse> volumes;
+
+    public List<InspectVolumeResponse> getVolumes() {
+        return volumes;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+}

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/AbstractDockerCmdExecFactory.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/AbstractDockerCmdExecFactory.java
@@ -63,6 +63,7 @@ import com.github.dockerjava.api.command.SearchImagesCmd;
 import com.github.dockerjava.api.command.StartContainerCmd;
 import com.github.dockerjava.api.command.StatsCmd;
 import com.github.dockerjava.api.command.StopContainerCmd;
+import com.github.dockerjava.api.command.SyncStatsCmd;
 import com.github.dockerjava.api.command.TagImageCmd;
 import com.github.dockerjava.api.command.TopContainerCmd;
 import com.github.dockerjava.api.command.UnpauseContainerCmd;
@@ -134,6 +135,7 @@ import com.github.dockerjava.core.exec.SearchImagesCmdExec;
 import com.github.dockerjava.core.exec.StartContainerCmdExec;
 import com.github.dockerjava.core.exec.StatsCmdExec;
 import com.github.dockerjava.core.exec.StopContainerCmdExec;
+import com.github.dockerjava.core.exec.SyncStatsCmdExec;
 import com.github.dockerjava.core.exec.TagImageCmdExec;
 import com.github.dockerjava.core.exec.TopContainerCmdExec;
 import com.github.dockerjava.core.exec.UnpauseContainerCmdExec;
@@ -365,6 +367,11 @@ public abstract class AbstractDockerCmdExecFactory implements DockerCmdExecFacto
     @Override
     public StatsCmd.Exec createStatsCmdExec() {
         return new StatsCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public SyncStatsCmd.Exec createSyncStatsCmdExec() {
+        return new SyncStatsCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
@@ -62,6 +62,7 @@ import com.github.dockerjava.api.command.SearchImagesCmd;
 import com.github.dockerjava.api.command.StartContainerCmd;
 import com.github.dockerjava.api.command.StatsCmd;
 import com.github.dockerjava.api.command.StopContainerCmd;
+import com.github.dockerjava.api.command.SyncStatsCmd;
 import com.github.dockerjava.api.command.TagImageCmd;
 import com.github.dockerjava.api.command.TopContainerCmd;
 import com.github.dockerjava.api.command.UnpauseContainerCmd;
@@ -137,6 +138,7 @@ import com.github.dockerjava.core.command.SearchImagesCmdImpl;
 import com.github.dockerjava.core.command.StartContainerCmdImpl;
 import com.github.dockerjava.core.command.StatsCmdImpl;
 import com.github.dockerjava.core.command.StopContainerCmdImpl;
+import com.github.dockerjava.core.command.SyncStatsCmdImpl;
 import com.github.dockerjava.core.command.TagImageCmdImpl;
 import com.github.dockerjava.core.command.TopContainerCmdImpl;
 import com.github.dockerjava.core.command.UnpauseContainerCmdImpl;
@@ -469,6 +471,11 @@ public class DockerClientImpl implements Closeable, DockerClient {
     @Override
     public StatsCmd statsCmd(String containerId) {
         return new StatsCmdImpl(getDockerCmdExecFactory().createStatsCmdExec(), containerId);
+    }
+
+    @Override
+    public SyncStatsCmd syncStatsCmd(String containerId) {
+        return new SyncStatsCmdImpl(getDockerCmdExecFactory().createSyncStatsCmdExec(), containerId);
     }
 
     @Override

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/SyncStatsCmdImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/SyncStatsCmdImpl.java
@@ -1,0 +1,31 @@
+package com.github.dockerjava.core.command;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.github.dockerjava.api.command.SyncStatsCmd;
+import com.github.dockerjava.api.model.Statistics;
+
+/**
+ * Container stats
+ */
+public class SyncStatsCmdImpl extends AbstrDockerCmd<SyncStatsCmd, Statistics> implements SyncStatsCmd {
+
+    private String containerId;
+
+    public SyncStatsCmdImpl(SyncStatsCmd.Exec exec, String containerId) {
+        super(exec);
+        withContainerId(containerId);
+    }
+
+    @Override
+    public SyncStatsCmd withContainerId(String containerId) {
+        checkNotNull(containerId, "containerId was not specified");
+        this.containerId = containerId;
+        return this;
+    }
+
+    @Override
+    public String getContainerId() {
+        return containerId;
+    }
+}

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/exec/SyncStatsCmdExec.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/exec/SyncStatsCmdExec.java
@@ -1,0 +1,29 @@
+package com.github.dockerjava.core.exec;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.github.dockerjava.api.command.SyncStatsCmd;
+import com.github.dockerjava.api.model.Statistics;
+import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.core.MediaType;
+import com.github.dockerjava.core.WebTarget;
+
+public class SyncStatsCmdExec extends AbstrSyncDockerCmdExec<SyncStatsCmd, Statistics> implements SyncStatsCmd.Exec {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SyncStatsCmdExec.class);
+
+    public SyncStatsCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
+    }
+
+    @Override
+    protected Statistics execute(SyncStatsCmd command) {
+        WebTarget webTarget = getBaseResource().path("/containers/{id}/stats").queryParam("stream", "false").resolveTemplate("id",
+                command.getContainerId());
+
+        LOGGER.trace("GET: {}", webTarget);
+        return webTarget.request().accept(MediaType.APPLICATION_JSON).get(new TypeReference<Statistics>() {
+        });
+    }
+}

--- a/docker-java-transport-jersey/src/main/java/com/github/dockerjava/jaxrs/JerseyDockerCmdExecFactory.java
+++ b/docker-java-transport-jersey/src/main/java/com/github/dockerjava/jaxrs/JerseyDockerCmdExecFactory.java
@@ -66,6 +66,7 @@ import com.github.dockerjava.api.command.SearchImagesCmd;
 import com.github.dockerjava.api.command.StartContainerCmd;
 import com.github.dockerjava.api.command.StatsCmd;
 import com.github.dockerjava.api.command.StopContainerCmd;
+import com.github.dockerjava.api.command.SyncStatsCmd;
 import com.github.dockerjava.api.command.TagImageCmd;
 import com.github.dockerjava.api.command.TopContainerCmd;
 import com.github.dockerjava.api.command.UnpauseContainerCmd;
@@ -523,6 +524,11 @@ public class JerseyDockerCmdExecFactory implements DockerCmdExecFactory, DockerC
     @Override
     public StatsCmd.Exec createStatsCmdExec() {
         return new StatsCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public SyncStatsCmd.Exec createSyncStatsCmdExec() {
+        return new SyncStatsCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override

--- a/docker-java-transport-jersey/src/main/java/com/github/dockerjava/jaxrs/SyncStatsCmdExec.java
+++ b/docker-java-transport-jersey/src/main/java/com/github/dockerjava/jaxrs/SyncStatsCmdExec.java
@@ -1,0 +1,31 @@
+package com.github.dockerjava.jaxrs;
+
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.dockerjava.api.command.SyncStatsCmd;
+import com.github.dockerjava.api.model.Statistics;
+import com.github.dockerjava.core.DockerClientConfig;
+
+
+public class SyncStatsCmdExec extends AbstrSyncDockerCmdExec<SyncStatsCmd, Statistics> implements SyncStatsCmd.Exec {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SyncStatsCmdExec.class);
+
+    public SyncStatsCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
+    }
+
+    @Override
+    protected Statistics execute(SyncStatsCmd command) {
+        WebTarget webTarget = getBaseResource().path("/containers/{id}/stats").queryParam("stream", "false").resolveTemplate("id",
+                command.getContainerId());
+
+        LOGGER.trace("GET: {}", webTarget);
+        return webTarget.request().accept(MediaType.APPLICATION_JSON).get(new GenericType<Statistics>() {
+        });
+    }
+}

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/SyncStatsCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/SyncStatsCmdIT.java
@@ -1,0 +1,45 @@
+package com.github.dockerjava.cmd;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.not;
+
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.model.Statistics;
+
+public class SyncStatsCmdIT extends CmdIT {
+    private static final Logger LOG = LoggerFactory.getLogger(SyncStatsCmdIT.class);
+
+    @Test
+    public void testStats() throws InterruptedException, IOException {
+        TimeUnit.SECONDS.sleep(1);
+
+        String containerName = "generated_" + new SecureRandom().nextInt();
+
+        CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox").withCmd("top")
+                .withName(containerName).exec();
+        LOG.info("Created container {}", container.toString());
+        assertThat(container.getId(), not(isEmptyString()));
+
+        dockerRule.getClient().startContainerCmd(container.getId()).exec();
+
+        Statistics statistics = dockerRule.getClient().syncStatsCmd(container.getId()).exec();
+        assertThat(statistics.getCpuStats().getCpuUsage().getTotalUsage(), is(greaterThan(0L)));
+        assertThat(statistics.getMemoryStats().getUsage(), is(greaterThan(0L)));
+        
+        LOG.info("Stopping container");
+        dockerRule.getClient().stopContainerCmd(container.getId()).exec();
+        dockerRule.getClient().removeContainerCmd(container.getId()).exec();
+        LOG.info("Completed test");
+    }
+}

--- a/docker-java/src/test/java/com/github/dockerjava/core/TestDockerCmdExecFactory.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/TestDockerCmdExecFactory.java
@@ -67,6 +67,7 @@ import com.github.dockerjava.api.command.SearchImagesCmd;
 import com.github.dockerjava.api.command.StartContainerCmd;
 import com.github.dockerjava.api.command.StatsCmd;
 import com.github.dockerjava.api.command.StopContainerCmd;
+import com.github.dockerjava.api.command.SyncStatsCmd;
 import com.github.dockerjava.api.command.TagImageCmd;
 import com.github.dockerjava.api.command.TopContainerCmd;
 import com.github.dockerjava.api.command.UnpauseContainerCmd;
@@ -348,6 +349,11 @@ public class TestDockerCmdExecFactory implements DockerCmdExecFactory, DockerCli
     @Override
     public StatsCmd.Exec createStatsCmdExec() {
         return delegate.createStatsCmdExec();
+    }
+    
+    @Override
+    public SyncStatsCmd.Exec createSyncStatsCmdExec() {
+        return delegate.createSyncStatsCmdExec();
     }
 
     @Override


### PR DESCRIPTION
See query parameter "stream" [https://docs.docker.com/engine/api/v1.40/#operation/ContainerStats](https://docs.docker.com/engine/api/v1.40/#operation/ContainerStats)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1261)
<!-- Reviewable:end -->
