### PR TITLE
Jar packaging.

### DIFF
--- a/docker-java-api/pom.xml
+++ b/docker-java-api/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>docker-java-api</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 
 	<name>docker-java-api</name>
 	<url>https://github.com/docker-java/docker-java</url>

--- a/docker-java-core/pom.xml
+++ b/docker-java-core/pom.xml
@@ -17,9 +17,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>${groupId}</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>docker-java-api</artifactId>
-			<version>${version}</version>
+			<version>${project.version}</version>
 		</dependency>
 
 		<dependency>

--- a/docker-java-core/pom.xml
+++ b/docker-java-core/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>docker-java-core</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 
 	<name>docker-java-core</name>
 	<url>https://github.com/docker-java/docker-java</url>

--- a/docker-java-transport-jersey/pom.xml
+++ b/docker-java-transport-jersey/pom.xml
@@ -17,9 +17,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>${groupId}</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>docker-java-core</artifactId>
-			<version>${version}</version>
+			<version>${project.version}</version>
 		</dependency>
 
 		<dependency>

--- a/docker-java-transport-jersey/pom.xml
+++ b/docker-java-transport-jersey/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>docker-java-transport-jersey</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 
 	<name>docker-java-transport-jersey</name>
 	<url>https://github.com/docker-java/docker-java</url>

--- a/docker-java-transport-netty/pom.xml
+++ b/docker-java-transport-netty/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>docker-java-transport-netty</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 
 	<name>docker-java-transport-netty</name>
 	<url>https://github.com/docker-java/docker-java</url>

--- a/docker-java-transport-netty/pom.xml
+++ b/docker-java-transport-netty/pom.xml
@@ -17,9 +17,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>${groupId}</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>docker-java-core</artifactId>
-			<version>${version}</version>
+			<version>${project.version}</version>
 		</dependency>
 
         <dependency>

--- a/docker-java-transport-okhttp/pom.xml
+++ b/docker-java-transport-okhttp/pom.xml
@@ -17,9 +17,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>${groupId}</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>docker-java-core</artifactId>
-			<version>${version}</version>
+			<version>${project.version}</version>
 		</dependency>
 
 		<dependency>

--- a/docker-java-transport-okhttp/pom.xml
+++ b/docker-java-transport-okhttp/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>docker-java-transport-okhttp</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 
 	<name>docker-java-transport-okhttp</name>
 	<url>https://github.com/docker-java/docker-java</url>

--- a/docker-java/pom.xml
+++ b/docker-java/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>docker-java</artifactId>
-	<packaging>bundle</packaging>
+	<packaging>jar</packaging>
 
 	<name>docker-java</name>
 	<url>https://github.com/docker-java/docker-java</url>

--- a/docker-java/pom.xml
+++ b/docker-java/pom.xml
@@ -17,19 +17,19 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>${groupId}</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>docker-java-core</artifactId>
-			<version>${version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>${groupId}</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>docker-java-transport-jersey</artifactId>
-			<version>${version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>${groupId}</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>docker-java-transport-netty</artifactId>
-			<version>${version}</version>
+			<version>${project.version}</version>
 		</dependency>
 
 		<dependency>
@@ -40,9 +40,9 @@
 
 		<!-- /// Test /////////////////////////// -->
 		<dependency>
-			<groupId>${groupId}</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>docker-java-transport-okhttp</artifactId>
-			<version>${version}</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,11 @@
 						</execution>
 					</executions>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.felix</groupId>
+					<artifactId>maven-bundle-plugin</artifactId>
+					<version>4.2.1</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>


### PR DESCRIPTION
bundle is duplicating everything.



this jar should contain single class, but has:
```
wget https://repo1.maven.org/maven2/com/github/docker-java/docker-java/3.2.0-rc5/docker-java-3.2.0-rc5.jar
bash-3.2$ unzip  docker-java-3.2.0-rc5.jar
Archive:  docker-java-3.2.0-rc5.jar
   creating: META-INF/
  inflating: META-INF/MANIFEST.MF
   creating: META-INF/maven/
   creating: META-INF/maven/com.github.docker-java/
   creating: META-INF/maven/com.github.docker-java/docker-java/
  inflating: META-INF/maven/com.github.docker-java/docker-java/pom.properties
  inflating: META-INF/maven/com.github.docker-java/docker-java/pom.xml
   creating: com/
   creating: com/github/
   creating: com/github/dockerjava/
   creating: com/github/dockerjava/api/
  inflating: com/github/dockerjava/api/DockerClient.class
   creating: com/github/dockerjava/api/async/
  inflating: com/github/dockerjava/api/async/ResultCallback$Adapter.class
  inflating: com/github/dockerjava/api/async/ResultCallback.class
  inflating: com/github/dockerjava/api/async/ResultCallbackTemplate.class
   creating: com/github/dockerjava/api/command/
  inflating: com/github/dockerjava/api/command/AsyncDockerCmd.class
...
 ```


Probably better switch to https://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html#adding-osgi-metadata-to-existing-projects-without-changing-the-packaging-type , but now let's unblock release by removing bundle packaging?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1337)
<!-- Reviewable:end -->
