### PR TITLE
add support for docker-for-windows new bind serialization format

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Bind.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Bind.java
@@ -103,7 +103,7 @@ public class Bind implements Serializable {
                     return new Bind(parts[0], new Volume(parts[1]));
                 }
                 case 4: {
-                    parts = new String[]{parts[0] +":"+ parts[1], parts[2], parts[3]};
+                    parts = new String[]{parts[0] + ":" + parts[1], parts[2], parts[3]};
                 }
                 case 3: {
                     String[] flags = parts[2].split(",");

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Bind.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Bind.java
@@ -97,41 +97,39 @@ public class Bind implements Serializable {
      */
     public static Bind parse(String serialized) {
         try {
-            String[] parts = serialized.split(":");
+            // Split by ':' but not ':\' (Windows-style path)
+            String[] parts = serialized.split(":(?!\\\\)");
             switch (parts.length) {
-                case 2: {
-                    return new Bind(parts[0], new Volume(parts[1]));
-                }
-                case 4: {
-                    parts = new String[]{parts[0] + ":" + parts[1], parts[2], parts[3]};
-                }
-                case 3: {
-                    String[] flags = parts[2].split(",");
-                    AccessMode accessMode = AccessMode.DEFAULT;
-                    SELContext seMode = SELContext.DEFAULT;
-                    Boolean nocopy = null;
-                    PropagationMode propagationMode = PropagationMode.DEFAULT_MODE;
-                    for (String p : flags) {
-                        if (p.length() == 2) {
-                            accessMode = AccessMode.valueOf(p.toLowerCase());
-                        } else if ("nocopy".equals(p)) {
-                            nocopy = true;
-                        } else if (PropagationMode.SHARED.toString().equals(p)) {
-                            propagationMode = PropagationMode.SHARED;
-                        } else if (PropagationMode.SLAVE.toString().equals(p)) {
-                            propagationMode = PropagationMode.SLAVE;
-                        } else if (PropagationMode.PRIVATE.toString().equals(p)) {
-                            propagationMode = PropagationMode.PRIVATE;
-                        } else {
-                            seMode = SELContext.fromString(p);
-                        }
+            case 2: {
+                return new Bind(parts[0], new Volume(parts[1]));
+            }
+            case 3: {
+                String[] flags = parts[2].split(",");
+                AccessMode accessMode = AccessMode.DEFAULT;
+                SELContext seMode = SELContext.DEFAULT;
+                Boolean nocopy = null;
+                PropagationMode propagationMode = PropagationMode.DEFAULT_MODE;
+                for (String p : flags) {
+                    if (p.length() == 2) {
+                        accessMode = AccessMode.valueOf(p.toLowerCase());
+                    } else if ("nocopy".equals(p)) {
+                        nocopy = true;
+                    } else if (PropagationMode.SHARED.toString().equals(p)) {
+                        propagationMode = PropagationMode.SHARED;
+                    } else if (PropagationMode.SLAVE.toString().equals(p)) {
+                        propagationMode = PropagationMode.SLAVE;
+                    } else if (PropagationMode.PRIVATE.toString().equals(p)) {
+                        propagationMode = PropagationMode.PRIVATE;
+                    } else {
+                        seMode = SELContext.fromString(p);
                     }
+                }
 
-                    return new Bind(parts[0], new Volume(parts[1]), accessMode, seMode, nocopy, propagationMode);
-                }
-                default: {
-                    throw new IllegalArgumentException();
-                }
+                return new Bind(parts[0], new Volume(parts[1]), accessMode, seMode, nocopy, propagationMode);
+            }
+            default: {
+                throw new IllegalArgumentException();
+            }
             }
         } catch (Exception e) {
             throw new IllegalArgumentException("Error parsing Bind '" + serialized + "'", e);

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Bind.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Bind.java
@@ -99,36 +99,39 @@ public class Bind implements Serializable {
         try {
             String[] parts = serialized.split(":");
             switch (parts.length) {
-            case 2: {
-                return new Bind(parts[0], new Volume(parts[1]));
-            }
-            case 3: {
-                String[] flags = parts[2].split(",");
-                AccessMode accessMode = AccessMode.DEFAULT;
-                SELContext seMode = SELContext.DEFAULT;
-                Boolean nocopy = null;
-                PropagationMode propagationMode = PropagationMode.DEFAULT_MODE;
-                for (String p : flags) {
-                    if (p.length() == 2) {
-                        accessMode = AccessMode.valueOf(p.toLowerCase());
-                    } else if ("nocopy".equals(p)) {
-                        nocopy = true;
-                    } else if (PropagationMode.SHARED.toString().equals(p)) {
-                        propagationMode = PropagationMode.SHARED;
-                    } else if (PropagationMode.SLAVE.toString().equals(p)) {
-                        propagationMode = PropagationMode.SLAVE;
-                    } else if (PropagationMode.PRIVATE.toString().equals(p)) {
-                        propagationMode = PropagationMode.PRIVATE;
-                    } else {
-                        seMode = SELContext.fromString(p);
-                    }
+                case 2: {
+                    return new Bind(parts[0], new Volume(parts[1]));
                 }
+                case 4: {
+                    parts = new String[]{parts[0] +":"+ parts[1], parts[2], parts[3]};
+                }
+                case 3: {
+                    String[] flags = parts[2].split(",");
+                    AccessMode accessMode = AccessMode.DEFAULT;
+                    SELContext seMode = SELContext.DEFAULT;
+                    Boolean nocopy = null;
+                    PropagationMode propagationMode = PropagationMode.DEFAULT_MODE;
+                    for (String p : flags) {
+                        if (p.length() == 2) {
+                            accessMode = AccessMode.valueOf(p.toLowerCase());
+                        } else if ("nocopy".equals(p)) {
+                            nocopy = true;
+                        } else if (PropagationMode.SHARED.toString().equals(p)) {
+                            propagationMode = PropagationMode.SHARED;
+                        } else if (PropagationMode.SLAVE.toString().equals(p)) {
+                            propagationMode = PropagationMode.SLAVE;
+                        } else if (PropagationMode.PRIVATE.toString().equals(p)) {
+                            propagationMode = PropagationMode.PRIVATE;
+                        } else {
+                            seMode = SELContext.fromString(p);
+                        }
+                    }
 
-                return new Bind(parts[0], new Volume(parts[1]), accessMode, seMode, nocopy, propagationMode);
-            }
-            default: {
-                throw new IllegalArgumentException();
-            }
+                    return new Bind(parts[0], new Volume(parts[1]), accessMode, seMode, nocopy, propagationMode);
+                }
+                default: {
+                    throw new IllegalArgumentException();
+                }
             }
         } catch (Exception e) {
             throw new IllegalArgumentException("Error parsing Bind '" + serialized + "'", e);

--- a/docker-java-transport-zerodep/pom.xml
+++ b/docker-java-transport-zerodep/pom.xml
@@ -48,6 +48,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.2.4</version>
 				<configuration>
 					<createDependencyReducedPom>true</createDependencyReducedPom>
 					<promoteTransitiveDependencies>true</promoteTransitiveDependencies>

--- a/docker-java-transport-zerodep/pom.xml
+++ b/docker-java-transport-zerodep/pom.xml
@@ -48,7 +48,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.2.4</version>
 				<configuration>
 					<createDependencyReducedPom>true</createDependencyReducedPom>
 					<promoteTransitiveDependencies>true</promoteTransitiveDependencies>

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/BindTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/BindTest.java
@@ -27,6 +27,113 @@ public class BindTest {
     }
 
     @Test
+    public void parseReadWriteWindows() {
+        Bind bind = Bind.parse("C:\\host:/container:rw");
+        assertThat(bind.getPath(), is("C:\\host"));
+        assertThat(bind.getVolume().getPath(), is("/container"));
+        assertThat(bind.getAccessMode(), is(rw));
+        assertThat(bind.getSecMode(), is(SELContext.none));
+        assertThat(bind.getNoCopy(), nullValue());
+        assertThat(bind.getPropagationMode(), is(PropagationMode.DEFAULT_MODE));
+    }
+
+    @Test
+    public void parseReadWriteNoCopyWindows() {
+        Bind bind = Bind.parse("C:\\host:/container:rw,nocopy");
+        assertThat(bind.getPath(), is("C:\\host"));
+        assertThat(bind.getVolume().getPath(), is("/container"));
+        assertThat(bind.getAccessMode(), is(rw));
+        assertThat(bind.getSecMode(), is(SELContext.none));
+        assertThat(bind.getNoCopy(), is(true));
+        assertThat(bind.getPropagationMode(), is(PropagationMode.DEFAULT_MODE));
+    }
+
+    @Test
+    public void parseReadWriteSharedWindows() {
+        Bind bind = Bind.parse("C:\\host:/container:rw,shared");
+        assertThat(bind.getPath(), is("C:\\host"));
+        assertThat(bind.getVolume().getPath(), is("/container"));
+        assertThat(bind.getAccessMode(), is(rw));
+        assertThat(bind.getSecMode(), is(SELContext.none));
+        assertThat(bind.getNoCopy(), nullValue());
+        assertThat(bind.getPropagationMode(), is(PropagationMode.SHARED));
+    }
+
+    @Test
+    public void parseReadWriteSlaveWindows() {
+        Bind bind = Bind.parse("C:\\host:/container:rw,slave");
+        assertThat(bind.getPath(), is("C:\\host"));
+        assertThat(bind.getVolume().getPath(), is("/container"));
+        assertThat(bind.getAccessMode(), is(rw));
+        assertThat(bind.getSecMode(), is(SELContext.none));
+        assertThat(bind.getNoCopy(), nullValue());
+        assertThat(bind.getPropagationMode(), is(PropagationMode.SLAVE));
+    }
+
+    @Test
+    public void parseReadWritePrivateWindows() {
+        Bind bind = Bind.parse("C:\\host:/container:rw,private");
+        assertThat(bind.getPath(), is("C:\\host"));
+        assertThat(bind.getVolume().getPath(), is("/container"));
+        assertThat(bind.getAccessMode(), is(rw));
+        assertThat(bind.getSecMode(), is(SELContext.none));
+        assertThat(bind.getNoCopy(), nullValue());
+        assertThat(bind.getPropagationMode(), is(PropagationMode.PRIVATE));
+    }
+
+    @Test
+    public void parseReadOnlyWindows() {
+        Bind bind = Bind.parse("C:\\host:/container:ro");
+        assertThat(bind.getPath(), is("C:\\host"));
+        assertThat(bind.getVolume().getPath(), is("/container"));
+        assertThat(bind.getAccessMode(), is(ro));
+        assertThat(bind.getSecMode(), is(SELContext.none));
+        assertThat(bind.getNoCopy(), nullValue());
+        assertThat(bind.getPropagationMode(), is(PropagationMode.DEFAULT_MODE));
+    }
+
+    @Test
+    public void parseSELOnlyWindows() {
+        Bind bind = Bind.parse("C:\\host:/container:Z");
+        assertThat(bind.getPath(), is("C:\\host"));
+        assertThat(bind.getVolume().getPath(), is("/container"));
+        assertThat(bind.getAccessMode(), is(AccessMode.DEFAULT));
+        assertThat(bind.getSecMode(), is(SELContext.single));
+        assertThat(bind.getNoCopy(), nullValue());
+        assertThat(bind.getPropagationMode(), is(PropagationMode.DEFAULT_MODE));
+
+        bind = Bind.parse("C:\\host:/container:z");
+        assertThat(bind.getPath(), is("C:\\host"));
+        assertThat(bind.getVolume().getPath(), is("/container"));
+        assertThat(bind.getAccessMode(), is(AccessMode.DEFAULT));
+        assertThat(bind.getSecMode(), is(SELContext.shared));
+        assertThat(bind.getNoCopy(), nullValue());
+        assertThat(bind.getPropagationMode(), is(PropagationMode.DEFAULT_MODE));
+    }
+
+    @Test
+    public void parseReadWriteSELWindows() {
+        Bind bind = Bind.parse("C:\\host:/container:rw,Z");
+        assertThat(bind.getPath(), is("C:\\host"));
+        assertThat(bind.getVolume().getPath(), is("/container"));
+        assertThat(bind.getAccessMode(), is(rw));
+        assertThat(bind.getSecMode(), is(SELContext.single));
+        assertThat(bind.getNoCopy(), nullValue());
+        assertThat(bind.getPropagationMode(), is(PropagationMode.DEFAULT_MODE));
+    }
+
+    @Test
+    public void parseReadOnlySELWindows() {
+        Bind bind = Bind.parse("C:\\host:/container:ro,z");
+        assertThat(bind.getPath(), is("C:\\host"));
+        assertThat(bind.getVolume().getPath(), is("/container"));
+        assertThat(bind.getAccessMode(), is(ro));
+        assertThat(bind.getSecMode(), is(SELContext.shared));
+        assertThat(bind.getNoCopy(), nullValue());
+        assertThat(bind.getPropagationMode(), is(PropagationMode.DEFAULT_MODE));
+    }
+
+    @Test
     public void parseReadWrite() {
         Bind bind = Bind.parse("/host:/container:rw");
         assertThat(bind.getPath(), is("/host"));


### PR DESCRIPTION
docker-for-windows has recently changed the way it presents bind information (see: https://github.com/docker-java/docker-java/issues/1462) this PR fixes this client + docker-for-windows. 