### PR TITLE
Catch more generic `FileSystemException` in `NamedPipeSocket`

### DIFF
--- a/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/NamedPipeSocket.java
+++ b/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/NamedPipeSocket.java
@@ -15,7 +15,7 @@ import java.nio.channels.AsynchronousCloseException;
 import java.nio.channels.AsynchronousFileChannel;
 import java.nio.channels.Channels;
 import java.nio.channels.CompletionHandler;
-import java.nio.file.NoSuchFileException;
+import java.nio.file.FileSystemException;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.CompletableFuture;
@@ -57,7 +57,7 @@ class NamedPipeSocket extends Socket {
                     )
                 );
                 break;
-            } catch (NoSuchFileException e) {
+            } catch (FileSystemException e) {
                 if (System.currentTimeMillis() - startedAt >= timeout) {
                     throw new RuntimeException(e);
                 } else {

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/NamedPipeSocket.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/NamedPipeSocket.java
@@ -15,7 +15,7 @@ import java.nio.channels.AsynchronousCloseException;
 import java.nio.channels.AsynchronousFileChannel;
 import java.nio.channels.Channels;
 import java.nio.channels.CompletionHandler;
-import java.nio.file.NoSuchFileException;
+import java.nio.file.FileSystemException;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.CompletableFuture;
@@ -58,7 +58,7 @@ class NamedPipeSocket extends Socket {
                     )
                 );
                 break;
-            } catch (NoSuchFileException e) {
+            } catch (FileSystemException e) {
                 if (System.currentTimeMillis() - startedAt >= timeout) {
                     throw new RuntimeException(e);
                 } else {


### PR DESCRIPTION
When npipe is busy, it throws the following exception:
`java.nio.file.FileSystemException: \\.\pipe\docker_engine: All pipe instances are busy.`

The previous, RandomAccessFile-base implementation was catching it as `FileNotFoundException`.
But the NIO-based one seems to be throwing a generic `FileSystemException`.