### PR TITLE
Fix type of `network` field Statistics.java

### DIFF
--- a/docker-java-api/pom.xml
+++ b/docker-java-api/pom.xml
@@ -89,6 +89,7 @@
 							<!-- Known 3.2.0 breaking changes: -->
 							<exclude>com.github.dockerjava.api.command.DockerCmdExecFactory#init(com.github.dockerjava.core.DockerClientConfig)</exclude>
 							<exclude>com.github.dockerjava.api.model.Identifier#tag</exclude>
+							<exclude>com.github.dockerjava.api.model.Statistics#getNetwork()</exclude>
 						</excludes>
 						<overrideCompatibilityChangeParameters>
 							<overrideCompatibilityChangeParameter>

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Statistics.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Statistics.java
@@ -32,7 +32,7 @@ public class Statistics implements Serializable {
      */
     @Deprecated
     @JsonProperty("network")
-    private Map<String, StatisticNetworksConfig> network;
+    private StatisticNetworksConfig network;
 
     @JsonProperty("memory_stats")
     private MemoryStatsConfig memoryStats;
@@ -71,7 +71,7 @@ public class Statistics implements Serializable {
      * @deprecated as of Docker Remote API 1.21, replaced by {@link #getNetworks()}
      */
     @Deprecated
-    public Map<String, StatisticNetworksConfig> getNetwork() {
+    public StatisticNetworksConfig getNetwork() {
         return network;
     }
 


### PR DESCRIPTION
As per the documentation (https://docs.docker.com/engine/api/v1.19/), the type of `network` field is incorrect in `Statistics.java`. Fixing that to match the correct type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1316)
<!-- Reviewable:end -->
