### PR TITLE
Upgrade to Netty 4.1.51.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
 		<!-- test dependencies -->
 		<logback.version>1.2.3</logback.version>
-		<netty.version>4.1.46.Final</netty.version>
+		<netty.version>4.1.51.Final</netty.version>
 		<hamcrest.library.version>2.2</hamcrest.library.version>
 		<hamcrest.jpa-matchers>1.8</hamcrest.jpa-matchers>
 		<lambdaj.version>2.3.3</lambdaj.version>


### PR DESCRIPTION
The update netty ver 4.1.50 includes both security fixes and AArch64 performance improvements
Refer release notes for detail: https://netty.io/news/2020/05/13/4-1-50-Final.html

Signed-off-by: odidev <odidev@puresoftware.com>