### PR TITLE
Allow multiple TAR streams when Building Image

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
@@ -214,7 +214,7 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
     BuildImageCmd withNetworkMode(String networkMode);
 
     /**
-     *@since {@link RemoteApiVersion#VERSION_1_32}
+     * @since {@link RemoteApiVersion#VERSION_1_32}
      */
     BuildImageCmd withPlatform(String platform);
 

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/async/JsonStreamProcessor.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/async/JsonStreamProcessor.java
@@ -39,7 +39,8 @@ public class JsonStreamProcessor<T> implements ResponseStreamProcessor<T> {
 
     public JsonStreamProcessor(ObjectMapper objectMapper, TypeReference<T> typeReference) {
         this.typeReference = typeReference;
-        this.objectMapper = objectMapper.copy().enable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
+        this.objectMapper = objectMapper.copy()
+                .enable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
     }
 
     @Override

--- a/docker-java-transport-jersey/pom.xml
+++ b/docker-java-transport-jersey/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpcore</artifactId>
-			<version>4.4.10</version>
+			<version>4.4.12</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/BuildImageCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/BuildImageCmdIT.java
@@ -87,6 +87,16 @@ public class BuildImageCmdIT extends CmdIT {
     }
 
     @Test
+    public void buildImageFromSpecifiedDockerfileWithFilesFromDirectory() throws Exception {
+        File baseDir = fileFromBuildTestResource("dockerfileAndCustomFiles");
+        File filesDir = new File(baseDir, "filesToAddFolder");
+        Collection<File> files = FileUtils.listFiles(filesDir, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
+        File tarFile = CompressArchiveUtil.archiveTARFiles(filesDir, files, UUID.randomUUID().toString());
+        String response = dockerfileBuild(new FileInputStream(tarFile), new File(baseDir, "dockerfileFolder/Dockerfile"));
+        assertThat(response, containsString("Successfully executed testrun.sh"));
+    }
+
+    @Test
     public void onBuild() throws Exception {
         File baseDir = fileFromBuildTestResource("ONBUILD/parent");
 
@@ -133,6 +143,11 @@ public class BuildImageCmdIT extends CmdIT {
     private String dockerfileBuild(InputStream tarInputStream, String dockerFilePath) throws Exception {
 
         return execBuild(dockerRule.getClient().buildImageCmd().withTarInputStream(tarInputStream).withDockerfilePath(dockerFilePath));
+    }
+
+    private String dockerfileBuild(InputStream tarInputStream, File dockerFile) throws Exception {
+
+        return execBuild(dockerRule.getClient().buildImageCmd(tarInputStream).withDockerfile(dockerFile));
     }
 
     private String dockerfileBuild(InputStream tarInputStream) throws Exception {

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CmdIT.java
@@ -71,6 +71,6 @@ public abstract class CmdIT {
     }
 
     @Rule
-    public DockerRule dockerRule = new DockerRule( this);
+    public DockerRule dockerRule = new DockerRule(this);
 
 }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/SaveImageCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/SaveImageCmdIT.java
@@ -21,8 +21,5 @@ public class SaveImageCmdIT extends CmdIT {
 
         InputStream image2 = IOUtils.toBufferedInputStream(dockerRule.getClient().saveImageCmd("busybox").withTag("latest").exec());
         assertThat(image2.read(), not(-1));
-
-
     }
-
 }

--- a/docker-java/src/test/resources/buildTests/dockerfileAndCustomFiles/dockerfileFolder/Dockerfile
+++ b/docker-java/src/test/resources/buildTests/dockerfileAndCustomFiles/dockerfileFolder/Dockerfile
@@ -1,0 +1,8 @@
+FROM busybox:latest
+
+ADD	testrun.sh       /tmp/
+
+RUN mkdir -p /usr/local/bin
+RUN cp /tmp/testrun.sh /usr/local/bin/ && chmod +x /usr/local/bin/testrun.sh
+
+CMD ["testrun.sh"]

--- a/docker-java/src/test/resources/buildTests/dockerfileAndCustomFiles/filesToAddFolder/testrun.sh
+++ b/docker-java/src/test/resources/buildTests/dockerfileAndCustomFiles/filesToAddFolder/testrun.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Successfully executed testrun.sh"

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
 					<plugin>
 						<groupId>org.jacoco</groupId>
 						<artifactId>jacoco-maven-plugin</artifactId>
-						<version>0.8.1</version>
+						<version>0.8.5</version>
 						<executions>
 							<execution>
 								<goals>


### PR DESCRIPTION
Hi, 
I found that I am unable to build image with multiple tar streams. It is because calling `client.buildImageCmd(tarInputStream).withDockerfile(file)` calls two times method `withTarInputStream` with result that only last one is used (first is overwriten by second).
My use-case is: I have to use `withDockerfile(..)` method with path to custom Dockerfile also sending custom files to daemon necessary for build.
Please check PR,
Ivos

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1301)
<!-- Reviewable:end -->
