### PR TITLE
Add OkHttp transport

### DIFF
--- a/docker-java-transport-okhttp/pom.xml
+++ b/docker-java-transport-okhttp/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.github.docker-java</groupId>
+		<artifactId>docker-java-parent</artifactId>
+		<version>3.2.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>docker-java-transport-okhttp</artifactId>
+	<packaging>bundle</packaging>
+
+	<name>docker-java-transport-okhttp</name>
+	<url>https://github.com/docker-java/docker-java</url>
+	<description>Java API Client for Docker</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>${groupId}</groupId>
+			<artifactId>docker-java-core</artifactId>
+			<version>${version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+			<version>3.14.4</version>
+		</dependency>
+
+		<dependency>
+			<groupId>net.java.dev.jna</groupId>
+			<artifactId>jna-platform</artifactId>
+			<version>5.4.0</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Export-Package>com.github.dockerjava.okhttp.*</Export-Package>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/FramedSink.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/FramedSink.java
@@ -1,0 +1,73 @@
+package com.github.dockerjava.okhttp;
+
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.api.model.StreamType;
+import okio.BufferedSource;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+class FramedSink implements Consumer<BufferedSource> {
+
+    private static final int HEADER_SIZE = 8;
+
+    private final ResultCallback<Frame> resultCallback;
+
+    FramedSink(ResultCallback<Frame> resultCallback) {
+        this.resultCallback = resultCallback;
+    }
+
+    @Override
+    public void accept(BufferedSource source) {
+        try {
+            while (!source.exhausted()) {
+                // See https://docs.docker.com/engine/api/v1.37/#operation/ContainerAttach
+                // [8]byte{STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4}[]byte{OUTPUT}
+
+                if (!source.request(HEADER_SIZE)) {
+                    return;
+                }
+                byte[] bytes = source.readByteArray(HEADER_SIZE);
+
+                StreamType streamType = streamType(bytes[0]);
+
+                if (streamType == StreamType.RAW) {
+                    resultCallback.onNext(new Frame(StreamType.RAW, bytes));
+                    byte[] buffer = new byte[1024];
+                    while (!source.exhausted()) {
+                        int readBytes = source.read(buffer);
+                        if (readBytes != -1) {
+                            resultCallback.onNext(new Frame(StreamType.RAW, Arrays.copyOf(buffer, readBytes)));
+                        }
+                    }
+                    return;
+                }
+
+                int payloadSize = ByteBuffer.wrap(bytes, 4, 4).getInt();
+                if (!source.request(payloadSize)) {
+                    return;
+                }
+                byte[] payload = source.readByteArray(payloadSize);
+
+                resultCallback.onNext(new Frame(streamType, payload));
+            }
+        } catch (Exception e) {
+            resultCallback.onError(e);
+        }
+    }
+
+    private static StreamType streamType(byte streamType) {
+        switch (streamType) {
+            case 0:
+                return StreamType.STDIN;
+            case 1:
+                return StreamType.STDOUT;
+            case 2:
+                return StreamType.STDERR;
+            default:
+                return StreamType.RAW;
+        }
+    }
+}

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/NamedPipeSocketFactory.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/NamedPipeSocketFactory.java
@@ -1,0 +1,136 @@
+package com.github.dockerjava.okhttp;
+
+import com.sun.jna.platform.win32.Kernel32;
+
+import javax.net.SocketFactory;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.RandomAccessFile;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+
+class NamedPipeSocketFactory extends SocketFactory {
+
+    final String socketFileName;
+
+    NamedPipeSocketFactory(String socketFileName) {
+        this.socketFileName = socketFileName;
+    }
+
+    @Override
+    public Socket createSocket() {
+        return new Socket() {
+
+            RandomAccessFile file;
+            InputStream is;
+            OutputStream os;
+
+            @Override
+            public void close() throws IOException {
+                if (file != null) {
+                    file.close();
+                    file = null;
+                }
+            }
+
+            @Override
+            public void connect(SocketAddress endpoint) {
+                connect(endpoint, 0);
+            }
+
+            @Override
+            public void connect(SocketAddress endpoint, int timeout) {
+                long startedAt = System.currentTimeMillis();
+                timeout = Math.max(timeout, 10_000);
+                while (true) {
+                    try {
+                        file = new RandomAccessFile(socketFileName, "rw");
+                        break;
+                    } catch (FileNotFoundException e) {
+                        if (System.currentTimeMillis() - startedAt >= timeout) {
+                            throw new RuntimeException(e);
+                        } else {
+                            Kernel32.INSTANCE.WaitNamedPipe(socketFileName, 100);
+                        }
+                    }
+                }
+
+                is = new InputStream() {
+                    @Override
+                    public int read(byte[] bytes, int off, int len) throws IOException {
+                        if (OkHttpInvocationBuilder.CLOSING.get()) {
+                            return 0;
+                        }
+                        return file.read(bytes, off, len);
+                    }
+
+                    @Override
+                    public int read() throws IOException {
+                        if (OkHttpInvocationBuilder.CLOSING.get()) {
+                            return 0;
+                        }
+                        return file.read();
+                    }
+
+                    @Override
+                    public int read(byte[] bytes) throws IOException {
+                        if (OkHttpInvocationBuilder.CLOSING.get()) {
+                            return 0;
+                        }
+                        return file.read(bytes);
+                    }
+                };
+
+                os = new OutputStream() {
+                    @Override
+                    public void write(byte[] bytes, int off, int len) throws IOException {
+                        file.write(bytes, off, len);
+                    }
+
+                    @Override
+                    public void write(int value) throws IOException {
+                        file.write(value);
+                    }
+
+                    @Override
+                    public void write(byte[] bytes) throws IOException {
+                        file.write(bytes);
+                    }
+                };
+            }
+
+            @Override
+            public InputStream getInputStream() {
+                return is;
+            }
+
+            @Override
+            public OutputStream getOutputStream() {
+                return os;
+            }
+        };
+    }
+
+    @Override
+    public Socket createSocket(String s, int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Socket createSocket(String s, int i, InetAddress inetAddress, int i1) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Socket createSocket(InetAddress inetAddress, int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Socket createSocket(InetAddress inetAddress, int i, InetAddress inetAddress1, int i1) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/OkHttpDockerCmdExecFactory.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/OkHttpDockerCmdExecFactory.java
@@ -1,0 +1,168 @@
+package com.github.dockerjava.okhttp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dockerjava.api.command.PingCmd;
+import com.github.dockerjava.core.AbstractDockerCmdExecFactory;
+import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.core.SSLConfig;
+import com.github.dockerjava.core.WebTarget;
+import com.github.dockerjava.core.exec.PingCmdExec;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.MultimapBuilder;
+import okhttp3.ConnectionPool;
+import okhttp3.Dns;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import org.apache.commons.io.IOUtils;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+public class OkHttpDockerCmdExecFactory extends AbstractDockerCmdExecFactory {
+
+    private static final String SOCKET_SUFFIX = ".socket";
+
+    private ObjectMapper objectMapper;
+
+    private OkHttpClient okHttpClient;
+
+    private HttpUrl baseUrl;
+
+    @Override
+    public void init(DockerClientConfig dockerClientConfig) {
+        super.init(dockerClientConfig);
+
+        OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder()
+            .readTimeout(0, TimeUnit.SECONDS)
+            .retryOnConnectionFailure(true);
+
+        URI dockerHost = dockerClientConfig.getDockerHost();
+        switch (dockerHost.getScheme()) {
+            case "unix":
+            case "npipe":
+                String socketPath = dockerHost.getPath();
+
+                if ("unix".equals(dockerHost.getScheme())) {
+                    clientBuilder
+                        .socketFactory(new UnixSocketFactory(socketPath));
+                } else {
+                    clientBuilder
+                        .socketFactory(new NamedPipeSocketFactory(socketPath));
+                }
+
+                clientBuilder
+                    // Disable pooling
+                    .connectionPool(new ConnectionPool(0, 1, TimeUnit.SECONDS))
+                    .dns(hostname -> {
+                        if (hostname.endsWith(SOCKET_SUFFIX)) {
+                            return Collections.singletonList(InetAddress.getByAddress(hostname, new byte[]{0, 0, 0, 0}));
+                        } else {
+                            return Dns.SYSTEM.lookup(hostname);
+                        }
+                    });
+            default:
+        }
+
+        SSLConfig sslConfig = dockerClientConfig.getSSLConfig();
+        if (sslConfig != null) {
+            try {
+                SSLContext sslContext = sslConfig.getSSLContext();
+                if (sslContext != null) {
+                    clientBuilder
+                            .sslSocketFactory(sslContext.getSocketFactory(), new TrustAllX509TrustManager());
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        okHttpClient = clientBuilder.build();
+
+        HttpUrl.Builder baseUrlBuilder;
+
+        switch (dockerHost.getScheme()) {
+            case "unix":
+            case "npipe":
+                baseUrlBuilder = new HttpUrl.Builder()
+                    .scheme("http")
+                    .host("docker" + SOCKET_SUFFIX);
+                break;
+            case "tcp":
+                SSLContext sslContext;
+                try {
+                    sslContext = sslConfig.getSSLContext();
+                } catch (KeyManagementException | UnrecoverableKeyException | NoSuchAlgorithmException | KeyStoreException e) {
+                    throw new RuntimeException(e);
+                }
+                baseUrlBuilder = new HttpUrl.Builder()
+                    .scheme(sslConfig != null && sslContext != null ? "https" : "http")
+                    .host(dockerHost.getHost())
+                    .port(dockerHost.getPort());
+                break;
+            default:
+                baseUrlBuilder = HttpUrl.get(dockerHost.toString()).newBuilder();
+        }
+        baseUrl = baseUrlBuilder.build();
+
+        objectMapper = dockerClientConfig.getObjectMapper();
+    }
+
+    @Override
+    protected OkHttpWebTarget getBaseResource() {
+        return new OkHttpWebTarget(
+            objectMapper,
+            okHttpClient,
+            baseUrl,
+            ImmutableList.of(),
+            MultimapBuilder.hashKeys().hashSetValues().build()
+        );
+    }
+
+    @Override
+    public PingCmd.Exec createPingCmdExec() {
+        return new PingCmdExec(getBaseResource(), getDockerClientConfig()) {
+
+            @Override
+            protected Void execute(PingCmd command) {
+                WebTarget webResource = getBaseResource().path("/_ping");
+
+                // TODO contribute to docker-java, make it close the stream
+                IOUtils.closeQuietly(webResource.request().get());
+
+                return null;
+            }
+        };
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+    private static class TrustAllX509TrustManager implements X509TrustManager {
+        @Override
+        public void checkClientTrusted(X509Certificate[] x509Certificates, String s) {
+
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] x509Certificates, String s) {
+
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    }
+}

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/OkHttpInvocationBuilder.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/OkHttpInvocationBuilder.java
@@ -1,0 +1,361 @@
+package com.github.dockerjava.okhttp;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.exception.BadRequestException;
+import com.github.dockerjava.api.exception.ConflictException;
+import com.github.dockerjava.api.exception.DockerException;
+import com.github.dockerjava.api.exception.InternalServerErrorException;
+import com.github.dockerjava.api.exception.NotAcceptableException;
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.exception.NotModifiedException;
+import com.github.dockerjava.api.exception.UnauthorizedException;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.core.InvocationBuilder;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.internal.connection.RealConnection;
+import okio.BufferedSink;
+import okio.BufferedSource;
+import okio.Okio;
+import okio.Source;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+class OkHttpInvocationBuilder implements InvocationBuilder {
+
+    static final ThreadLocal<Boolean> CLOSING = ThreadLocal.withInitial(() -> false);
+
+    private final ObjectMapper objectMapper;
+
+    private final OkHttpClient okHttpClient;
+
+    private final Request.Builder requestBuilder;
+
+    public OkHttpInvocationBuilder(ObjectMapper objectMapper, OkHttpClient okHttpClient, HttpUrl httpUrl) {
+        this.objectMapper = objectMapper;
+        this.okHttpClient = okHttpClient;
+
+        requestBuilder = new Request.Builder()
+            .url(httpUrl);
+    }
+
+    @Override
+    public OkHttpInvocationBuilder accept(com.github.dockerjava.core.MediaType mediaType) {
+        return header("accept", mediaType.getMediaType());
+    }
+
+    @Override
+    public OkHttpInvocationBuilder header(String name, String value) {
+        requestBuilder.header(name, value);
+        return this;
+    }
+
+    @Override
+    public void delete() {
+        Request request = requestBuilder
+            .delete()
+            .build();
+
+        execute(request).close();
+    }
+
+    @Override
+    public void get(ResultCallback<Frame> resultCallback) {
+        Request request = requestBuilder
+            .get()
+            .build();
+
+        executeAndStream(
+            request,
+            resultCallback,
+            new FramedSink(resultCallback)
+        );
+    }
+
+    @Override
+    public <T> T get(TypeReference<T> typeReference) {
+        try (InputStream inputStream = get()) {
+            return objectMapper.readValue(inputStream, typeReference);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public <T> void get(TypeReference<T> typeReference, ResultCallback<T> resultCallback) {
+        Request request = requestBuilder
+            .get()
+            .build();
+
+        executeAndStream(
+            request,
+            resultCallback,
+            new JsonSink<>(objectMapper, typeReference, resultCallback)
+        );
+    }
+
+    @Override
+    public InputStream post(Object entity) {
+        try {
+            Request request = requestBuilder
+                    .post(RequestBody.create(MediaType.parse("application/json"), objectMapper.writeValueAsBytes(entity)))
+                    .build();
+
+            return execute(request).body().byteStream();
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public <T> T post(Object entity, TypeReference<T> typeReference) {
+        try {
+            Request request = requestBuilder
+                    .post(RequestBody.create(MediaType.parse("application/json"), objectMapper.writeValueAsBytes(entity)))
+                    .build();
+
+            try (Response response = execute(request)) {
+                String inputStream = response.body().string();
+                return objectMapper.readValue(inputStream, typeReference);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public <T> void post(Object entity, TypeReference<T> typeReference, ResultCallback<T> resultCallback) {
+        try {
+            post(typeReference, resultCallback, new ByteArrayInputStream(objectMapper.writeValueAsBytes(entity)));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public <T> T post(TypeReference<T> typeReference, InputStream body) {
+        try (InputStream inputStream = post(body)) {
+            return objectMapper.readValue(inputStream, typeReference);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void post(Object entity, InputStream stdin, ResultCallback<Frame> resultCallback) {
+        final Request request;
+        try {
+            request = requestBuilder
+                .post(RequestBody.create(MediaType.parse("application/json"), objectMapper.writeValueAsBytes(entity)))
+                .build();
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        OkHttpClient okHttpClient = this.okHttpClient;
+
+        if (stdin != null) {
+            // FIXME there must be a better way of handling it
+            okHttpClient = okHttpClient.newBuilder()
+                .addNetworkInterceptor(chain -> {
+                    Response response = chain.proceed(chain.request());
+                    if (response.isSuccessful()) {
+                        Thread thread = new Thread(() -> {
+                            try {
+                                Field sinkField = RealConnection.class.getDeclaredField("sink");
+                                sinkField.setAccessible(true);
+
+                                try (
+                                        BufferedSink sink = (BufferedSink) sinkField.get(chain.connection());
+                                        Source source = Okio.source(stdin);
+                                ) {
+                                    sink.writeAll(source);
+                                }
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+                        thread.start();
+                    }
+                    return response;
+                })
+                .build();
+        }
+
+        executeAndStream(
+            okHttpClient,
+            request,
+            resultCallback,
+            new FramedSink(resultCallback)
+        );
+    }
+
+    @Override
+    public <T> void post(TypeReference<T> typeReference, ResultCallback<T> resultCallback, InputStream body) {
+        Request request = requestBuilder
+            .post(toRequestBody(body, null))
+            .build();
+
+        executeAndStream(
+            request,
+            resultCallback,
+            new JsonSink<>(objectMapper, typeReference, resultCallback)
+        );
+    }
+
+    @Override
+    public void postStream(InputStream body) {
+        Request request = requestBuilder
+            .post(toRequestBody(body, null))
+            .build();
+
+        execute(request).close();
+    }
+
+    @Override
+    public InputStream get() {
+        Request request = requestBuilder
+            .get()
+            .build();
+
+        return execute(request).body().byteStream();
+    }
+
+    @Override
+    public void put(InputStream body, com.github.dockerjava.core.MediaType mediaType) {
+        Request request = requestBuilder
+            .put(toRequestBody(body, mediaType.toString()))
+            .build();
+
+        execute(request).close();
+    }
+
+    protected RequestBody toRequestBody(InputStream body, String mediaType) {
+        return new RequestBody() {
+            @Override
+            public MediaType contentType() {
+                if (mediaType == null) {
+                    return null;
+                }
+                return MediaType.parse(mediaType);
+            }
+
+            @Override
+            public void writeTo(BufferedSink sink) throws IOException {
+                try (Source source = Okio.source(body)) {
+                    sink.writeAll(source);
+                }
+            }
+        };
+    }
+
+    protected Response execute(Request request) {
+        return execute(okHttpClient, request);
+    }
+
+    protected Response execute(OkHttpClient okHttpClient, Request request) {
+        try {
+            Response response = okHttpClient.newCall(request).execute();
+            if (!response.isSuccessful()) {
+                String body = response.body().string();
+                switch (response.code()) {
+                    case 304:
+                        throw new NotModifiedException(body);
+                    case 400:
+                        throw new BadRequestException(body);
+                    case 401:
+                        throw new UnauthorizedException(body);
+                    case 404:
+                        throw new NotFoundException(body);
+                    case 406:
+                        throw new NotAcceptableException(body);
+                    case 409:
+                        throw new ConflictException(body);
+                    case 500:
+                        throw new InternalServerErrorException(body);
+                    default:
+                        throw new DockerException(body, response.code());
+                }
+            } else {
+                return response;
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected <T> void executeAndStream(Request request, ResultCallback<T> callback, Consumer<BufferedSource> sourceConsumer) {
+        executeAndStream(okHttpClient, request, callback, sourceConsumer);
+    }
+
+    protected <T> void executeAndStream(OkHttpClient okHttpClient, Request request, ResultCallback<T> callback, Consumer<BufferedSource> sourceConsumer) {
+        Thread thread = new Thread(() -> {
+            try (
+                    Response response = execute(okHttpClient, request.newBuilder().tag("streaming").build());
+                    BufferedSource source = response.body().source();
+            ) {
+                callback.onStart(() -> {
+                    boolean previous = CLOSING.get();
+                    CLOSING.set(true);
+                    try {
+                        response.close();
+                    } finally {
+                        CLOSING.set(previous);
+                    }
+                });
+
+                sourceConsumer.accept(source);
+                callback.onComplete();
+            } catch (Exception e) {
+                callback.onError(e);
+            }
+        }, "tc-okhttp-stream-" + Objects.hashCode(request));
+        thread.setDaemon(true);
+
+        thread.start();
+    }
+
+    private static class JsonSink<T> implements Consumer<BufferedSource> {
+
+        private final ObjectMapper objectMapper;
+
+        private final TypeReference<T> typeReference;
+
+        private final ResultCallback<T> resultCallback;
+
+        public JsonSink(ObjectMapper objectMapper, TypeReference<T> typeReference, ResultCallback<T> resultCallback) {
+            this.objectMapper = objectMapper;
+            this.typeReference = typeReference;
+            this.resultCallback = resultCallback;
+        }
+
+        @Override
+        public void accept(BufferedSource source) {
+            try {
+                while (true) {
+                    String line = source.readUtf8Line();
+                    if (line == null) {
+                        break;
+                    }
+
+                    resultCallback.onNext(objectMapper.readValue(line, typeReference));
+                }
+            } catch (Exception e) {
+                resultCallback.onError(e);
+            }
+        }
+    }
+
+}

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/OkHttpInvocationBuilder.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/OkHttpInvocationBuilder.java
@@ -43,7 +43,7 @@ class OkHttpInvocationBuilder implements InvocationBuilder {
 
     private final Request.Builder requestBuilder;
 
-    public OkHttpInvocationBuilder(ObjectMapper objectMapper, OkHttpClient okHttpClient, HttpUrl httpUrl) {
+    OkHttpInvocationBuilder(ObjectMapper objectMapper, OkHttpClient okHttpClient, HttpUrl httpUrl) {
         this.objectMapper = objectMapper;
         this.okHttpClient = okHttpClient;
 
@@ -164,11 +164,11 @@ class OkHttpInvocationBuilder implements InvocationBuilder {
             throw new RuntimeException(e);
         }
 
-        OkHttpClient okHttpClient = this.okHttpClient;
+        OkHttpClient clientToUse = this.okHttpClient;
 
         if (stdin != null) {
             // FIXME there must be a better way of handling it
-            okHttpClient = okHttpClient.newBuilder()
+            clientToUse = clientToUse.newBuilder()
                 .addNetworkInterceptor(chain -> {
                     Response response = chain.proceed(chain.request());
                     if (response.isSuccessful()) {
@@ -195,7 +195,7 @@ class OkHttpInvocationBuilder implements InvocationBuilder {
         }
 
         executeAndStream(
-            okHttpClient,
+            clientToUse,
             request,
             resultCallback,
             new FramedSink(resultCallback)
@@ -300,7 +300,12 @@ class OkHttpInvocationBuilder implements InvocationBuilder {
         executeAndStream(okHttpClient, request, callback, sourceConsumer);
     }
 
-    protected <T> void executeAndStream(OkHttpClient okHttpClient, Request request, ResultCallback<T> callback, Consumer<BufferedSource> sourceConsumer) {
+    protected <T> void executeAndStream(
+            OkHttpClient okHttpClient,
+            Request request,
+            ResultCallback<T> callback,
+            Consumer<BufferedSource> sourceConsumer
+    ) {
         Thread thread = new Thread(() -> {
             try (
                     Response response = execute(okHttpClient, request.newBuilder().tag("streaming").build());
@@ -335,7 +340,7 @@ class OkHttpInvocationBuilder implements InvocationBuilder {
 
         private final ResultCallback<T> resultCallback;
 
-        public JsonSink(ObjectMapper objectMapper, TypeReference<T> typeReference, ResultCallback<T> resultCallback) {
+        JsonSink(ObjectMapper objectMapper, TypeReference<T> typeReference, ResultCallback<T> resultCallback) {
             this.objectMapper = objectMapper;
             this.typeReference = typeReference;
             this.resultCallback = resultCallback;

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/OkHttpInvocationBuilder.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/OkHttpInvocationBuilder.java
@@ -181,7 +181,13 @@ class OkHttpInvocationBuilder implements InvocationBuilder {
                                         BufferedSink sink = (BufferedSink) sinkField.get(chain.connection());
                                         Source source = Okio.source(stdin);
                                 ) {
-                                    sink.writeAll(source);
+                                    while (sink.isOpen()) {
+                                        int available = stdin.available();
+                                        if (available > 0) {
+                                            sink.write(source, available);
+                                            sink.emit();
+                                        }
+                                    }
                                 }
                             } catch (Exception e) {
                                 throw new RuntimeException(e);

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/OkHttpWebTarget.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/OkHttpWebTarget.java
@@ -1,0 +1,148 @@
+package com.github.dockerjava.okhttp;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dockerjava.core.InvocationBuilder;
+import com.github.dockerjava.core.WebTarget;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.SetMultimap;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class OkHttpWebTarget implements WebTarget {
+
+    final ObjectMapper objectMapper;
+
+    final OkHttpClient okHttpClient;
+
+    final HttpUrl baseUrl;
+
+    final ImmutableList<String> path;
+
+    final SetMultimap<String, String> queryParams;
+
+    public OkHttpWebTarget(
+            ObjectMapper objectMapper,
+            OkHttpClient okHttpClient,
+            HttpUrl baseUrl,
+            ImmutableList<String> path,
+            SetMultimap<String, String> queryParams
+    ) {
+        this.objectMapper = objectMapper;
+        this.okHttpClient = okHttpClient;
+        this.baseUrl = baseUrl;
+        this.path = path;
+        this.queryParams = queryParams;
+    }
+
+    @Override
+    public InvocationBuilder request() {
+        String resource = StringUtils.join(path, "/");
+
+        if (!resource.startsWith("/")) {
+            resource = "/" + resource;
+        }
+
+        HttpUrl.Builder baseUrlBuilder = baseUrl.newBuilder()
+            .encodedPath(resource);
+
+        for (Map.Entry<String, Collection<String>> queryParamEntry : queryParams.asMap().entrySet()) {
+            String key = queryParamEntry.getKey();
+            for (String paramValue : queryParamEntry.getValue()) {
+                baseUrlBuilder.addQueryParameter(key, paramValue);
+            }
+        }
+
+        return new OkHttpInvocationBuilder(
+            objectMapper,
+            okHttpClient,
+            baseUrlBuilder.build()
+        );
+    }
+
+    @Override
+    public OkHttpWebTarget path(String... components) {
+        ImmutableList<String> newPath = ImmutableList.<String>builder()
+                .addAll(path)
+                .add(components)
+                .build();
+        return new OkHttpWebTarget(
+                objectMapper,
+                okHttpClient,
+                baseUrl,
+                newPath,
+                queryParams
+        );
+    }
+
+    @Override
+    public OkHttpWebTarget resolveTemplate(String name, Object value) {
+        ImmutableList.Builder<String> newPath = ImmutableList.builder();
+        for (String component : path) {
+            component = component.replaceAll("\\{" + name + "\\}", value.toString());
+            newPath.add(component);
+        }
+
+        return new OkHttpWebTarget(
+                objectMapper,
+                okHttpClient,
+                baseUrl,
+                newPath.build(),
+                queryParams
+        );
+    }
+
+    @Override
+    public OkHttpWebTarget queryParam(String name, Object value) {
+        if (value == null) {
+            return this;
+        }
+
+        SetMultimap<String, String> newQueryParams = HashMultimap.create(queryParams);
+        newQueryParams.put(name, value.toString());
+
+        return new OkHttpWebTarget(
+                objectMapper,
+                okHttpClient,
+                baseUrl,
+                path,
+                newQueryParams
+        );
+    }
+
+    @Override
+    public OkHttpWebTarget queryParamsSet(String name, Set<?> values) {
+        SetMultimap<String, String> newQueryParams = HashMultimap.create(queryParams);
+        newQueryParams.replaceValues(name, values.stream().filter(Objects::nonNull).map(Object::toString).collect(Collectors.toSet()));
+
+        return new OkHttpWebTarget(
+                objectMapper,
+                okHttpClient,
+                baseUrl,
+                path,
+                newQueryParams
+        );
+    }
+
+    @Override
+    public OkHttpWebTarget queryParamsJsonMap(String name, Map<String, String> values) {
+        if (values == null || values.isEmpty()) {
+            return this;
+        }
+
+        // when param value is JSON string
+        try {
+            return queryParam(name, objectMapper.writeValueAsString(values));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/OkHttpWebTarget.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/OkHttpWebTarget.java
@@ -29,7 +29,7 @@ class OkHttpWebTarget implements WebTarget {
 
     final SetMultimap<String, String> queryParams;
 
-    public OkHttpWebTarget(
+    OkHttpWebTarget(
             ObjectMapper objectMapper,
             OkHttpClient okHttpClient,
             HttpUrl baseUrl,

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/UnixDomainSocket.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/UnixDomainSocket.java
@@ -52,12 +52,18 @@
 
 package com.github.dockerjava.okhttp;
 
-import com.sun.jna.*;
+import com.sun.jna.LastErrorException;
+import com.sun.jna.Native;
+import com.sun.jna.Platform;
+import com.sun.jna.Structure;
 
-import java.io.*;
-import java.net.*;
-import java.util.*;
-import java.util.concurrent.atomic.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 class UnixDomainSocket extends Socket {
 
@@ -82,7 +88,7 @@ class UnixDomainSocket extends Socket {
     private OutputStream os;
     private boolean connected;
 
-    public UnixDomainSocket(String path) throws IOException {
+    UnixDomainSocket(String path) throws IOException {
         if (Platform.isWindows() || Platform.isWindowsCE()) {
             throw new IOException("Unix domain sockets are not supported on Windows");
         }
@@ -196,19 +202,19 @@ class UnixDomainSocket extends Socket {
 
     public static class SockAddr extends Structure {
 
-        public short sun_family;
-        public byte[] sun_path;
+        public short sunFamily;
+        public byte[] sunPath;
 
         /**
          * Contructor.
          *
          * @param sunPath path
          */
-        public SockAddr(String sunPath) {
-            sun_family = AF_UNIX;
+        SockAddr(String sunPath) {
+            sunFamily = AF_UNIX;
             byte[] arr = sunPath.getBytes();
-            sun_path = new byte[arr.length + 1];
-            System.arraycopy(arr, 0, sun_path, 0, Math.min(sun_path.length - 1, arr.length));
+            this.sunPath = new byte[arr.length + 1];
+            System.arraycopy(arr, 0, this.sunPath, 0, Math.min(this.sunPath.length - 1, arr.length));
             allocateMemory();
         }
 

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/UnixDomainSocket.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/UnixDomainSocket.java
@@ -1,0 +1,306 @@
+/*
+ *
+ * MariaDB Client for Java
+ *
+ * Copyright (c) 2012-2014 Monty Program Ab.
+ * Copyright (c) 2015-2019 MariaDB Ab.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to Monty Program Ab info@montyprogram.com.
+ *
+ * This particular MariaDB Client for Java file is work
+ * derived from a Drizzle-JDBC. Drizzle-JDBC file which is covered by subject to
+ * the following copyright and notice provisions:
+ *
+ * Copyright (c) 2009-2011, Marcus Eriksson
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of the driver nor the names of its contributors may not be
+ * used to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS  AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+
+package com.github.dockerjava.okhttp;
+
+import com.sun.jna.*;
+
+import java.io.*;
+import java.net.*;
+import java.util.*;
+import java.util.concurrent.atomic.*;
+
+class UnixDomainSocket extends Socket {
+
+    private static final int AF_UNIX = 1;
+    private static final int SOCK_STREAM = Platform.isSolaris() ? 2 : 1;
+    private static final int PROTOCOL = 0;
+
+    static {
+        if (Platform.isSolaris()) {
+            System.loadLibrary("nsl");
+            System.loadLibrary("socket");
+        }
+        if (!Platform.isWindows() && !Platform.isWindowsCE()) {
+            Native.register("c");
+        }
+    }
+
+    private final AtomicBoolean closeLock = new AtomicBoolean();
+    private final SockAddr sockaddr;
+    private final int fd;
+    private InputStream is;
+    private OutputStream os;
+    private boolean connected;
+
+    public UnixDomainSocket(String path) throws IOException {
+        if (Platform.isWindows() || Platform.isWindowsCE()) {
+            throw new IOException("Unix domain sockets are not supported on Windows");
+        }
+        sockaddr = new SockAddr(path);
+        closeLock.set(false);
+        try {
+            fd = socket(AF_UNIX, SOCK_STREAM, PROTOCOL);
+        } catch (LastErrorException lee) {
+            throw new IOException("native socket() failed : " + formatError(lee));
+        }
+    }
+
+    public static native int socket(int domain, int type, int protocol) throws LastErrorException;
+
+    public static native int connect(int sockfd, SockAddr sockaddr, int addrlen)
+            throws LastErrorException;
+
+    public static native int recv(int fd, byte[] buffer, int count, int flags)
+            throws LastErrorException;
+
+    public static native int send(int fd, byte[] buffer, int count, int flags)
+            throws LastErrorException;
+
+    public static native int close(int fd) throws LastErrorException;
+
+    public static native String strerror(int errno);
+
+    private static String formatError(LastErrorException lee) {
+        try {
+            return strerror(lee.getErrorCode());
+        } catch (Throwable t) {
+            return lee.getMessage();
+        }
+    }
+
+    @Override
+    public boolean isConnected() {
+        return connected;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (!closeLock.getAndSet(true)) {
+            try {
+                close(fd);
+            } catch (LastErrorException lee) {
+                throw new IOException("native close() failed : " + formatError(lee));
+            }
+            connected = false;
+        }
+    }
+
+    @Override
+    public void connect(SocketAddress endpoint) throws IOException {
+        connect(endpoint, 0);
+    }
+
+    public void connect(SocketAddress endpoint, int timeout) throws IOException {
+        try {
+            int ret = connect(fd, sockaddr, sockaddr.size());
+            if (ret != 0) {
+                throw new IOException(strerror(Native.getLastError()));
+            }
+            connected = true;
+        } catch (LastErrorException lee) {
+            throw new IOException("native connect() failed : " + formatError(lee));
+        }
+        is = new UnixSocketInputStream();
+        os = new UnixSocketOutputStream();
+    }
+
+    public InputStream getInputStream() {
+        return is;
+    }
+
+    public OutputStream getOutputStream() {
+        return os;
+    }
+
+    public void setTcpNoDelay(boolean b) {
+        // do nothing
+    }
+
+    public void setKeepAlive(boolean b) {
+        // do nothing
+    }
+
+    public void setReceiveBufferSize(int size) {
+        // do nothing
+    }
+
+    public void setSendBufferSize(int size) {
+        // do nothing
+    }
+
+    public void setSoLinger(boolean b, int i) {
+        // do nothing
+    }
+
+    public void setSoTimeout(int timeout) {
+        // do nothing
+    }
+
+    public void shutdownInput() {
+        // do nothing
+    }
+
+    public void shutdownOutput() {
+        // do nothing
+    }
+
+    public static class SockAddr extends Structure {
+
+        public short sun_family;
+        public byte[] sun_path;
+
+        /**
+         * Contructor.
+         *
+         * @param sunPath path
+         */
+        public SockAddr(String sunPath) {
+            sun_family = AF_UNIX;
+            byte[] arr = sunPath.getBytes();
+            sun_path = new byte[arr.length + 1];
+            System.arraycopy(arr, 0, sun_path, 0, Math.min(sun_path.length - 1, arr.length));
+            allocateMemory();
+        }
+
+        @Override
+        protected java.util.List<String> getFieldOrder() {
+            return Arrays.asList("sun_family", "sun_path");
+        }
+    }
+
+    class UnixSocketInputStream extends InputStream {
+
+        @Override
+        public int read(byte[] bytesEntry, int off, int len) throws IOException {
+            try {
+                if (off > 0) {
+                    int bytes = 0;
+                    int remainingLength = len;
+                    int size;
+                    byte[] data = new byte[(len < 10240) ? len : 10240];
+                    do {
+                        size = recv(fd, data, (remainingLength < 10240) ? remainingLength : 10240, 0);
+                        if (size > 0) {
+                            System.arraycopy(data, 0, bytesEntry, off, size);
+                            bytes += size;
+                            off += size;
+                            remainingLength -= size;
+                        }
+                    } while ((remainingLength > 0) && (size > 0));
+                    return bytes;
+                } else {
+                    return recv(fd, bytesEntry, len, 0);
+                }
+            } catch (LastErrorException lee) {
+                throw new IOException("native read() failed : " + formatError(lee));
+            }
+        }
+
+        @Override
+        public int read() throws IOException {
+            byte[] bytes = new byte[1];
+            int bytesRead = read(bytes);
+            if (bytesRead == 0) {
+                return -1;
+            }
+            return bytes[0] & 0xff;
+        }
+
+        @Override
+        public int read(byte[] bytes) throws IOException {
+            return read(bytes, 0, bytes.length);
+        }
+    }
+
+    class UnixSocketOutputStream extends OutputStream {
+
+        @Override
+        public void write(byte[] bytesEntry, int off, int len) throws IOException {
+            int bytes;
+            try {
+                if (off > 0) {
+                    int size;
+                    int remainingLength = len;
+                    byte[] data = new byte[(len < 10240) ? len : 10240];
+                    do {
+                        size = (remainingLength < 10240) ? remainingLength : 10240;
+                        System.arraycopy(bytesEntry, off, data, 0, size);
+                        bytes = send(fd, data, size, 0);
+                        if (bytes > 0) {
+                            off += bytes;
+                            remainingLength -= bytes;
+                        }
+                    } while ((remainingLength > 0) && (bytes > 0));
+                } else {
+                    bytes = send(fd, bytesEntry, len, 0);
+                }
+
+                if (bytes != len) {
+                    throw new IOException("can't write " + len + "bytes");
+                }
+            } catch (LastErrorException lee) {
+                throw new IOException("native write() failed : " + formatError(lee));
+            }
+        }
+
+        @Override
+        public void write(int value) throws IOException {
+            write(new byte[] {(byte) value});
+        }
+
+        @Override
+        public void write(byte[] bytes) throws IOException {
+            write(bytes, 0, bytes.length);
+        }
+    }
+}

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/UnixDomainSocket.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/UnixDomainSocket.java
@@ -202,8 +202,10 @@ class UnixDomainSocket extends Socket {
 
     public static class SockAddr extends Structure {
 
-        public short sunFamily;
-        public byte[] sunPath;
+        @SuppressWarnings("checkstyle:membername")
+        public short sun_family;
+        @SuppressWarnings("checkstyle:membername")
+        public byte[] sun_path;
 
         /**
          * Contructor.
@@ -211,10 +213,10 @@ class UnixDomainSocket extends Socket {
          * @param sunPath path
          */
         SockAddr(String sunPath) {
-            sunFamily = AF_UNIX;
+            sun_family = AF_UNIX;
             byte[] arr = sunPath.getBytes();
-            this.sunPath = new byte[arr.length + 1];
-            System.arraycopy(arr, 0, this.sunPath, 0, Math.min(this.sunPath.length - 1, arr.length));
+            sun_path = new byte[arr.length + 1];
+            System.arraycopy(arr, 0, sun_path, 0, Math.min(sun_path.length - 1, arr.length));
             allocateMemory();
         }
 

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/UnixSocketFactory.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/UnixSocketFactory.java
@@ -14,7 +14,7 @@ class UnixSocketFactory extends SocketFactory {
 
     private final String socketPath;
 
-    public UnixSocketFactory(String socketPath) {
+    UnixSocketFactory(String socketPath) {
         this.socketPath = socketPath;
     }
 

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/UnixSocketFactory.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/UnixSocketFactory.java
@@ -1,0 +1,88 @@
+package com.github.dockerjava.okhttp;
+
+import javax.net.SocketFactory;
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+
+class UnixSocketFactory extends SocketFactory {
+
+    private final String socketPath;
+
+    public UnixSocketFactory(String socketPath) {
+        this.socketPath = socketPath;
+    }
+
+    @Override
+    public Socket createSocket() {
+        try {
+            return new UnixDomainSocket(socketPath) {
+                @Override
+                public void connect(SocketAddress endpoint, int timeout) throws IOException {
+                    super.connect(endpoint, timeout);
+                }
+
+                @Override
+                public InputStream getInputStream() {
+                    return new FilterInputStream(super.getInputStream()) {
+                        @Override
+                        public void close() throws IOException {
+                            shutdownInput();
+                        }
+
+                        @Override
+                        public int read(byte[] b, int off, int len) throws IOException {
+                            if (OkHttpInvocationBuilder.CLOSING.get()) {
+                                return 0;
+                            }
+                            return super.read(b, off, len);
+                        }
+                    };
+                }
+
+                @Override
+                public OutputStream getOutputStream() {
+                    return new FilterOutputStream(super.getOutputStream()) {
+
+                        @Override
+                        public void write(byte[] b, int off, int len) throws IOException {
+                            out.write(b, off, len);
+                        }
+
+                        @Override
+                        public void close() throws IOException {
+                            shutdownOutput();
+                        }
+                    };
+                }
+            };
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Socket createSocket(String s, int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Socket createSocket(String s, int i, InetAddress inetAddress, int i1) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Socket createSocket(InetAddress inetAddress, int i) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Socket createSocket(InetAddress inetAddress, int i, InetAddress inetAddress1, int i1) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/docker-java/pom.xml
+++ b/docker-java/pom.xml
@@ -40,6 +40,12 @@
 
 		<!-- /// Test /////////////////////////// -->
 		<dependency>
+			<groupId>${groupId}</groupId>
+			<artifactId>docker-java-transport-okhttp</artifactId>
+			<version>${version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-core</artifactId>
 			<version>${logback.version}</version>

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
@@ -6,6 +6,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.StreamType;
 import com.github.dockerjava.core.command.AttachContainerResultCallback;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -32,7 +33,6 @@ import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeThat;
 
 /**
  * @author Kanstantsin Shautsou
@@ -48,7 +48,7 @@ public class AttachContainerCmdIT extends CmdIT {
     public void attachContainerWithStdin() throws Exception {
         DockerClient dockerClient = dockerRule.getClient();
 
-        assumeThat(getFactoryType(), is(FactoryType.NETTY));
+        Assume.assumeTrue("supports stdin attach", getFactoryType().supportsStdinAttach());
 
         String snippet = "hello world";
 
@@ -172,9 +172,8 @@ public class AttachContainerCmdIT extends CmdIT {
     public void attachContainerStdinUnsupported() throws Exception {
 
         DockerClient dockerClient = dockerRule.getClient();
-        if (getFactoryType() == FactoryType.JERSEY) {
-            expectedException.expect(UnsupportedOperationException.class);
-        }
+        Assume.assumeFalse("does not support stdin attach", getFactoryType().supportsStdinAttach());
+        expectedException.expect(UnsupportedOperationException.class);
 
         String snippet = "hello world";
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CmdIT.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 
 import static com.github.dockerjava.cmd.CmdIT.FactoryType.JERSEY;
 import static com.github.dockerjava.cmd.CmdIT.FactoryType.NETTY;
+import static com.github.dockerjava.cmd.CmdIT.FactoryType.OKHTTP;
 
 /**
  * @author Kanstantsin Shautsou
@@ -19,13 +20,13 @@ import static com.github.dockerjava.cmd.CmdIT.FactoryType.NETTY;
 @RunWith(Parameterized.class)
 public abstract class CmdIT {
     public enum FactoryType {
-        NETTY, JERSEY
+        NETTY, JERSEY, OKHTTP
     }
 
     @Parameterized.Parameters(name = "{index}:{0}")
     public static Iterable<FactoryType> data() {
         return Arrays.asList(
-                NETTY, JERSEY
+                NETTY, JERSEY,OKHTTP
         );
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CmdIT.java
@@ -1,7 +1,11 @@
 package com.github.dockerjava.cmd;
 
+import com.github.dockerjava.api.command.DockerCmdExecFactory;
+import com.github.dockerjava.jaxrs.JerseyDockerCmdExecFactory;
 import com.github.dockerjava.junit.DockerRule;
 import com.github.dockerjava.junit.category.Integration;
+import com.github.dockerjava.netty.NettyDockerCmdExecFactory;
+import com.github.dockerjava.okhttp.OkHttpDockerCmdExecFactory;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -20,7 +24,42 @@ import static com.github.dockerjava.cmd.CmdIT.FactoryType.OKHTTP;
 @RunWith(Parameterized.class)
 public abstract class CmdIT {
     public enum FactoryType {
-        NETTY, JERSEY, OKHTTP
+        NETTY(true) {
+            @Override
+            public DockerCmdExecFactory createExecFactory() {
+                return new NettyDockerCmdExecFactory().withConnectTimeout(10 * 1000);
+            }
+        },
+        JERSEY(false) {
+            @Override
+            public DockerCmdExecFactory createExecFactory() {
+                return new JerseyDockerCmdExecFactory().withConnectTimeout(10 * 1000);
+            }
+        },
+        OKHTTP(true) {
+            @Override
+            public DockerCmdExecFactory createExecFactory() {
+                return new OkHttpDockerCmdExecFactory();
+            }
+        };
+
+        private final String subnetPrefix;
+        private final boolean supportsStdinAttach;
+
+        FactoryType(boolean supportsStdinAttach) {
+            this.subnetPrefix = "10." + (100 + ordinal()) + ".";
+            this.supportsStdinAttach = supportsStdinAttach;
+        }
+
+        public String getSubnetPrefix() {
+            return subnetPrefix;
+        }
+
+        public boolean supportsStdinAttach() {
+            return supportsStdinAttach;
+        }
+
+        public abstract DockerCmdExecFactory createExecFactory();
     }
 
     @Parameterized.Parameters(name = "{index}:{0}")

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CmdIT.java
@@ -26,7 +26,7 @@ public abstract class CmdIT {
     @Parameterized.Parameters(name = "{index}:{0}")
     public static Iterable<FactoryType> data() {
         return Arrays.asList(
-                NETTY, JERSEY,OKHTTP
+                NETTY, JERSEY, OKHTTP
         );
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/ConnectToNetworkCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/ConnectToNetworkCmdIT.java
@@ -9,7 +9,6 @@ import com.github.dockerjava.api.model.Network;
 import net.jcip.annotations.ThreadSafe;
 import org.junit.Test;
 
-import static com.github.dockerjava.cmd.CmdIT.FactoryType.JERSEY;
 import static com.github.dockerjava.junit.DockerAssume.assumeNotSwarm;
 import static com.github.dockerjava.junit.DockerRule.DEFAULT_IMAGE;
 import static org.hamcrest.Matchers.hasItem;
@@ -49,7 +48,7 @@ public class ConnectToNetworkCmdIT extends CmdIT {
     public void connectToNetworkWithContainerNetwork() throws InterruptedException {
         assumeNotSwarm("no network in swarm", dockerRule);
 
-        final String subnetPrefix = getFactoryType() == JERSEY ?  "10.100.102" : "10.100.103";
+        final String subnetPrefix = getFactoryType().getSubnetPrefix() + "100";
         final String networkName = "ContainerWithNetwork" + dockerRule.getKind();
         final String containerIp = subnetPrefix + ".100";
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveFromContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveFromContainerCmdIT.java
@@ -43,8 +43,6 @@ public class CopyArchiveFromContainerCmdIT extends CmdIT {
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
 
         InputStream response = dockerRule.getClient().copyArchiveFromContainerCmd(container.getId(), "/copyFromContainer").exec();
-        Boolean bytesAvailable = response.available() > 0;
-        assertTrue("The file was not copied from the container.", bytesAvailable );
 
         // read the stream fully. Otherwise, the underlying stream will not be closed.
         String responseAsString = TestUtils.asString(response);
@@ -76,8 +74,6 @@ public class CopyArchiveFromContainerCmdIT extends CmdIT {
         }
 
         InputStream response = dockerRule.getClient().copyArchiveFromContainerCmd(container.getId(), "/binary.dat").exec();
-        Boolean bytesAvailable = response.available() > 0;
-        assertTrue("The file was not copied from the container.", bytesAvailable);
 
         try (TarArchiveInputStream tarInputStream = new TarArchiveInputStream(response)) {
             TarArchiveEntry nextTarEntry = tarInputStream.getNextTarEntry();

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveToContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveToContainerCmdIT.java
@@ -72,7 +72,7 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
 
     private void assertFileCopied(CreateContainerResponse container) throws IOException {
         try (InputStream response = dockerRule.getClient().copyArchiveFromContainerCmd(container.getId(), "testReadFile").exec()) {
-            boolean bytesAvailable = response.available() > 0;
+            boolean bytesAvailable = response.read() != -1;
             assertTrue( "The file was not copied to the container.", bytesAvailable);
         }
     }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CopyFileFromContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CopyFileFromContainerCmdIT.java
@@ -43,8 +43,6 @@ public class CopyFileFromContainerCmdIT extends CmdIT {
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
 
         InputStream response = dockerRule.getClient().copyFileFromContainerCmd(container.getId(), "/copyFileFromContainer").exec();
-        Boolean bytesAvailable = response.available() > 0;
-        assertTrue("The file was not copied from the container.", bytesAvailable );
 
         // read the stream fully. Otherwise, the underlying stream will not be closed.
         String responseAsString = asString(response);

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CreateContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CreateContainerCmdIT.java
@@ -49,7 +49,6 @@ import java.util.concurrent.TimeUnit;
 import static com.github.dockerjava.api.model.Capability.MKNOD;
 import static com.github.dockerjava.api.model.Capability.NET_ADMIN;
 import static com.github.dockerjava.api.model.HostConfig.newHostConfig;
-import static com.github.dockerjava.cmd.CmdIT.FactoryType.JERSEY;
 import static com.github.dockerjava.core.RemoteApiVersion.VERSION_1_23;
 import static com.github.dockerjava.core.RemoteApiVersion.VERSION_1_24;
 import static com.github.dockerjava.junit.DockerMatchers.isGreaterOrEqual;
@@ -483,7 +482,7 @@ public class CreateContainerCmdIT extends CmdIT {
     public void createContainerWithCustomIp() throws DockerException {
         String containerName1 = "containerCustomIplink_" + dockerRule.getKind();
         String networkName = "customIpNet" + dockerRule.getKind();
-        String subnetPrefix = getFactoryType() == JERSEY ? "10.100.104" : "10.100.105";
+        String subnetPrefix = getFactoryType().getSubnetPrefix() + "101";
 
         CreateNetworkResponse createNetworkResponse = dockerRule.getClient().createNetworkCmd()
                 .withIpam(new Network.Ipam()
@@ -646,7 +645,7 @@ public class CreateContainerCmdIT extends CmdIT {
 
     @Test
     public void createContainerWithPortBindings() throws DockerException {
-        int baseport = getFactoryType() == FactoryType.JERSEY ? 11000 : 12000;
+        int baseport = 10_000 + (getFactoryType().ordinal() * 1000);
 
         ExposedPort tcp22 = ExposedPort.tcp(22);
         ExposedPort tcp23 = ExposedPort.tcp(23);

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CreateNetworkCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CreateNetworkCmdIT.java
@@ -44,7 +44,7 @@ public class CreateNetworkCmdIT extends CmdIT {
         assumeNotSwarm("no network in swarm", dockerRule);
 
         String networkName = "networkIpam" + dockerRule.getKind();
-        String subnet = getFactoryType() == FactoryType.JERSEY ? "10.67.79.0/24" : "10.67.90.0/24";
+        String subnet = "10.67." + (79 + getFactoryType().ordinal()) + ".0/24";
 
         Network.Ipam ipam = new Network.Ipam().withConfig(new Network.Ipam.Config().withSubnet(subnet));
         CreateNetworkResponse createNetworkResponse = dockerRule.getClient().createNetworkCmd().withName(networkName).withIpam(ipam).exec();

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/ExecStartCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/ExecStartCmdIT.java
@@ -45,8 +45,6 @@ public class ExecStartCmdIT extends CmdIT {
                 .awaitCompletion();
 
         InputStream response = dockerRule.getClient().copyArchiveFromContainerCmd(container.getId(), "/execStartTest.log").exec();
-        Boolean bytesAvailable = response.available() > 0;
-        assertTrue("The file was not copied from the container.", bytesAvailable);
 
         // read the stream fully. Otherwise, the underlying stream will not be closed.
         String responseAsString = asString(response);
@@ -71,8 +69,6 @@ public class ExecStartCmdIT extends CmdIT {
                 .exec(new ExecStartResultCallback(System.out, System.err)).awaitCompletion();
 
         InputStream response = dockerRule.getClient().copyArchiveFromContainerCmd(container.getId(), "/execStartTest.log").exec();
-        Boolean bytesAvailable = response.available() > 0;
-        assertTrue( "The file was not copied from the container.", bytesAvailable);
 
         // read the stream fully. Otherwise, the underlying stream will not be closed.
         String responseAsString = asString(response);

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/SaveImageCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/SaveImageCmdIT.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
 
 public class SaveImageCmdIT extends CmdIT {
     public static final Logger LOG = LoggerFactory.getLogger(SaveImageCmdIT.class);
@@ -17,10 +17,10 @@ public class SaveImageCmdIT extends CmdIT {
     public void saveImage() throws Exception {
 
         InputStream image = IOUtils.toBufferedInputStream(dockerRule.getClient().saveImageCmd("busybox").exec());
-        assertThat(image.available(), greaterThan(0));
+        assertThat(image.read(), not(-1));
 
         InputStream image2 = IOUtils.toBufferedInputStream(dockerRule.getClient().saveImageCmd("busybox").withTag("latest").exec());
-        assertThat(image2.available(), greaterThan(0));
+        assertThat(image2.read(), not(-1));
 
 
     }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/StartContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/StartContainerCmdIT.java
@@ -172,7 +172,7 @@ public class StartContainerCmdIT extends CmdIT {
 
     @Test
     public void startContainerWithPortBindings() throws DockerException {
-        int baseport = getFactoryType() == FactoryType.JERSEY ? 13000 : 14000;
+        int baseport = 20_000 + (getFactoryType().ordinal() * 1000);
 
         ExposedPort tcp22 = ExposedPort.tcp(22);
         ExposedPort tcp23 = ExposedPort.tcp(23);

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/SwarmCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/SwarmCmdIT.java
@@ -13,10 +13,8 @@ import com.github.dockerjava.cmd.CmdIT;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientBuilder;
 import com.github.dockerjava.core.command.PullImageResultCallback;
-import com.github.dockerjava.jaxrs.JerseyDockerCmdExecFactory;
 import com.github.dockerjava.junit.category.Integration;
 import com.github.dockerjava.junit.category.SwarmModeIntegration;
-import com.github.dockerjava.netty.NettyDockerCmdExecFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
@@ -121,7 +119,7 @@ public abstract class SwarmCmdIT extends CmdIT {
                 .withRegistryUrl("https://index.docker.io/v1/")
                 .withDockerHost("tcp://localhost:" + port).build();
         return DockerClientBuilder.getInstance(config)
-                .withDockerCmdExecFactory(getFactoryType() == FactoryType.NETTY ? new NettyDockerCmdExecFactory() : new JerseyDockerCmdExecFactory())
+                .withDockerCmdExecFactory(getFactoryType().createExecFactory())
                 .build();
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/netty/handler/HttpResponseStreamHandlerTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/netty/handler/HttpResponseStreamHandlerTest.java
@@ -93,7 +93,7 @@ public class HttpResponseStreamHandlerTest {
         });
 
         firstWrite.await();
-        assertTrue(inputStream.available() > 0);
+        assertTrue(inputStream.read() != -1);
 
         // second write should have started
         Thread.sleep(500L);

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
 		<module>docker-java-core</module>
 		<module>docker-java-transport-netty</module>
 		<module>docker-java-transport-jersey</module>
+		<module>docker-java-transport-okhttp</module>
 		<module>docker-java</module>
 	</modules>
 


### PR DESCRIPTION
This is a backport of the OkHttp transport from http://github.com/testcontainers/testcontainers-java

OkHttp provides a lightweight API, supports the same feature set as Netty does but also has Windows Npipe support since it can use Java's Socket abstraction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1284)
<!-- Reviewable:end -->
