### PR TITLE
OkHttp: extract hijacking logic into `HijackingInterceptor`

### DIFF
--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/Hijacked.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/Hijacked.java
@@ -1,0 +1,16 @@
+package com.github.dockerjava.okhttp;
+
+import java.io.InputStream;
+
+class Hijacked {
+
+    private final InputStream inputStream;
+
+    Hijacked(InputStream inputStream) {
+        this.inputStream = inputStream;
+    }
+
+    public InputStream getInputStream() {
+        return inputStream;
+    }
+}

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/HijackingInterceptor.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/HijackingInterceptor.java
@@ -1,0 +1,55 @@
+package com.github.dockerjava.okhttp;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.internal.Internal;
+import okhttp3.internal.ws.RealWebSocket;
+import okio.BufferedSink;
+import okio.Okio;
+import okio.Source;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+class HijackingInterceptor implements Interceptor {
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+        Request request = chain.request();
+        Response response = chain.proceed(request);
+        if (!response.isSuccessful()) {
+            return response;
+        }
+        Hijacked hijacked = request.tag(Hijacked.class);
+
+        if (hijacked == null) {
+            return response;
+        }
+
+        InputStream inputStream = hijacked.getInputStream();
+
+        RealWebSocket.Streams streams = Internal.instance.exchange(response).newWebSocketStreams();
+        Thread thread = new Thread(() -> {
+            try {
+                try (
+                        BufferedSink sink = streams.sink;
+                        Source source = Okio.source(inputStream);
+                ) {
+                    while (sink.isOpen()) {
+                        int available = inputStream.available();
+                        if (available > 0) {
+                            sink.write(source, available);
+                            sink.emit();
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        thread.setName("docker-java-hijack-" + System.identityHashCode(request));
+        thread.start();
+        return response;
+    }
+}

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/HijackingInterceptor.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/HijackingInterceptor.java
@@ -29,6 +29,10 @@ class HijackingInterceptor implements Interceptor {
 
         InputStream inputStream = hijacked.getInputStream();
 
+        if (inputStream == null) {
+            return response;
+        }
+
         RealWebSocket.Streams streams = Internal.instance.exchange(response).newWebSocketStreams();
         Thread thread = new Thread(() -> {
             try (

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/HijackingInterceptor.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/HijackingInterceptor.java
@@ -31,17 +31,15 @@ class HijackingInterceptor implements Interceptor {
 
         RealWebSocket.Streams streams = Internal.instance.exchange(response).newWebSocketStreams();
         Thread thread = new Thread(() -> {
-            try {
-                try (
-                        BufferedSink sink = streams.sink;
-                        Source source = Okio.source(inputStream);
-                ) {
-                    while (sink.isOpen()) {
-                        int available = inputStream.available();
-                        if (available > 0) {
-                            sink.write(source, available);
-                            sink.emit();
-                        }
+            try (
+                    BufferedSink sink = streams.sink;
+                    Source source = Okio.source(inputStream);
+            ) {
+                while (sink.isOpen()) {
+                    int available = inputStream.available();
+                    if (available > 0) {
+                        sink.write(source, available);
+                        sink.emit();
                     }
                 }
             } catch (Exception e) {

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/OkHttpDockerCmdExecFactory.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/OkHttpDockerCmdExecFactory.java
@@ -99,7 +99,9 @@ public class OkHttpDockerCmdExecFactory extends AbstractDockerCmdExecFactory {
             }
         }
 
-        okHttpClient = clientBuilder.build();
+        okHttpClient = clientBuilder
+            .addNetworkInterceptor(new HijackingInterceptor())
+            .build();
 
         HttpUrl.Builder baseUrlBuilder;
 


### PR DESCRIPTION
The change also removes reflection access to OkHttp's internals and replaces it with `Internal.instance.exchange()` and `newWebSocketStreams()` from OkHttp.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/1347)
<!-- Reviewable:end -->
