### PR TITLE
Bump Jersey to 2.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<jdk.source>1.8</jdk.source>
 		<jdk.target>1.8</jdk.target>
 
-		<jersey.version>2.27</jersey.version>
+		<jersey.version>2.30</jersey.version>
 		<jackson.version>2.9.8</jackson.version>
 		<jackson-jaxrs.version>2.9.8</jackson-jaxrs.version>
 		<httpclient.version>4.5.6</httpclient.version><!-- 4.5.1-4.5.2 broken -->


### PR DESCRIPTION
Hi,
as described here https://github.com/docker-java/docker-java/issues/698#issuecomment-572228590 bumping Jersey to latest version fixes `ChunkedInputStream` vs `ObjectMapper` CRLF error.
Hope is it ok like this.
Ivos

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1308)
<!-- Reviewable:end -->
