### PR TITLE
SCTP Support

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/ExposedPort.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/ExposedPort.java
@@ -1,13 +1,15 @@
 package com.github.dockerjava.api.model;
 
+import static com.github.dockerjava.api.model.InternetProtocol.TCP;
+import static com.github.dockerjava.api.model.InternetProtocol.UDP;
+import static com.github.dockerjava.api.model.InternetProtocol.SCTP;
+
 import java.io.Serializable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.github.dockerjava.api.model.Ports.Binding;
 import lombok.EqualsAndHashCode;
-
-import static com.github.dockerjava.api.model.InternetProtocol.*;
 
 /**
  * Represents a container port that Docker exposes to external clients. The port is defined by its {@link #getPort() port number} and an

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/ExposedPort.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/ExposedPort.java
@@ -1,14 +1,13 @@
 package com.github.dockerjava.api.model;
 
-import static com.github.dockerjava.api.model.InternetProtocol.TCP;
-import static com.github.dockerjava.api.model.InternetProtocol.UDP;
-
 import java.io.Serializable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.github.dockerjava.api.model.Ports.Binding;
 import lombok.EqualsAndHashCode;
+
+import static com.github.dockerjava.api.model.InternetProtocol.*;
 
 /**
  * Represents a container port that Docker exposes to external clients. The port is defined by its {@link #getPort() port number} and an
@@ -50,7 +49,7 @@ public class ExposedPort implements Serializable {
      * Creates an {@link ExposedPort} for the given parameters.
      *
      * @param scheme
-     *            the {@link #getScheme() scheme}, <code>tcp</code> or <code>udp</code>
+     *            the {@link #getScheme() scheme}, <code>tcp</code>, <code>udp</code> or <code>sctp</code>
      * @param port
      *            the {@link #getPort() port number}
      * @deprecated use {@link #ExposedPort(int, InternetProtocol)}
@@ -68,7 +67,7 @@ public class ExposedPort implements Serializable {
     }
 
     /**
-     * @return the scheme (internet protocol), <code>tcp</code> or <code>udp</code>
+     * @return the scheme (internet protocol), <code>tcp</code>, <code>udp</code> or <code>sctp</code>
      * @deprecated use {@link #getProtocol()}
      */
     @Deprecated
@@ -95,6 +94,14 @@ public class ExposedPort implements Serializable {
      */
     public static ExposedPort udp(int port) {
         return new ExposedPort(port, UDP);
+    }
+
+    /**
+     * Creates an {@link ExposedPort} for {@link InternetProtocol#SCTP}. This is a shortcut for
+     * <code>new ExposedPort(port, {@link InternetProtocol#SCTP})</code>
+     */
+    public static ExposedPort sctp(int port) {
+        return new ExposedPort(port, SCTP);
     }
 
     /**

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/InternetProtocol.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/InternetProtocol.java
@@ -15,7 +15,12 @@ public enum InternetProtocol {
     /**
      * The <i>User Datagram Protocol</i>
      */
-    UDP;
+    UDP,
+
+    /**
+     * The <i>Stream Control Transmission Protocol</i>
+     */
+    SCTP;
 
     /**
      * The default {@link InternetProtocol}: {@link #TCP}

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/InternetProtocol.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/InternetProtocol.java
@@ -5,6 +5,7 @@ package com.github.dockerjava.api.model;
  *
  * @see #TCP
  * @see #UDP
+ * @see #SCTP
  */
 public enum InternetProtocol {
     /**

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/PortConfigProtocol.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/PortConfigProtocol.java
@@ -11,6 +11,9 @@ public enum PortConfigProtocol {
     TCP,
 
     @JsonProperty("udp")
-    UDP
+    UDP,
+
+    @JsonProperty("sctp")
+    SCTP
 
 }

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/ExposedPortsTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/ExposedPortsTest.java
@@ -14,21 +14,23 @@ public class ExposedPortsTest {
     public void usesToJson() throws Exception {
         ExposedPorts ports = new ExposedPorts(
                 new ExposedPort(80),
-                new ExposedPort(123, InternetProtocol.UDP)
+                new ExposedPort(123, InternetProtocol.UDP),
+                new ExposedPort(3868, InternetProtocol.SCTP)
         );
         String json = JSONTestHelper.getMapper().writeValueAsString(ports);
 
-        assertThat(json, is("{\"80/tcp\":{},\"123/udp\":{}}"));
+        assertThat(json, is("{\"80/tcp\":{},\"123/udp\":{},\"3868/sctp\":{}}"));
     }
 
     @Test
     public void usesFromJson() throws Exception {
-        ExposedPorts ports = JSONTestHelper.getMapper().readValue("{\"80/tcp\":{},\"123/udp\":{}}", ExposedPorts.class);
+        ExposedPorts ports = JSONTestHelper.getMapper().readValue("{\"80/tcp\":{},\"123/udp\":{},\"3868/sctp\":{}}", ExposedPorts.class);
 
         assertThat(ports, notNullValue());
         assertThat(ports.getExposedPorts(), arrayContaining(
                 new ExposedPort(80),
-                new ExposedPort(123, InternetProtocol.UDP)
+                new ExposedPort(123, InternetProtocol.UDP),
+                new ExposedPort(3868, InternetProtocol.SCTP)
         ));
     }
 }

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/ExposedPortsTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/ExposedPortsTest.java
@@ -19,7 +19,7 @@ public class ExposedPortsTest {
         );
         String json = JSONTestHelper.getMapper().writeValueAsString(ports);
 
-        assertThat(json, is("{\"80/tcp\":{},\"123/udp\":{},\"3868/sctp\":{}}"));
+        assertThat(json, is("{\"80/tcp\":{},\"3868/sctp\":{},\"123/udp\":{}}"));
     }
 
     @Test


### PR DESCRIPTION
Hello, first PR here so please go easy.

This PR should add support for parsing exposed ports declared with the SCTP protocol. SCTP port mapping has been a feature in Docker Engine since [18.03.0-ce](https://docs.docker.com/engine/release-notes/#18030-ce).

My process for adding this in was searching through the project for "UDP" and adding an "SCTP" equivalent for each item. Hopefully this is all that is required!

Equivalent PR for docker-py: https://github.com/docker/docker-py/pull/2281

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1341)
<!-- Reviewable:end -->
