### PR TITLE
Fix "docker-java-stream" thread stuck at UnixDomainSocket.recv()

### DIFF
--- a/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/UnixDomainSocket.java
+++ b/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/UnixDomainSocket.java
@@ -257,7 +257,7 @@ class UnixDomainSocket extends Socket {
         public int read() throws IOException {
             byte[] bytes = new byte[1];
             int bytesRead = read(bytes);
-            if (bytesRead == 0) {
+            if (bytesRead <= 0) {
                 return -1;
             }
             return bytes[0] & 0xff;

--- a/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/UnixDomainSocket.java
+++ b/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/UnixDomainSocket.java
@@ -231,24 +231,16 @@ class UnixDomainSocket extends Socket {
         public int read(byte[] bytesEntry, int off, int len) throws IOException {
             try {
                 if (off > 0) {
-                    int bytes = 0;
-                    int remainingLength = len;
-                    int size;
                     byte[] data = new byte[(len < 10240) ? len : 10240];
-                    do {
-                        if (!isConnected()) {
-                            return -1;
-                        }
-                        size = UnixDomainSocket.read(fd, data, (remainingLength < 10240) ? remainingLength : 10240);
-                        if (size <= 0) {
-                            return -1;
-                        }
-                        System.arraycopy(data, 0, bytesEntry, off, size);
-                        bytes += size;
-                        off += size;
-                        remainingLength -= size;
-                    } while ((remainingLength > 0) && (size > 0));
-                    return bytes;
+                    if (!isConnected()) {
+                        return -1;
+                    }
+                    int size = UnixDomainSocket.read(fd, data, (len < 10240) ? len : 10240);
+                    if (size <= 0) {
+                        return -1;
+                    }
+                    System.arraycopy(data, 0, bytesEntry, off, size);
+                    return size;
                 } else {
                     if (!isConnected()) {
                         return -1;

--- a/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/UnixDomainSocket.java
+++ b/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/UnixDomainSocket.java
@@ -229,12 +229,12 @@ class UnixDomainSocket extends Socket {
 
         @Override
         public int read(byte[] bytesEntry, int off, int len) throws IOException {
+            if (!isConnected()) {
+                return -1;
+            }
             try {
                 if (off > 0) {
                     byte[] data = new byte[(len < 10240) ? len : 10240];
-                    if (!isConnected()) {
-                        return -1;
-                    }
                     int size = UnixDomainSocket.read(fd, data, data.length);
                     if (size <= 0) {
                         return -1;
@@ -242,9 +242,6 @@ class UnixDomainSocket extends Socket {
                     System.arraycopy(data, 0, bytesEntry, off, size);
                     return size;
                 } else {
-                    if (!isConnected()) {
-                        return -1;
-                    }
                     int size = UnixDomainSocket.read(fd, bytesEntry, len);
                     if (size <= 0) {
                         return -1;

--- a/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/UnixDomainSocket.java
+++ b/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/UnixDomainSocket.java
@@ -235,7 +235,7 @@ class UnixDomainSocket extends Socket {
                     if (!isConnected()) {
                         return -1;
                     }
-                    int size = UnixDomainSocket.read(fd, data, (len < 10240) ? len : 10240);
+                    int size = UnixDomainSocket.read(fd, data, data.length);
                     if (size <= 0) {
                         return -1;
                     }

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/UnixDomainSocket.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/UnixDomainSocket.java
@@ -232,20 +232,12 @@ class UnixDomainSocket extends Socket {
         public int read(byte[] bytesEntry, int off, int len) throws IOException {
             try {
                 if (off > 0) {
-                    int bytes = 0;
-                    int remainingLength = len;
-                    int size;
                     byte[] data = new byte[(len < 10240) ? len : 10240];
-                    do {
-                        size = recv(fd, data, (remainingLength < 10240) ? remainingLength : 10240, 0);
-                        if (size > 0) {
-                            System.arraycopy(data, 0, bytesEntry, off, size);
-                            bytes += size;
-                            off += size;
-                            remainingLength -= size;
-                        }
-                    } while ((remainingLength > 0) && (size > 0));
-                    return bytes;
+                    int size = recv(fd, data, (len < 10240) ? len : 10240, 0);
+                    if (size > 0) {
+                        System.arraycopy(data, 0, bytesEntry, off, size);
+                    }
+                    return size;
                 } else {
                     return recv(fd, bytesEntry, len, 0);
                 }

--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/UnixDomainSocket.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/UnixDomainSocket.java
@@ -233,7 +233,7 @@ class UnixDomainSocket extends Socket {
             try {
                 if (off > 0) {
                     byte[] data = new byte[(len < 10240) ? len : 10240];
-                    int size = recv(fd, data, (len < 10240) ? len : 10240, 0);
+                    int size = recv(fd, data, data.length, 0);
                     if (size > 0) {
                         System.arraycopy(data, 0, bytesEntry, off, size);
                     }


### PR DESCRIPTION
The fix is trivial and it is located in `com.github.dockerjava.okhttp.UnixDomainSocket.UnixSocketInputStream.read(byte[], int, int)`.

I have also fixed `AttachContainerCmdIT`, which used to fail for me from time to time because of the race condition. I believe the canonical way is to: (1) create the container, (2) attach to it, and then (3) start it. The last two actions have been previously shifted. This led to the race condition: the container might have finished its execution before the attach actually happened.

For me (with Docker for Mac 2.4.0.0), the issue is reproduced in `com.github.dockerjava.cmd.AttachContainerCmdIT.attachContainerWithTTY` test for OkHttp transport:
1. Sporadically in `master` branch.

2. Steadily after applying the PR #1483 with the patch for `AttachContainerCmdIT`:
The `main` thread waits for `AttachContainerTestCallback` to complete.
	```
	"main@1" prio=5 tid=0x1 nid=NA waiting
	  java.lang.Thread.State: WAITING
		  at jdk.internal.misc.Unsafe.park(Unsafe.java:-1)
		  at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:234)
		  at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedNanos(AbstractQueuedSynchronizer.java:1079)
		  at java.util.concurrent.locks.AbstractQueuedSynchronizer.tryAcquireSharedNanos(AbstractQueuedSynchronizer.java:1369)
		  at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:278)
		  at com.github.dockerjava.api.async.ResultCallbackTemplate.awaitCompletion(ResultCallbackTemplate.java:111)
		  at com.github.dockerjava.cmd.AttachContainerCmdIT.attachContainerWithTTY(AttachContainerCmdIT.java:169)
		  ...
		  at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:53)
	```
	And `docker-java-stream` thread is stuck on `recv()` when trying to process HTTP response headers of `attach` command (while it should read the standard streams of the Docker container):
	```
	"docker-java-stream-1410725528" #28 daemon prio=5 os_prio=31 cpu=0.82ms elapsed=1.92s tid=0x00007f8fb7115000 nid=0x9f07 runnable  [0x000070000c28b000]
	   java.lang.Thread.State: RUNNABLE
		at com.github.dockerjava.okhttp.UnixDomainSocket.recv(Native Method)
		at com.github.dockerjava.okhttp.UnixDomainSocket$UnixSocketInputStream.read(UnixDomainSocket.java:240)
		at java.io.FilterInputStream.read(java.base@11.0.8/FilterInputStream.java:133)
		at com.github.dockerjava.okhttp.UnixSocketFactory$1$1.read(UnixSocketFactory.java:45)
		at okio.Okio$2.read(Okio.java:140)
		at okio.AsyncTimeout$2.read(AsyncTimeout.java:237)
		at okio.RealBufferedSource.indexOf(RealBufferedSource.java:358)
		at okio.RealBufferedSource.readUtf8LineStrict(RealBufferedSource.java:230)
		at okhttp3.internal.http1.Http1ExchangeCodec.readHeaderLine(Http1ExchangeCodec.java:242)
		at okhttp3.internal.http1.Http1ExchangeCodec.readHeaders(Http1ExchangeCodec.java:251)
		at okhttp3.internal.http1.Http1ExchangeCodec.readResponseHeaders(Http1ExchangeCodec.java:219)
		at okhttp3.internal.connection.Exchange.readResponseHeaders(Exchange.java:115)
		at okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.java:94)
		at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
		at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117)
		at com.github.dockerjava.okhttp.HijackingInterceptor.intercept(HijackingInterceptor.java:20)
		at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
		at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:43)
		...
		at okhttp3.RealCall.execute(RealCall.java:81)
		at com.github.dockerjava.okhttp.OkDockerHttpClient$OkResponse.<init>(OkDockerHttpClient.java:251)
		at com.github.dockerjava.okhttp.OkDockerHttpClient.execute(OkDockerHttpClient.java:225)
		at com.github.dockerjava.cmd.TrackingDockerHttpClient.execute(TrackingDockerHttpClient.java:27)
		at com.github.dockerjava.core.DefaultInvocationBuilder.execute(DefaultInvocationBuilder.java:228)
		at com.github.dockerjava.core.DefaultInvocationBuilder.lambda$executeAndStream$1(DefaultInvocationBuilder.java:269)
		at com.github.dockerjava.core.DefaultInvocationBuilder$$Lambda$97/0x00000008002c1040.run(Unknown Source)
		at java.lang.Thread.run(java.base@11.0.8/Thread.java:834)

	```