### PR TITLE
Add local enum value to LoggingType

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/LogConfig.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/LogConfig.java
@@ -62,6 +62,7 @@ public class LogConfig implements Serializable {
     public enum LoggingType {
         NONE("none"),
         DEFAULT("json-file"),
+        LOCAL("local"),
         ETWLOGS("etwlogs"),
         JSON_FILE("json-file"),
         SYSLOG("syslog"),


### PR DESCRIPTION
Adds the `local` log driver as one of the available options to `LogConfig.LoggingType`.

Fixes #1306

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1307)
<!-- Reviewable:end -->
