### PR TITLE
Fix sporadic failures of AttachContainerCmdIT tests

### DIFF
--- a/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
@@ -26,8 +26,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -51,10 +51,10 @@ public class AttachContainerCmdIT extends CmdIT {
         String snippet = "hello world";
 
         CreateContainerResponse container = dockerClient.createContainerCmd("busybox")
-                .withCmd("/bin/sh", "-c", "sleep 1 && read line && echo $line")
-                .withTty(false)
-                .withStdinOpen(true)
-                .exec();
+            .withCmd("/bin/sh", "-c", "sleep 1 && read line && echo $line")
+            .withTty(false)
+            .withStdinOpen(true)
+            .exec();
 
         LOG.info("Created container: {}", container.toString());
         assertThat(container.getId(), not(is(emptyString())));
@@ -101,9 +101,9 @@ public class AttachContainerCmdIT extends CmdIT {
         String snippet = "hello world";
 
         CreateContainerResponse container = dockerClient.createContainerCmd(DEFAULT_IMAGE)
-                .withCmd("echo", snippet)
-                .withTty(false)
-                .exec();
+            .withCmd("echo", snippet)
+            .withTty(false)
+            .exec();
 
         LOG.info("Created container: {}", container.toString());
         assertThat(container.getId(), not(is(emptyString())));
@@ -119,12 +119,12 @@ public class AttachContainerCmdIT extends CmdIT {
         };
 
         dockerClient.attachContainerCmd(container.getId())
-                .withStdErr(true)
-                .withStdOut(true)
-                .withFollowStream(true)
-                .withLogs(true)
-                .exec(callback)
-                .awaitCompletion(30, TimeUnit.SECONDS);
+            .withStdErr(true)
+            .withStdOut(true)
+            .withFollowStream(true)
+            .withLogs(true)
+            .exec(callback)
+            .awaitCompletion(30, TimeUnit.SECONDS);
         callback.close();
 
         assertThat(callback.toString(), containsString(snippet));
@@ -135,7 +135,7 @@ public class AttachContainerCmdIT extends CmdIT {
         DockerClient dockerClient = dockerRule.getClient();
 
         File baseDir = new File(Thread.currentThread().getContextClassLoader()
-                .getResource("attachContainerTestDockerfile").getFile());
+            .getResource("attachContainerTestDockerfile").getFile());
 
         String imageId = dockerRule.buildImage(baseDir);
 
@@ -155,11 +155,11 @@ public class AttachContainerCmdIT extends CmdIT {
         };
 
         dockerClient.attachContainerCmd(container.getId())
-                .withStdErr(true)
-                .withStdOut(true)
-                .withFollowStream(true)
-                .exec(callback)
-                .awaitCompletion(15, TimeUnit.SECONDS);
+            .withStdErr(true)
+            .withStdOut(true)
+            .withFollowStream(true)
+            .exec(callback)
+            .awaitCompletion(15, TimeUnit.SECONDS);
         callback.close();
 
         LOG.debug("log: {}", callback.toString());
@@ -178,9 +178,9 @@ public class AttachContainerCmdIT extends CmdIT {
         String snippet = "hello world";
 
         CreateContainerResponse container = dockerClient.createContainerCmd(DEFAULT_IMAGE)
-                .withCmd("echo", snippet)
-                .withTty(false)
-                .exec();
+            .withCmd("echo", snippet)
+            .withTty(false)
+            .exec();
 
         LOG.info("Created container: {}", container.toString());
         assertThat(container.getId(), not(is(emptyString())));
@@ -198,13 +198,13 @@ public class AttachContainerCmdIT extends CmdIT {
         InputStream stdin = new ByteArrayInputStream("".getBytes());
 
         dockerClient.attachContainerCmd(container.getId())
-                .withStdErr(true)
-                .withStdOut(true)
-                .withFollowStream(true)
-                .withLogs(true)
-                .withStdIn(stdin)
-                .exec(callback)
-                .awaitCompletion(30, TimeUnit.SECONDS);
+            .withStdErr(true)
+            .withStdOut(true)
+            .withFollowStream(true)
+            .withLogs(true)
+            .withStdIn(stdin)
+            .exec(callback)
+            .awaitCompletion(30, TimeUnit.SECONDS);
         callback.close();
     }
 
@@ -217,33 +217,33 @@ public class AttachContainerCmdIT extends CmdIT {
         DockerClient dockerClient = dockerRule.getClient();
 
         CreateContainerResponse container = dockerClient.createContainerCmd(DEFAULT_IMAGE)
-                .withCmd("echo", "hello")
-                .withTty(false)
-                .exec();
+            .withCmd("echo", "hello")
+            .withTty(false)
+            .exec();
         LOG.info("Created container: {}", container.toString());
 
         CountDownLatch gotLine = new CountDownLatch(1);
         try (
-                ResultCallback.Adapter<Frame> resultCallback = dockerClient.attachContainerCmd(container.getId())
-                        .withStdOut(true)
-                        .withStdErr(true)
-                        .withFollowStream(true)
-                        .exec(new ResultCallback.Adapter<Frame>() {
-                            @Override
-                            public void onNext(Frame item) {
-                                LOG.info("Got frame: {}", item);
-                                if (item.getStreamType() == StreamType.STDOUT) {
-                                    gotLine.countDown();
-                                }
-                                super.onNext(item);
-                            }
+            ResultCallback.Adapter<Frame> resultCallback = dockerClient.attachContainerCmd(container.getId())
+                .withStdOut(true)
+                .withStdErr(true)
+                .withFollowStream(true)
+                .exec(new ResultCallback.Adapter<Frame>() {
+                    @Override
+                    public void onNext(Frame item) {
+                        LOG.info("Got frame: {}", item);
+                        if (item.getStreamType() == StreamType.STDOUT) {
+                            gotLine.countDown();
+                        }
+                        super.onNext(item);
+                    }
 
-                            @Override
-                            public void onComplete() {
-                                LOG.info("On complete");
-                                super.onComplete();
-                            }
-                        })
+                    @Override
+                    public void onComplete() {
+                        LOG.info("On complete");
+                        super.onComplete();
+                    }
+                })
         ) {
             resultCallback.awaitStarted(5, SECONDS);
             LOG.info("Attach started");

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
@@ -75,7 +75,7 @@ public class AttachContainerCmdIT extends CmdIT {
 
         try (
             PipedOutputStream out = new PipedOutputStream();
-            PipedInputStream in = new PipedInputStream(out);
+            PipedInputStream in = new PipedInputStream(out)
         ) {
             dockerClient.attachContainerCmd(container.getId())
                 .withStdErr(true)
@@ -115,7 +115,7 @@ public class AttachContainerCmdIT extends CmdIT {
             public void onNext(Frame frame) {
                 assertThat(frame.getStreamType(), equalTo(StreamType.STDOUT));
                 super.onNext(frame);
-            };
+            }
         };
 
         dockerClient.attachContainerCmd(container.getId())
@@ -151,7 +151,7 @@ public class AttachContainerCmdIT extends CmdIT {
             public void onNext(Frame frame) {
                 assertThat(frame.getStreamType(), equalTo(StreamType.RAW));
                 super.onNext(frame);
-            };
+            }
         };
 
         dockerClient.attachContainerCmd(container.getId())
@@ -192,7 +192,7 @@ public class AttachContainerCmdIT extends CmdIT {
             public void onNext(Frame frame) {
                 assertThat(frame.getStreamType(), equalTo(StreamType.STDOUT));
                 super.onNext(frame);
-            };
+            }
         };
 
         InputStream stdin = new ByteArrayInputStream("".getBytes());

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
@@ -258,7 +258,7 @@ public class AttachContainerCmdIT extends CmdIT {
     }
 
     public static class AttachContainerTestCallback extends ResultCallback.Adapter<Frame> {
-        private StringBuffer log = new StringBuffer();
+        private final StringBuffer log = new StringBuffer();
 
         @Override
         public void onNext(Frame item) {

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
@@ -50,7 +50,7 @@ public class AttachContainerCmdIT extends CmdIT {
         String snippet = "hello world";
 
         CreateContainerResponse container = dockerClient.createContainerCmd("busybox")
-            .withCmd("/bin/sh", "-c", "sleep 1 && read line && echo $line")
+            .withCmd("/bin/sh", "-c", "read line && echo $line")
             .withTty(false)
             .withAttachStdin(true)
             .withAttachStdout(true)

--- a/docker-java/src/test/resources/attachContainerTestDockerfile/echo.sh
+++ b/docker-java/src/test/resources/attachContainerTestDockerfile/echo.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-while sleep 2; do echo stdout && echo stderr >&2; done
+echo stdout && echo stderr >&2


### PR DESCRIPTION
Fix `AttachContainerCmdIT`, which used to fail for me from time to time because of the race condition. I believe the canonical way is to: (1) create the container, (2) attach to it, and then (3) start it. The last two actions have been previously shifted. This led to the race condition: the container might have finished its execution before the attach actually happened.

Please note that the test `com.github.dockerjava.cmd.AttachContainerCmdIT.attachContainerWithTTY` might fail now with the exception:
```
java.lang.AssertionError: 
Expected: a string containing "stdout\r\nstderr"
     but: was ""
<Click to see difference>


	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
	at com.github.dockerjava.cmd.AttachContainerCmdIT.attachContainerWithTTY(AttachContainerCmdIT.java:175)
	...
```

This happens because `docker-java-stream-...` worker thread is stuck on `recv()` system call while receiving HTTP headers response for `attach` request to the container:
```
"docker-java-stream--616211391@3896" daemon prio=5 tid=0x1b nid=NA runnable
  java.lang.Thread.State: RUNNABLE
	  at com.github.dockerjava.okhttp.UnixDomainSocket.recv(UnixDomainSocket.java:-1)
	  at com.github.dockerjava.okhttp.UnixDomainSocket$UnixSocketInputStream.read(UnixDomainSocket.java:240)
	  at java.io.FilterInputStream.read(FilterInputStream.java:133)
	  at com.github.dockerjava.okhttp.UnixSocketFactory$1$1.read(UnixSocketFactory.java:45)
	  at okio.Okio$2.read(Okio.java:140)
	  at okio.AsyncTimeout$2.read(AsyncTimeout.java:237)
	  at okio.RealBufferedSource.indexOf(RealBufferedSource.java:358)
	  at okio.RealBufferedSource.readUtf8LineStrict(RealBufferedSource.java:230)
	  at okhttp3.internal.http1.Http1ExchangeCodec.readHeaderLine(Http1ExchangeCodec.java:242)
	  at okhttp3.internal.http1.Http1ExchangeCodec.readHeaders(Http1ExchangeCodec.java:251)
	  at okhttp3.internal.http1.Http1ExchangeCodec.readResponseHeaders(Http1ExchangeCodec.java:219)
	  at okhttp3.internal.connection.Exchange.readResponseHeaders(Exchange.java:115)
	  at okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.java:94)
	  at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
	  at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117)
	  at com.github.dockerjava.okhttp.HijackingInterceptor.intercept(HijackingInterceptor.java:20)
	  at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
	  at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:43)
	  at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
	  at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117)
	  at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:94)
	  at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
	  at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117)
	  at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93)
	  at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
	  at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:88)
	  at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142)
	  at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117)
	  at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:229)
	  at okhttp3.RealCall.execute(RealCall.java:81)
	  at com.github.dockerjava.okhttp.OkDockerHttpClient$OkResponse.<init>(OkDockerHttpClient.java:251)
	  at com.github.dockerjava.okhttp.OkDockerHttpClient.execute(OkDockerHttpClient.java:225)
	  at com.github.dockerjava.cmd.TrackingDockerHttpClient.execute(TrackingDockerHttpClient.java:27)
	  at com.github.dockerjava.core.DefaultInvocationBuilder.execute(DefaultInvocationBuilder.java:228)
	  at com.github.dockerjava.core.DefaultInvocationBuilder.lambda$executeAndStream$1(DefaultInvocationBuilder.java:269)
	  at com.github.dockerjava.core.DefaultInvocationBuilder$$Lambda$82.1028811481.run(Unknown Source:-1)
	  at java.lang.Thread.run(Thread.java:834)
```

There is the PR with the fix for it #1476.