### PR TITLE
Make Ulimit use Long to hold soft/hard values exceeding Integer bounds

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Ulimit.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Ulimit.java
@@ -1,6 +1,9 @@
 package com.github.dockerjava.api.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -11,6 +14,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @author Vangie Du (duwan@live.com)
  */
+@JsonPropertyOrder({"Name", "Soft", "Hard"})
 @EqualsAndHashCode
 @ToString
 public class Ulimit implements Serializable {
@@ -19,16 +23,20 @@ public class Ulimit implements Serializable {
     @JsonProperty("Name")
     private String name;
 
-    @JsonProperty("Soft")
-    private Integer soft;
+    private Long soft;
 
-    @JsonProperty("Hard")
-    private Integer hard;
+    private Long hard;
 
     public Ulimit() {
     }
 
+    @Deprecated
     public Ulimit(String name, int soft, int hard) {
+        this(name, (long) soft, (long) hard);
+    }
+
+    @JsonCreator
+    public Ulimit(@JsonProperty("Name") String name, @JsonProperty("Soft") long soft, @JsonProperty("Hard") long hard) {
         requireNonNull(name, "Name is null");
         this.name = name;
         this.soft = soft;
@@ -39,11 +47,25 @@ public class Ulimit implements Serializable {
         return name;
     }
 
+    @Deprecated
+    @JsonIgnore
     public Integer getSoft() {
+        return soft != null ? soft.intValue() : null;
+    }
+
+    @Deprecated
+    @JsonIgnore
+    public Integer getHard() {
+        return hard != null ? hard.intValue() : null;
+    }
+
+    @JsonProperty("Soft")
+    public Long getSoftLong() {
         return soft;
     }
 
-    public Integer getHard() {
+    @JsonProperty("Hard")
+    public Long getHardLong() {
         return hard;
     }
 }

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/UlimitsTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/UlimitsTest.java
@@ -1,0 +1,36 @@
+package com.github.dockerjava.api.model;
+
+import com.github.dockerjava.test.serdes.JSONTestHelper;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class UlimitsTest {
+
+    @Test
+    public void usesToJson() throws Exception {
+        Ulimit[] ulimits = new Ulimit[]{
+                new Ulimit("nproc", 709, 1026),
+                new Ulimit("nofile", 1024, 4096),
+                new Ulimit("core", 99999999998L, 99999999999L)
+        };
+        String json = JSONTestHelper.getMapper().writeValueAsString(ulimits);
+
+        assertThat(json, is("[{\"Name\":\"nproc\",\"Soft\":709,\"Hard\":1026},{\"Name\":\"nofile\",\"Soft\":1024,\"Hard\":4096},{\"Name\":\"core\",\"Soft\":99999999998,\"Hard\":99999999999}]"));
+    }
+
+    @Test
+    public void usesFromJson() throws Exception {
+        Ulimit[] ulimits = JSONTestHelper.getMapper().readValue("[{\"Name\":\"nproc\",\"Soft\":709,\"Hard\":1026},{\"Name\":\"nofile\",\"Soft\":1024,\"Hard\":4096},{\"Name\":\"core\",\"Soft\":99999999998,\"Hard\":99999999999}]", Ulimit[].class);
+
+        assertThat(ulimits, notNullValue());
+        assertThat(ulimits, arrayContaining(
+                new Ulimit("nproc", 709, 1026),
+                new Ulimit("nofile", 1024, 4096),
+                new Ulimit("core", 99999999998L, 99999999999L)
+        ));
+    }
+}

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CreateContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CreateContainerCmdIT.java
@@ -832,6 +832,28 @@ public class CreateContainerCmdIT extends CmdIT {
     }
 
     @Test
+    public void createContainerWithIntegerBoundsExceedingULimit() throws DockerException {
+        String containerName = "containercoreulimit" + dockerRule.getKind();
+        Ulimit[] ulimits = {new Ulimit("core", 99999999998L, 99999999999L)};
+
+        CreateContainerResponse container = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
+                .withName(containerName)
+                .withHostConfig(newHostConfig()
+                        .withUlimits(ulimits))
+                .exec();
+
+        LOG.info("Created container {}", container.toString());
+
+        assertThat(container.getId(), not(isEmptyString()));
+
+        InspectContainerResponse inspectContainerResponse = dockerRule.getClient().inspectContainerCmd(container.getId()).exec();
+
+        assertThat(Arrays.asList(inspectContainerResponse.getHostConfig().getUlimits()),
+                contains(new Ulimit("core", 99999999998L, 99999999999L)));
+
+    }
+
+    @Test
     public void createContainerWithLabels() throws DockerException {
 
         Map<String, String> labels = new HashMap<>();


### PR DESCRIPTION
- core ulimits can exceed integer bounds
- preserve binary compatibility of Ulimit class so that API doesn't break
- preserve JSON serdes of Ulimit class
- fixes #1088

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1302)
<!-- Reviewable:end -->
