### PR TITLE
Add a new "zerodep" transport based on AHC5

### DIFF
--- a/docker-java-transport-httpclient5/pom.xml
+++ b/docker-java-transport-httpclient5/pom.xml
@@ -36,7 +36,7 @@
 
 		<dependency>
 			<groupId>net.java.dev.jna</groupId>
-			<artifactId>jna-platform</artifactId>
+			<artifactId>jna</artifactId>
 			<version>5.5.0</version>
 		</dependency>
 	</dependencies>

--- a/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/ApacheDockerHttpClientImpl.java
+++ b/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/ApacheDockerHttpClientImpl.java
@@ -1,0 +1,222 @@
+package com.github.dockerjava.httpclient5;
+
+import com.github.dockerjava.transport.DockerHttpClient;
+import com.github.dockerjava.transport.SSLConfig;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.ManagedHttpClientConnectionFactory;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.ConnectionClosedException;
+import org.apache.hc.core5.http.ContentLengthStrategy;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.config.Registry;
+import org.apache.hc.core5.http.config.RegistryBuilder;
+import org.apache.hc.core5.http.impl.DefaultContentLengthStrategy;
+import org.apache.hc.core5.http.impl.io.EmptyInputStream;
+import org.apache.hc.core5.http.io.entity.InputStreamEntity;
+import org.apache.hc.core5.http.protocol.BasicHttpContext;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.net.URIAuthority;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Socket;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class ApacheDockerHttpClientImpl implements DockerHttpClient {
+
+    private final CloseableHttpClient httpClient;
+
+    private final HttpHost host;
+
+    protected ApacheDockerHttpClientImpl(
+        URI dockerHost,
+        SSLConfig sslConfig
+    ) {
+        Registry<ConnectionSocketFactory> socketFactoryRegistry = createConnectionSocketFactoryRegistry(sslConfig, dockerHost);
+
+        switch (dockerHost.getScheme()) {
+            case "unix":
+            case "npipe":
+                host = new HttpHost(dockerHost.getScheme(), "localhost", 2375);
+                break;
+            case "tcp":
+                host = new HttpHost(
+                    socketFactoryRegistry.lookup("https") != null ? "https" : "http",
+                    dockerHost.getHost(),
+                    dockerHost.getPort()
+                );
+                break;
+            default:
+                host = HttpHost.create(dockerHost);
+        }
+
+        httpClient = HttpClients.custom()
+            .setRequestExecutor(new HijackingHttpRequestExecutor(null))
+            .setConnectionManager(new PoolingHttpClientConnectionManager(
+                socketFactoryRegistry,
+                new ManagedHttpClientConnectionFactory(
+                    null,
+                    null,
+                    null,
+                    null,
+                    message -> {
+                        Header transferEncodingHeader = message.getFirstHeader(HttpHeaders.TRANSFER_ENCODING);
+                        if (transferEncodingHeader != null) {
+                            if ("identity".equalsIgnoreCase(transferEncodingHeader.getValue())) {
+                                return ContentLengthStrategy.UNDEFINED;
+                            }
+                        }
+                        return DefaultContentLengthStrategy.INSTANCE.determineLength(message);
+                    },
+                    null
+                )
+            ))
+            .build();
+    }
+
+    private Registry<ConnectionSocketFactory> createConnectionSocketFactoryRegistry(
+        SSLConfig sslConfig,
+        URI dockerHost
+    ) {
+        RegistryBuilder<ConnectionSocketFactory> socketFactoryRegistryBuilder = RegistryBuilder.create();
+
+        if (sslConfig != null) {
+            try {
+                SSLContext sslContext = sslConfig.getSSLContext();
+                if (sslContext != null) {
+                    socketFactoryRegistryBuilder.register("https", new SSLConnectionSocketFactory(sslContext));
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return socketFactoryRegistryBuilder
+            .register("tcp", PlainConnectionSocketFactory.INSTANCE)
+            .register("http", PlainConnectionSocketFactory.INSTANCE)
+            .register("unix", new PlainConnectionSocketFactory() {
+                @Override
+                public Socket createSocket(HttpContext context) throws IOException {
+                    return new UnixDomainSocket(dockerHost.getPath());
+                }
+            })
+            .register("npipe", new PlainConnectionSocketFactory() {
+                @Override
+                public Socket createSocket(HttpContext context) {
+                    return new NamedPipeSocket(dockerHost.getPath());
+                }
+            })
+            .build();
+    }
+
+    @Override
+    public Response execute(Request request) {
+        HttpContext context = new BasicHttpContext();
+        HttpUriRequestBase httpUriRequest = new HttpUriRequestBase(request.method(), URI.create(request.path()));
+        httpUriRequest.setScheme(host.getSchemeName());
+        httpUriRequest.setAuthority(new URIAuthority(host.getHostName(), host.getPort()));
+
+        request.headers().forEach(httpUriRequest::addHeader);
+
+        InputStream body = request.body();
+        if (body != null) {
+            httpUriRequest.setEntity(new InputStreamEntity(body, null));
+        }
+
+        if (request.hijackedInput() != null) {
+            context.setAttribute(HijackingHttpRequestExecutor.HIJACKED_INPUT_ATTRIBUTE, request.hijackedInput());
+            httpUriRequest.setHeader("Upgrade", "tcp");
+            httpUriRequest.setHeader("Connection", "Upgrade");
+        }
+
+        try {
+            CloseableHttpResponse response = httpClient.execute(host, httpUriRequest, context);
+
+            return new ApacheResponse(httpUriRequest, response);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        httpClient.close();
+    }
+
+    static class ApacheResponse implements Response {
+
+        private static final Logger LOGGER = LoggerFactory.getLogger(ApacheResponse.class);
+
+        private final HttpUriRequestBase request;
+
+        private final CloseableHttpResponse response;
+
+        ApacheResponse(HttpUriRequestBase httpUriRequest, CloseableHttpResponse response) {
+            this.request = httpUriRequest;
+            this.response = response;
+        }
+
+        @Override
+        public int getStatusCode() {
+            return response.getCode();
+        }
+
+        @Override
+        public Map<String, List<String>> getHeaders() {
+            return Stream.of(response.getHeaders()).collect(Collectors.groupingBy(
+                NameValuePair::getName,
+                Collectors.mapping(NameValuePair::getValue, Collectors.toList())
+            ));
+        }
+
+        @Override
+        public String getHeader(String name) {
+            Header firstHeader = response.getFirstHeader(name);
+            return firstHeader != null ? firstHeader.getValue() : null;
+        }
+
+        @Override
+        public InputStream getBody() {
+            try {
+                return response.getEntity() != null
+                    ? response.getEntity().getContent()
+                    : EmptyInputStream.INSTANCE;
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void close() {
+            try {
+                request.abort();
+            } catch (Exception e) {
+                LOGGER.debug("Failed to abort the request", e);
+            }
+
+            try {
+                response.close();
+            } catch (ConnectionClosedException e) {
+                LOGGER.trace("Failed to close the response", e);
+            } catch (Exception e) {
+                LOGGER.debug("Failed to close the response", e);
+            }
+        }
+    }
+}

--- a/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/NamedPipeSocket.java
+++ b/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/NamedPipeSocket.java
@@ -1,6 +1,8 @@
 package com.github.dockerjava.httpclient5;
 
-import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.Native;
+import com.sun.jna.win32.StdCallLibrary;
+import com.sun.jna.win32.W32APIOptions;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -97,5 +99,13 @@ class NamedPipeSocket extends Socket {
     @Override
     public OutputStream getOutputStream() {
         return os;
+    }
+
+    interface Kernel32 extends StdCallLibrary {
+
+        Kernel32 INSTANCE = Native.load("kernel32", Kernel32.class, W32APIOptions.DEFAULT_OPTIONS);
+
+        @SuppressWarnings("checkstyle:methodname")
+        boolean WaitNamedPipe(String lpNamedPipeName, int nTimeOut);
     }
 }

--- a/docker-java-transport-zerodep/pom.xml
+++ b/docker-java-transport-zerodep/pom.xml
@@ -1,0 +1,104 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.github.docker-java</groupId>
+		<artifactId>docker-java-parent</artifactId>
+		<version>3.2.2-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>docker-java-transport-zerodep</artifactId>
+	<packaging>jar</packaging>
+
+	<name>docker-java-transport-zerodep</name>
+	<url>https://github.com/docker-java/docker-java</url>
+	<description>Java API Client for Docker</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>docker-java-transport-httpclient5</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+				<configuration>
+					<!-- TODO remove once this module is released -->
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Export-Package>com.github.dockerjava.zerodep.*</Export-Package>
+					</instructions>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<configuration>
+					<createDependencyReducedPom>true</createDependencyReducedPom>
+					<promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+					<createSourcesJar>true</createSourcesJar>
+
+					<artifactSet>
+						<excludes>
+							<exclude>com.github.docker-java:docker-java-transport</exclude>
+							<exclude>net.java.dev.jna:jna-platform</exclude>
+							<exclude>net.java.dev.jna:*</exclude>
+							<exclude>org.slf4j:slf4j-api</exclude>
+						</excludes>
+					</artifactSet>
+					<filters>
+						<filter>
+							<artifact>com.github.docker-java:docker-java-transport-httpclient5</artifact>
+							<excludes>
+								<exclude>com/github/dockerjava/httpclient5/ApacheDockerHttpClient.class</exclude>
+								<exclude>com/github/dockerjava/httpclient5/ApacheDockerHttpClient$*</exclude>
+							</excludes>
+						</filter>
+						<filter>
+							<artifact>org.apache.httpcomponents.client5:httpclient5</artifact>
+							<excludes>
+								<exclude>mozilla/*</exclude>
+							</excludes>
+						</filter>
+					</filters>
+					<relocations>
+						<relocation>
+							<pattern>org.apache</pattern>
+							<shadedPattern>com.github.dockerjava.zerodep.shaded.org.apache</shadedPattern>
+						</relocation>
+						<relocation>
+							<pattern>com.github.dockerjava.httpclient5</pattern>
+							<shadedPattern>com.github.dockerjava.zerodep</shadedPattern>
+						</relocation>
+					</relocations>
+					<transformers>
+						<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+					</transformers>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/docker-java-transport-zerodep/src/main/java/com/github/dockerjava/httpclient5/ZerodepDockerHttpClient.java
+++ b/docker-java-transport-zerodep/src/main/java/com/github/dockerjava/httpclient5/ZerodepDockerHttpClient.java
@@ -5,7 +5,8 @@ import com.github.dockerjava.transport.SSLConfig;
 import java.net.URI;
 import java.util.Objects;
 
-public final class ApacheDockerHttpClient extends ApacheDockerHttpClientImpl {
+@SuppressWarnings("unused")
+public final class ZerodepDockerHttpClient extends ApacheDockerHttpClientImpl {
 
     public static final class Builder {
 
@@ -23,13 +24,13 @@ public final class ApacheDockerHttpClient extends ApacheDockerHttpClientImpl {
             return this;
         }
 
-        public ApacheDockerHttpClient build() {
+        public ZerodepDockerHttpClient build() {
             Objects.requireNonNull(dockerHost, "dockerHost");
-            return new ApacheDockerHttpClient(dockerHost, sslConfig);
+            return new ZerodepDockerHttpClient(dockerHost, sslConfig);
         }
     }
 
-    private ApacheDockerHttpClient(URI dockerHost, SSLConfig sslConfig) {
+    protected ZerodepDockerHttpClient(URI dockerHost, SSLConfig sslConfig) {
         super(dockerHost, sslConfig);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
 		<module>docker-java-transport-jersey</module>
 		<module>docker-java-transport-okhttp</module>
 		<module>docker-java-transport-httpclient5</module>
+		<module>docker-java-transport-zerodep</module>
 		<module>docker-java</module>
 	</modules>
 


### PR DESCRIPTION
Well, not really "0 dependencies", but only slf4j-api and JNA, which is fine-ish.