### PR TITLE
Compile each file match pattern only once

### DIFF
--- a/docker-java-core/src/main/java/com/github/dockerjava/core/GoLangFileMatch.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/GoLangFileMatch.java
@@ -5,7 +5,9 @@ package com.github.dockerjava.core;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
@@ -52,6 +54,8 @@ public class GoLangFileMatch {
 
     private static final String PATTERN_CHARS_TO_ESCAPE = "\\.[]{}()*+-?^$|";
 
+    private static final Map<String, Pattern> PATTERNS = new HashMap<>();
+
     public static boolean match(List<String> patterns, File file) {
         return !match(patterns, file.getPath()).isEmpty();
     }
@@ -74,7 +78,7 @@ public class GoLangFileMatch {
     }
 
     public static boolean match(String pattern, String name) {
-        return buildPattern(pattern).matcher(name).matches();
+        return PATTERNS.computeIfAbsent(pattern, GoLangFileMatch::buildPattern).matcher(name).matches();
     }
 
     private static Pattern buildPattern(String pattern) {


### PR DESCRIPTION
I ran a profiler to analyse performance of ``ScannedResult # addFilesInDirectory`` in the scenario described in #1409. All ignore strings must be matched on each of the +60k files, and a not neglible amount of time is spent compiling the Strings from ``ignores`` into patterns over and over again. It seems sensible to cache already compiled patterns into a map for quick resolution.

Unfortunately, it does not improve the situation in #1409 too much. The majority of processing time is spent walking the directory tree, which is possibly bound by I/O.