### PR TITLE
Move callbacks to the API package, add `ResultCallback.Adapter`

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/async/ResultCallback.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/async/ResultCallback.java
@@ -6,6 +6,14 @@ import java.io.Closeable;
  * Result callback
  */
 public interface ResultCallback<A_RES_T> extends Closeable {
+
+    class Adapter<A_RES_T> extends ResultCallbackTemplate<Adapter<A_RES_T>, A_RES_T> {
+        @Override
+        public void onNext(A_RES_T object) {
+
+        }
+    }
+
     /**
      * Called when the async processing starts respectively when the response arrives from the server. The passed {@link Closeable} can be
      * used to close/interrupt the processing.

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/AsyncDockerCmd.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/AsyncDockerCmd.java
@@ -4,6 +4,7 @@
 package com.github.dockerjava.api.command;
 
 import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.async.ResultCallbackTemplate;
 
 /**
  *
@@ -15,4 +16,7 @@ public interface AsyncDockerCmd<CMD_T extends AsyncDockerCmd<CMD_T, A_RES_T>, A_
 
     <T extends ResultCallback<A_RES_T>> T exec(T resultCallback);
 
+    default ResultCallbackTemplate<?, A_RES_T> start() {
+        return exec(new ResultCallback.Adapter<>());
+    }
 }

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/BuildImageCmd.java
@@ -223,6 +223,11 @@ public interface BuildImageCmd extends AsyncDockerCmd<BuildImageCmd, BuildRespon
      */
     BuildImageCmd withTarget(String target);
 
+    @Override
+    default BuildImageResultCallback start() {
+        return exec(new BuildImageResultCallback());
+    }
+
     interface Exec extends DockerCmdAsyncExec<BuildImageCmd, BuildResponseItem> {
     }
 

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/BuildImageResultCallback.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/BuildImageResultCallback.java
@@ -1,23 +1,21 @@
 /*
  * Created on 21.07.2015
  */
-package com.github.dockerjava.core.command;
+package com.github.dockerjava.api.command;
 
-import java.util.concurrent.TimeUnit;
-
+import com.github.dockerjava.api.async.ResultCallbackTemplate;
+import com.github.dockerjava.api.exception.DockerClientException;
+import com.github.dockerjava.api.model.BuildResponseItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.exception.DockerClientException;
-import com.github.dockerjava.api.model.BuildResponseItem;
-import com.github.dockerjava.core.async.ResultCallbackTemplate;
+import java.util.concurrent.TimeUnit;
 
 /**
  *
  * @author Marcus Linke
  *
  */
-@Deprecated
 public class BuildImageResultCallback extends ResultCallbackTemplate<BuildImageResultCallback, BuildResponseItem> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BuildImageResultCallback.class);

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/PullImageCmd.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/PullImageCmd.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.api.command;
 
+import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.PullResponseItem;
 
@@ -40,6 +41,11 @@ public interface PullImageCmd extends AsyncDockerCmd<PullImageCmd, PullResponseI
     PullImageCmd withRegistry(String registry);
 
     PullImageCmd withAuthConfig(AuthConfig authConfig);
+
+    @Override
+    default ResultCallback.Adapter<PullResponseItem> start() {
+        return exec(new PullImageResultCallback());
+    }
 
     interface Exec extends DockerCmdAsyncExec<PullImageCmd, PullResponseItem> {
     }

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/PullImageResultCallback.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/PullImageResultCallback.java
@@ -23,7 +23,7 @@ class PullImageResultCallback extends ResultCallback.Adapter<PullResponseItem> {
     private static final Logger LOGGER = LoggerFactory.getLogger(PullImageResultCallback.class);
 
     private boolean isSwarm = false;
-    private Map<String, PullResponseItem> results = null;InspectExecResponse
+    private Map<String, PullResponseItem> results = null;
 
     @CheckForNull
     private PullResponseItem latestItem = null;

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/PullImageResultCallback.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/PullImageResultCallback.java
@@ -1,31 +1,29 @@
 /*
  * Created on 21.07.2015
  */
-package com.github.dockerjava.core.command;
+package com.github.dockerjava.api.command;
 
+import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.model.PullResponseItem;
-import com.github.dockerjava.core.async.ResultCallbackTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckForNull;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  *
  * @author Marcus Linke
  *
  */
-@Deprecated
-public class PullImageResultCallback extends ResultCallbackTemplate<PullImageResultCallback, PullResponseItem> {
+class PullImageResultCallback extends ResultCallback.Adapter<PullResponseItem> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PullImageResultCallback.class);
 
     private boolean isSwarm = false;
-    private Map<String, PullResponseItem> results = null;
+    private Map<String, PullResponseItem> results = null;InspectExecResponse
 
     @CheckForNull
     private PullResponseItem latestItem = null;
@@ -110,21 +108,6 @@ public class PullImageResultCallback extends ResultCallbackTemplate<PullImageRes
             checkDockerSwarmPullSuccessful();
         } else {
             checkDockerClientPullSuccessful();
-        }
-    }
-
-    /**
-     * Awaits the image to be pulled successful.
-     *
-     * @deprecated use {@link #awaitCompletion()} or {@link #awaitCompletion(long, TimeUnit)} instead
-     * @throws DockerClientException
-     *             if the pull fails.
-     */
-    public void awaitSuccess() {
-        try {
-            awaitCompletion();
-        } catch (InterruptedException e) {
-            throw new DockerClientException("", e);
         }
     }
 }

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/PushImageCmd.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/PushImageCmd.java
@@ -2,8 +2,10 @@ package com.github.dockerjava.api.command;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.PushResponseItem;
@@ -45,6 +47,31 @@ public interface PushImageCmd extends AsyncDockerCmd<PushImageCmd, PushResponseI
      */
     @Override
     <T extends ResultCallback<PushResponseItem>> T exec(T resultCallback);
+
+    @Override
+    default ResultCallback.Adapter<PushResponseItem> start() {
+        return exec(new ResultCallback.Adapter<PushResponseItem>() {
+
+            @Nullable
+            private PushResponseItem latestItem = null;
+
+            @Override
+            public void onNext(PushResponseItem item) {
+                this.latestItem = item;
+            }
+
+            @Override
+            protected void throwFirstError() {
+                super.throwFirstError();
+
+                if (latestItem == null) {
+                    throw new DockerClientException("Could not push image");
+                } else if (latestItem.isErrorIndicated()) {
+                    throw new DockerClientException("Could not push image: " + latestItem.getError());
+                }
+            }
+        });
+    }
 
     interface Exec extends DockerCmdAsyncExec<PushImageCmd, PushResponseItem> {
     }

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/WaitContainerCmd.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/WaitContainerCmd.java
@@ -26,6 +26,11 @@ public interface WaitContainerCmd extends AsyncDockerCmd<WaitContainerCmd, WaitR
     @Override
     <T extends ResultCallback<WaitResponse>> T exec(T resultCallback);
 
+    @Override
+    default WaitContainerResultCallback start() {
+        return exec(new WaitContainerResultCallback());
+    }
+
     interface Exec extends DockerCmdAsyncExec<WaitContainerCmd, WaitResponse> {
     }
 

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/WaitContainerResultCallback.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/WaitContainerResultCallback.java
@@ -1,25 +1,22 @@
 /*
  * Created on 21.07.2015
  */
-package com.github.dockerjava.core.command;
+package com.github.dockerjava.api.command;
 
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.CheckForNull;
-
+import com.github.dockerjava.api.async.ResultCallbackTemplate;
+import com.github.dockerjava.api.exception.DockerClientException;
+import com.github.dockerjava.api.model.WaitResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.dockerjava.api.exception.DockerClientException;
-import com.github.dockerjava.api.model.WaitResponse;
-import com.github.dockerjava.core.async.ResultCallbackTemplate;
+import javax.annotation.CheckForNull;
+import java.util.concurrent.TimeUnit;
 
 /**
  *
  * @author Marcus Linke
  *
  */
-@Deprecated
 public class WaitContainerResultCallback extends ResultCallbackTemplate<WaitContainerResultCallback, WaitResponse> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WaitContainerResultCallback.class);

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/AttachContainerResultCallback.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/AttachContainerResultCallback.java
@@ -14,6 +14,7 @@ import com.github.dockerjava.core.async.ResultCallbackTemplate;
  * @author Marcus Linke
  *
  */
+@Deprecated
 public class AttachContainerResultCallback extends ResultCallbackTemplate<AttachContainerResultCallback, Frame> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AttachContainerResultCallback.class);

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/EventsResultCallback.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/EventsResultCallback.java
@@ -14,6 +14,7 @@ import com.github.dockerjava.core.async.ResultCallbackTemplate;
  * @author Marcus Linke
  *
  */
+@Deprecated
 public class EventsResultCallback extends ResultCallbackTemplate<EventsResultCallback, Event> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EventsResultCallback.class);

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/ExecStartResultCallback.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/ExecStartResultCallback.java
@@ -14,6 +14,7 @@ import com.github.dockerjava.core.async.ResultCallbackTemplate;
  * @author Marcus Linke
  *
  */
+@Deprecated
 public class ExecStartResultCallback extends ResultCallbackTemplate<ExecStartResultCallback, Frame> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ExecStartResultCallback.class);

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/LogContainerResultCallback.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/LogContainerResultCallback.java
@@ -14,6 +14,7 @@ import com.github.dockerjava.core.async.ResultCallbackTemplate;
  * @author Marcus Linke
  *
  */
+@Deprecated
 public class LogContainerResultCallback extends ResultCallbackTemplate<LogContainerResultCallback, Frame> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LogContainerResultCallback.class);

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/PushImageResultCallback.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/PushImageResultCallback.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
  * @author Marcus Linke
  *
  */
+@Deprecated
 public class PushImageResultCallback extends ResultCallbackTemplate<PushImageResultCallback, PushResponseItem> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PushImageResultCallback.class);

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
@@ -1,11 +1,11 @@
 package com.github.dockerjava.cmd;
 
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.StreamType;
-import com.github.dockerjava.core.command.AttachContainerResultCallback;
 import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
@@ -207,7 +207,7 @@ public class AttachContainerCmdIT extends CmdIT {
     }
 
     /**
-     * {@link AttachContainerResultCallback#onComplete()} should be called immediately after
+     * {@link ResultCallback#onComplete()} should be called immediately after
      * container exit. It was broken for Netty and TLS connection.
      */
     @Test
@@ -222,11 +222,11 @@ public class AttachContainerCmdIT extends CmdIT {
 
         CountDownLatch gotLine = new CountDownLatch(1);
         try (
-                AttachContainerResultCallback resultCallback = dockerClient.attachContainerCmd(container.getId())
+                ResultCallback.Adapter<Frame> resultCallback = dockerClient.attachContainerCmd(container.getId())
                         .withStdOut(true)
                         .withStdErr(true)
                         .withFollowStream(true)
-                        .exec(new AttachContainerTestCallback() {
+                        .exec(new ResultCallback.Adapter<Frame>() {
                             @Override
                             public void onNext(Frame item) {
                                 LOG.info("Got frame: {}", item);
@@ -255,7 +255,7 @@ public class AttachContainerCmdIT extends CmdIT {
         }
     }
 
-    public static class AttachContainerTestCallback extends AttachContainerResultCallback {
+    public static class AttachContainerTestCallback extends ResultCallback.Adapter<Frame> {
         private StringBuffer log = new StringBuffer();
 
         @Override

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CommitCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CommitCmdIT.java
@@ -4,7 +4,6 @@ import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.command.InspectImageResponse;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.exception.NotFoundException;
-import com.github.dockerjava.core.command.WaitContainerResultCallback;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -67,7 +66,7 @@ public class CommitCmdIT extends CmdIT {
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
 
         Integer status = dockerRule.getClient().waitContainerCmd(container.getId())
-                .exec(new WaitContainerResultCallback())
+                .start()
                 .awaitStatusCode();
 
         assertThat(status, is(0));

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/ContainerDiffCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/ContainerDiffCmdIT.java
@@ -4,7 +4,6 @@ import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.ChangeLog;
-import com.github.dockerjava.core.command.WaitContainerResultCallback;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +28,7 @@ public class ContainerDiffCmdIT extends CmdIT {
         assertThat(container.getId(), not(isEmptyString()));
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
 
-        int exitCode = dockerRule.getClient().waitContainerCmd(container.getId()).exec(new WaitContainerResultCallback())
+        int exitCode = dockerRule.getClient().waitContainerCmd(container.getId()).start()
                 .awaitStatusCode();
         assertThat(exitCode, equalTo(0));
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveToContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveToContainerCmdIT.java
@@ -3,7 +3,6 @@ package com.github.dockerjava.cmd;
 import com.github.dockerjava.api.command.CopyArchiveToContainerCmd;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.exception.NotFoundException;
-import com.github.dockerjava.core.command.WaitContainerResultCallback;
 import com.github.dockerjava.core.util.CompressArchiveUtil;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
@@ -138,7 +137,7 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
                 .exec();
         // await exid code
         int exitCode = dockerRule.getClient().waitContainerCmd(container.getId())
-                .exec(new WaitContainerResultCallback())
+                .start()
                 .awaitStatusCode();
         // check result
         assertThat(exitCode, equalTo(0));

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CreateContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CreateContainerCmdIT.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.cmd;
 
+import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.command.CreateNetworkResponse;
 import com.github.dockerjava.api.command.CreateVolumeResponse;
@@ -24,7 +25,6 @@ import com.github.dockerjava.api.model.RestartPolicy;
 import com.github.dockerjava.api.model.Ulimit;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.api.model.VolumesFrom;
-import com.github.dockerjava.core.command.LogContainerResultCallback;
 import com.github.dockerjava.junit.DockerAssume;
 import com.github.dockerjava.junit.PrivateRegistryRule;
 import com.github.dockerjava.utils.TestUtils;
@@ -938,7 +938,7 @@ public class CreateContainerCmdIT extends CmdIT {
         assertThat(log, is("exit trapped 10"));
     }
 
-    private static class StringBuilderLogReader extends LogContainerResultCallback {
+    private static class StringBuilderLogReader extends ResultCallback.Adapter<Frame> {
         public StringBuilder builder;
 
         public StringBuilderLogReader(StringBuilder builder) {

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/EventsCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/EventsCmdIT.java
@@ -1,9 +1,8 @@
 package com.github.dockerjava.cmd;
 
+import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.model.Event;
-import com.github.dockerjava.core.command.EventsResultCallback;
-import com.github.dockerjava.core.command.PullImageResultCallback;
 import com.github.dockerjava.utils.TestUtils;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -120,7 +119,7 @@ public class EventsCmdIT extends CmdIT {
     private int generateEvents() throws Exception {
         String testImage = "busybox:latest";
 
-        dockerRule.getClient().pullImageCmd(testImage).exec(new PullImageResultCallback()).awaitSuccess();
+        dockerRule.getClient().pullImageCmd(testImage).start().awaitCompletion();
         CreateContainerResponse container = dockerRule.getClient().createContainerCmd(testImage).withCmd("sleep", "9999").exec();
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
         dockerRule.getClient().stopContainerCmd(container.getId()).withTimeout(1).exec();
@@ -136,7 +135,7 @@ public class EventsCmdIT extends CmdIT {
         return 5;
     }
 
-    private class EventsTestCallback extends EventsResultCallback {
+    private class EventsTestCallback extends ResultCallback.Adapter<Event> {
 
         private final CountDownLatch countDownLatch;
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/ListContainersCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/ListContainersCmdIT.java
@@ -5,8 +5,6 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.Volume;
-import com.github.dockerjava.core.command.PullImageResultCallback;
-import com.github.dockerjava.core.command.WaitContainerResultCallback;
 import com.github.dockerjava.junit.DockerAssume;
 import org.hamcrest.Matcher;
 import org.junit.After;
@@ -314,7 +312,7 @@ public class ListContainersCmdIT extends CmdIT {
 
         dockerRule.getClient().pullImageCmd("busybox")
                 .withTag("1.24")
-                .exec(new PullImageResultCallback())
+                .start()
                 .awaitCompletion();
 
         dockerRule.getClient().createContainerCmd("busybox:1.24")
@@ -352,7 +350,7 @@ public class ListContainersCmdIT extends CmdIT {
 
         dockerRule.getClient().startContainerCmd(id).exec();
 
-        Integer status = dockerRule.getClient().waitContainerCmd(id).exec(new WaitContainerResultCallback())
+        Integer status = dockerRule.getClient().waitContainerCmd(id).start()
                 .awaitStatusCode();
 
         assertThat(status, is(42));

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/LogContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/LogContainerCmdIT.java
@@ -3,7 +3,6 @@ package com.github.dockerjava.cmd;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.StreamType;
-import com.github.dockerjava.core.command.WaitContainerResultCallback;
 import com.github.dockerjava.utils.LogContainerTestCallback;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -129,7 +128,7 @@ public class LogContainerCmdIT extends CmdIT {
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
 
         int exitCode = dockerRule.getClient().waitContainerCmd(container.getId())
-                .exec(new WaitContainerResultCallback())
+                .start()
                 .awaitStatusCode();
 
         assertThat(exitCode, equalTo(0));
@@ -180,7 +179,7 @@ public class LogContainerCmdIT extends CmdIT {
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
 
         int exitCode = dockerRule.getClient().waitContainerCmd(container.getId())
-                .exec(new WaitContainerResultCallback())
+                .start()
                 .awaitStatusCode();
 
         assertThat(exitCode, equalTo(0));

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/PullImageCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/PullImageCmdIT.java
@@ -7,7 +7,6 @@ import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.Info;
 import com.github.dockerjava.core.RemoteApiVersion;
-import com.github.dockerjava.core.command.PullImageResultCallback;
 import com.github.dockerjava.junit.PrivateRegistryRule;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -65,7 +64,7 @@ public class PullImageCmdIT extends CmdIT {
         LOG.info("Pulling image: {}", testImage);
 
         dockerRule.getClient().pullImageCmd(testImage)
-                .exec(new PullImageResultCallback())
+                .start()
                 .awaitCompletion(30, TimeUnit.SECONDS);
 
         info = dockerRule.getClient().infoCmd().exec();
@@ -89,7 +88,7 @@ public class PullImageCmdIT extends CmdIT {
 
         // stream needs to be fully read in order to close the underlying connection
         dockerRule.getClient().pullImageCmd("xvxcv/foo")
-                .exec(new PullImageResultCallback())
+                .start()
                 .awaitCompletion(30, TimeUnit.SECONDS);
     }
 
@@ -102,7 +101,7 @@ public class PullImageCmdIT extends CmdIT {
         // stream needs to be fully read in order to close the underlying connection
         dockerRule.getClient().pullImageCmd(imgName)
                 .withAuthConfig(authConfig)
-                .exec(new PullImageResultCallback())
+                .start()
                 .awaitCompletion(30, TimeUnit.SECONDS);
     }
 
@@ -115,7 +114,7 @@ public class PullImageCmdIT extends CmdIT {
         // stream needs to be fully read in order to close the underlying connection
         dockerRule.getClient().pullImageCmd(imgName)
                 .withAuthConfig(authConfig)
-                .exec(new PullImageResultCallback())
+                .start()
                 .awaitCompletion(30, TimeUnit.SECONDS);
     }
 
@@ -134,7 +133,7 @@ public class PullImageCmdIT extends CmdIT {
 
         // stream needs to be fully read in order to close the underlying connection
         dockerRule.getClient().pullImageCmd(imgName)
-                .exec(new PullImageResultCallback())
+                .start()
                 .awaitCompletion(30, TimeUnit.SECONDS);
     }
 
@@ -160,7 +159,7 @@ public class PullImageCmdIT extends CmdIT {
         // stream needs to be fully read in order to close the underlying connection
         dockerRule.getClient().pullImageCmd(imgName)
                 .withAuthConfig(invalidAuthConfig)
-                .exec(new PullImageResultCallback())
+                .start()
                 .awaitCompletion(30, TimeUnit.SECONDS);
     }
 }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/PushImageCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/PushImageCmdIT.java
@@ -5,8 +5,6 @@ import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.core.RemoteApiVersion;
-import com.github.dockerjava.core.command.PullImageResultCallback;
-import com.github.dockerjava.core.command.PushImageResultCallback;
 import com.github.dockerjava.junit.PrivateRegistryRule;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -59,7 +57,7 @@ public class PushImageCmdIT extends CmdIT {
         // we have to block until image is pushed
         dockerRule.getClient().pushImageCmd(imgName)
                 .withAuthConfig(authConfig)
-                .exec(new PushImageResultCallback())
+                .start()
                 .awaitCompletion(30, TimeUnit.SECONDS);
 
         LOG.info("Removing image: {}", imageId);
@@ -68,7 +66,7 @@ public class PushImageCmdIT extends CmdIT {
         dockerRule.getClient().pullImageCmd(imgName)
                 .withTag("latest")
                 .withAuthConfig(authConfig)
-                .exec(new PullImageResultCallback())
+                .start()
                 .awaitCompletion(30, TimeUnit.SECONDS);
     }
 
@@ -83,7 +81,7 @@ public class PushImageCmdIT extends CmdIT {
         }
 
         dockerRule.getClient().pushImageCmd(username + "/xxx")
-                .exec(new PushImageResultCallback())
+                .start()
                 .awaitCompletion(30, TimeUnit.SECONDS); // exclude infinite await sleep
 
     }
@@ -95,7 +93,7 @@ public class PushImageCmdIT extends CmdIT {
         // stream needs to be fully read in order to close the underlying connection
         dockerRule.getClient().pushImageCmd(imgName)
                 .withAuthConfig(authConfig)
-                .exec(new PushImageResultCallback())
+                .start()
                 .awaitCompletion(30, TimeUnit.SECONDS);
     }
 
@@ -107,7 +105,7 @@ public class PushImageCmdIT extends CmdIT {
 
         // stream needs to be fully read in order to close the underlying connection
         dockerRule.getClient().pushImageCmd(imgName)
-                .exec(new PushImageResultCallback())
+                .start()
                 .awaitCompletion(30, TimeUnit.SECONDS);
     }
 
@@ -126,7 +124,7 @@ public class PushImageCmdIT extends CmdIT {
         // stream needs to be fully read in order to close the underlying connection
         dockerRule.getClient().pushImageCmd(imgName)
                 .withAuthConfig(invalidAuthConfig)
-                .exec(new PushImageResultCallback())
+                .start()
                 .awaitCompletion(30, TimeUnit.SECONDS);
     }
 }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/RemoveContainerCmdImplIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/RemoveContainerCmdImplIT.java
@@ -4,7 +4,6 @@ import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Container;
-import com.github.dockerjava.core.command.WaitContainerResultCallback;
 import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -24,12 +23,12 @@ public class RemoveContainerCmdImplIT extends CmdIT {
     
 
     @Test
-    public void removeContainer() throws DockerException {
+    public void removeContainer() throws Exception {
 
         CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox").withCmd("true").exec();
 
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
-        dockerRule.getClient().waitContainerCmd(container.getId()).exec(new WaitContainerResultCallback()).awaitStatusCode();
+        dockerRule.getClient().waitContainerCmd(container.getId()).start().awaitCompletion();
 
         LOG.info("Removing container: {}", container.getId());
         dockerRule.getClient().removeContainerCmd(container.getId()).exec();

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/RemoveContainerCmdImplIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/RemoveContainerCmdImplIT.java
@@ -28,7 +28,7 @@ public class RemoveContainerCmdImplIT extends CmdIT {
         CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox").withCmd("true").exec();
 
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
-        dockerRule.getClient().waitContainerCmd(container.getId()).start().awaitCompletion();
+        dockerRule.getClient().waitContainerCmd(container.getId()).start().awaitStatusCode();
 
         LOG.info("Removing container: {}", container.getId());
         dockerRule.getClient().removeContainerCmd(container.getId()).exec();

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/StartContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/StartContainerCmdIT.java
@@ -14,7 +14,6 @@ import com.github.dockerjava.api.model.Ports.Binding;
 import com.github.dockerjava.api.model.RestartPolicy;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.api.model.VolumesFrom;
-import com.github.dockerjava.core.command.WaitContainerResultCallback;
 import net.jcip.annotations.NotThreadSafe;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -45,7 +44,7 @@ public class StartContainerCmdIT extends CmdIT {
     public static final Logger LOG = LoggerFactory.getLogger(StartContainerCmdIT.class);
 
     @Test
-    public void startContainerWithVolumes() throws DockerException {
+    public void startContainerWithVolumes() throws Exception {
 
         // see http://docs.docker.io/use/working_with_volumes/
         Volume volume1 = new Volume("/opt/webapp1");
@@ -68,7 +67,7 @@ public class StartContainerCmdIT extends CmdIT {
 
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
 
-        dockerRule.getClient().waitContainerCmd(container.getId()).exec(new WaitContainerResultCallback()).awaitStatusCode();
+        dockerRule.getClient().waitContainerCmd(container.getId()).start().awaitCompletion();
 
         inspectContainerResponse = dockerRule.getClient().inspectContainerCmd(container.getId()).exec();
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/StartContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/StartContainerCmdIT.java
@@ -67,7 +67,7 @@ public class StartContainerCmdIT extends CmdIT {
 
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
 
-        dockerRule.getClient().waitContainerCmd(container.getId()).start().awaitCompletion();
+        dockerRule.getClient().waitContainerCmd(container.getId()).start().awaitStatusCode();
 
         inspectContainerResponse = dockerRule.getClient().inspectContainerCmd(container.getId()).exec();
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/JoinSwarmCmdExecIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/JoinSwarmCmdExecIT.java
@@ -33,7 +33,7 @@ public class JoinSwarmCmdExecIT extends SwarmCmdIT {
     }
 
     @Test
-    public void joinSwarmAsWorker() throws DockerException {
+    public void joinSwarmAsWorker() throws Exception {
         DockerClient docker1 = startDockerInDocker();
         DockerClient docker2 = startDockerInDocker();
 
@@ -69,7 +69,7 @@ public class JoinSwarmCmdExecIT extends SwarmCmdIT {
     }
 
     @Test(expected = NotAcceptableException.class)
-    public void joinSwarmIfAlreadyInSwarm() {
+    public void joinSwarmIfAlreadyInSwarm() throws Exception {
         DockerClient docker1 = startDockerInDocker();
         DockerClient docker2 = startDockerInDocker();
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/ListServicesCmdExecIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/ListServicesCmdExecIT.java
@@ -29,7 +29,7 @@ public class ListServicesCmdExecIT extends SwarmCmdIT {
     private static final String LABEL_VALUE = "test";
 
     @Test
-    public void testListServices() throws DockerException {
+    public void testListServices() throws Exception {
         DockerClient docker1 = startDockerInDocker();
         docker1.initializeSwarmCmd(new SwarmSpec()).exec();
         Map<String, String> serviceLabels = Collections.singletonMap(LABEL_KEY, LABEL_VALUE);

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/SwarmCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/SwarmCmdIT.java
@@ -12,7 +12,6 @@ import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.cmd.CmdIT;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientBuilder;
-import com.github.dockerjava.core.command.PullImageResultCallback;
 import com.github.dockerjava.junit.category.Integration;
 import com.github.dockerjava.junit.category.SwarmModeIntegration;
 import org.junit.After;
@@ -68,7 +67,7 @@ public abstract class SwarmCmdIT extends CmdIT {
         numberOfDockersInDocker = 0;
     }
 
-    protected DockerClient startDockerInDocker() {
+    protected DockerClient startDockerInDocker() throws InterruptedException {
         numberOfDockersInDocker++;
         String name = DOCKER_IN_DOCKER_CONTAINER_PREFIX + numberOfDockersInDocker;
 
@@ -92,8 +91,8 @@ public abstract class SwarmCmdIT extends CmdIT {
 
         dockerRule.getClient().pullImageCmd(DOCKER_IN_DOCKER_IMAGE_REPOSITORY)
                 .withTag(DOCKER_IN_DOCKER_IMAGE_TAG)
-                .exec(new PullImageResultCallback())
-                .awaitSuccess();
+                .start()
+                .awaitCompletion();
 
         int port = PORT_START + (numberOfDockersInDocker - 1);
         CreateContainerResponse response = dockerRule.getClient()

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/UpdateSwarmNodeIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/UpdateSwarmNodeIT.java
@@ -15,7 +15,7 @@ import static org.hamcrest.Matchers.is;
 
 public class UpdateSwarmNodeIT extends SwarmCmdIT {
     @Test
-    public void testUpdateSwarmNode() {
+    public void testUpdateSwarmNode() throws Exception {
         DockerClient docker1 = startDockerInDocker();
         docker1.initializeSwarmCmd(new SwarmSpec()).exec();
         List<SwarmNode> nodes = docker1.listSwarmNodesCmd().exec();

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/UpdateSwarmServiceIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/UpdateSwarmServiceIT.java
@@ -21,7 +21,7 @@ import static org.hamcrest.Matchers.is;
 
 public class UpdateSwarmServiceIT extends SwarmCmdIT {
     @Test
-    public void testUpdateServiceReplicate() {
+    public void testUpdateServiceReplicate() throws Exception {
         DockerClient docker1 = startDockerInDocker();
         docker1.initializeSwarmCmd(new SwarmSpec()).exec();
         //create network

--- a/docker-java/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
@@ -34,7 +34,7 @@ public class DockerfileFixture implements AutoCloseable {
         LOGGER.info("building {}", directory);
 
         client.buildImageCmd(new File("src/test/resources", directory)).withNoCache(true)
-                .start().awaitCompletion();
+                .start().awaitImageId();
 
         Image lastCreatedImage = client.listImagesCmd().exec().get(0);
 

--- a/docker-java/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/command/DockerfileFixture.java
@@ -4,7 +4,6 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.exception.InternalServerErrorException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Image;
-import com.github.dockerjava.core.command.BuildImageResultCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +34,7 @@ public class DockerfileFixture implements AutoCloseable {
         LOGGER.info("building {}", directory);
 
         client.buildImageCmd(new File("src/test/resources", directory)).withNoCache(true)
-                .exec(new BuildImageResultCallback()).awaitImageId();
+                .start().awaitCompletion();
 
         Image lastCreatedImage = client.listImagesCmd().exec().get(0);
 

--- a/docker-java/src/test/java/com/github/dockerjava/core/command/FrameReaderITest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/command/FrameReaderITest.java
@@ -1,6 +1,7 @@
 package com.github.dockerjava.core.command;
 
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.StreamType;
 import com.github.dockerjava.core.DockerClientBuilder;
@@ -46,7 +47,7 @@ public class FrameReaderITest {
 
         // wait for the container to be successfully executed
         int exitCode = dockerClient.waitContainerCmd(dockerfileFixture.getContainerId())
-                .exec(new WaitContainerResultCallback()).awaitStatusCode();
+                .start().awaitStatusCode();
         assertEquals(0, exitCode);
 
         final List<Frame> loggingFrames = getLoggingFrames();
@@ -96,7 +97,7 @@ public class FrameReaderITest {
 
     }
 
-    public static class FrameReaderITestCallback extends LogContainerResultCallback {
+    public static class FrameReaderITestCallback extends ResultCallback.Adapter<Frame> {
 
         public List<Frame> frames = new ArrayList<>();
 

--- a/docker-java/src/test/java/com/github/dockerjava/junit/DockerRule.java
+++ b/docker-java/src/test/java/com/github/dockerjava/junit/DockerRule.java
@@ -13,8 +13,6 @@ import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.cmd.CmdIT;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientBuilder;
-import com.github.dockerjava.core.command.BuildImageResultCallback;
-import com.github.dockerjava.core.command.PullImageResultCallback;
 import com.github.dockerjava.utils.LogContainerTestCallback;
 import org.junit.rules.ExternalResource;
 import org.junit.runner.Description;
@@ -109,8 +107,8 @@ public class DockerRule extends ExternalResource {
             // need to block until image is pulled completely
             getClient().pullImageCmd("busybox")
                     .withTag("latest")
-                    .exec(new PullImageResultCallback())
-                    .awaitSuccess();
+                    .start()
+                    .awaitCompletion();
         }
 
 //        assertThat(getClient(), notNullValue());
@@ -181,7 +179,7 @@ public class DockerRule extends ExternalResource {
     public String buildImage(File baseDir) throws Exception {
         return getClient().buildImageCmd(baseDir)
                 .withNoCache(true)
-                .exec(new BuildImageResultCallback())
+                .start()
                 .awaitImageId();
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/junit/PrivateRegistryRule.java
+++ b/docker-java/src/test/java/com/github/dockerjava/junit/PrivateRegistryRule.java
@@ -8,8 +8,6 @@ import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.core.DockerClientBuilder;
-import com.github.dockerjava.core.command.BuildImageResultCallback;
-import com.github.dockerjava.core.command.PushImageResultCallback;
 import org.junit.rules.ExternalResource;
 
 import java.io.File;
@@ -42,7 +40,7 @@ public class PrivateRegistryRule extends ExternalResource {
 
         dockerClient.pushImageCmd(imgNameWithTag)
                 .withAuthConfig(authConfig)
-                .exec(new PushImageResultCallback())
+                .start()
                 .awaitCompletion(30, TimeUnit.SECONDS);
 
         dockerClient.removeImageCmd(imgNameWithTag).exec();
@@ -75,7 +73,7 @@ public class PrivateRegistryRule extends ExternalResource {
 
         String registryImageId = dockerClient.buildImageCmd(baseDir)
                 .withNoCache(true)
-                .exec(new BuildImageResultCallback())
+                .start()
                 .awaitImageId();
 
         InspectImageResponse inspectImageResponse = dockerClient.inspectImageCmd(registryImageId).exec();

--- a/docker-java/src/test/java/com/github/dockerjava/utils/LogContainerTestCallback.java
+++ b/docker-java/src/test/java/com/github/dockerjava/utils/LogContainerTestCallback.java
@@ -1,7 +1,7 @@
 package com.github.dockerjava.utils;
 
+import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.model.Frame;
-import com.github.dockerjava.core.command.LogContainerResultCallback;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -9,7 +9,7 @@ import java.util.List;
 /**
  * @author Kanstantsin Shautsou
  */
-public class LogContainerTestCallback extends LogContainerResultCallback {
+public class LogContainerTestCallback extends ResultCallback.Adapter<Frame> {
     protected final StringBuffer log = new StringBuffer();
 
     List<Frame> collectedFrames = new ArrayList<>();


### PR DESCRIPTION
These classes belong to the API and essential for calling some of the API methods.

Also, sometimes they are not needed, actually, but the current API (`ResultCallbackTemplate`) is hard to use due to the generic signature, hence the addition of `ResultCallback.Adapter`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1321)
<!-- Reviewable:end -->
