### PR TITLE
add support for DeviceRequests parameter

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/DeviceRequest.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/DeviceRequest.java
@@ -1,0 +1,75 @@
+package com.github.dockerjava.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+@EqualsAndHashCode
+@ToString
+public class DeviceRequest implements Serializable {
+    public static final long serialVersionUID = 1L;
+
+    @JsonProperty("Driver")
+    private String driver;
+
+    @JsonProperty("Count")
+    private Integer count;
+
+    @JsonProperty("DeviceIDs")
+    private List<String> deviceIds;
+
+    @JsonProperty("Capabilities")
+    private List<List<String>> capabilities;
+
+    @JsonProperty("Options")
+    private Map<String, String> options;
+
+    public String getDriver() {
+        return driver;
+    }
+
+    public DeviceRequest withDriver(String driver) {
+        this.driver = driver;
+        return this;
+    }
+
+    public Integer getCount() {
+        return count;
+    }
+
+    public DeviceRequest withCount(Integer count) {
+        this.count = count;
+        return this;
+    }
+
+    public List<String> getDeviceIds() {
+        return deviceIds;
+    }
+
+    public DeviceRequest withDeviceIds(List<String> deviceIds) {
+        this.deviceIds = deviceIds;
+        return this;
+    }
+
+    public List<List<String>> getCapabilities() {
+        return capabilities;
+    }
+
+    public DeviceRequest withCapabilities(List<List<String>> capabilities) {
+        this.capabilities = capabilities;
+        return this;
+    }
+
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    public DeviceRequest withOptions(Map<String, String> options) {
+        this.options = options;
+        return this;
+    }
+}

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/HostConfig.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/HostConfig.java
@@ -113,6 +113,12 @@ public class HostConfig implements Serializable {
     private List<String> deviceCgroupRules;
 
     /**
+     * @since {@link com.github.dockerjava.core.RemoteApiVersion#VERSION_1_40}
+     */
+    @JsonProperty("DeviceRequests")
+    private List<DeviceRequest> deviceRequests;
+
+    /**
      * @since {@link RemoteApiVersion#VERSION_1_25}
      */
     @JsonProperty("DiskQuota")
@@ -1034,6 +1040,16 @@ public class HostConfig implements Serializable {
 
     public HostConfig withDeviceCgroupRules(List<String> deviceCgroupRules) {
         this.deviceCgroupRules = deviceCgroupRules;
+        return this;
+    }
+
+    @CheckForNull
+    public List<DeviceRequest> getDeviceRequests() {
+        return deviceRequests;
+    }
+
+    public HostConfig withDeviceRequests(List<DeviceRequest> deviceRequests) {
+        this.deviceRequests = deviceRequests;
         return this;
     }
 

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/RemoteApiVersion.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/RemoteApiVersion.java
@@ -89,6 +89,7 @@ public class RemoteApiVersion implements Serializable {
     public static final RemoteApiVersion VERSION_1_36 = RemoteApiVersion.create(1, 36);
     public static final RemoteApiVersion VERSION_1_37 = RemoteApiVersion.create(1, 37);
     public static final RemoteApiVersion VERSION_1_38 = RemoteApiVersion.create(1, 38);
+    public static final RemoteApiVersion VERSION_1_40 = RemoteApiVersion.create(1, 40);
 
 
     /**


### PR DESCRIPTION
This should allow users to support the "--gpus" option as per https://github.com/docker-java/docker-java/issues/1273

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1303)
<!-- Reviewable:end -->
