### PR TITLE
Memoize file match patterns

### DIFF
--- a/docker-java-core/src/main/java/com/github/dockerjava/core/GoLangFileMatch.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/GoLangFileMatch.java
@@ -59,8 +59,8 @@ public class GoLangFileMatch {
     private static final String PATTERN_CHARS_TO_ESCAPE = "\\.[]{}()*+-?^$|";
 
     private static final LoadingCache<String, Pattern> PATTERN_CACHE = CacheBuilder.newBuilder()
-        .expireAfterWrite(1, TimeUnit.HOURS) // ttl 1 hour
-        .maximumSize(50) // max 50 entries
+        .expireAfterAccess(1, TimeUnit.HOURS)
+        .maximumSize(10_000)
         .build(CacheLoader.from(GoLangFileMatch::buildPattern));
 
     public static boolean match(List<String> patterns, File file) {

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/GoLangFileMatch.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/GoLangFileMatch.java
@@ -6,8 +6,14 @@ package com.github.dockerjava.core;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.apache.commons.lang.StringUtils;
 
 import com.github.dockerjava.core.exception.GoLangFileMatchException;
@@ -52,6 +58,11 @@ public class GoLangFileMatch {
 
     private static final String PATTERN_CHARS_TO_ESCAPE = "\\.[]{}()*+-?^$|";
 
+    private static final LoadingCache<String, Pattern> PATTERN_CACHE = CacheBuilder.newBuilder()
+        .expireAfterWrite(1, TimeUnit.HOURS) // ttl 1 hour
+        .maximumSize(50) // max 50 entries
+        .build(CacheLoader.from(GoLangFileMatch::buildPattern));
+
     public static boolean match(List<String> patterns, File file) {
         return !match(patterns, file.getPath()).isEmpty();
     }
@@ -74,7 +85,11 @@ public class GoLangFileMatch {
     }
 
     public static boolean match(String pattern, String name) {
-        return buildPattern(pattern).matcher(name).matches();
+        try {
+            return PATTERN_CACHE.get(pattern).matcher(name).matches();
+        } catch (ExecutionException | UncheckedExecutionException e) {
+            throw new GoLangFileMatchException(e.getCause().getMessage());
+        }
     }
 
     private static Pattern buildPattern(String pattern) {


### PR DESCRIPTION
I ran a profiler to analyse performance of ScannedResult # addFilesInDirectory in the scenario described in #1409. All ignore strings must be matched on each of the +60k files, and a not neglible amount of time is spent compiling the Strings from ignores into patterns over and over again. It seems sensible to cache already compiled patterns into a map for quick resolution.

Unfortunately, it does not improve the situation in #1409 too much. The majority of processing time is spent walking the directory tree, which is possibly bound by I/O.