### PR TITLE
Workaround the problem with attachContainerWithTTY test failure (#1492)

### DIFF
--- a/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
@@ -164,6 +164,11 @@ public class AttachContainerCmdIT extends CmdIT {
             .withFollowStream(true)
             .exec(callback);
 
+        // The delay above is the workaround for #1492 issue for this test executed on Jersey or HttpClient5 transport implementations.
+        // Without the delay HTTP requests are sometimes performed in the reverse order ('start' and then 'attach').
+        // This results in the lost data from stdout and stderr streams of the container process and leads to the test failure.
+        Thread.sleep(5000L);
+
         dockerClient.startContainerCmd(container.getId()).exec();
 
         callback.awaitCompletion(15, TimeUnit.SECONDS);


### PR DESCRIPTION
Unfortunately, the attempt to fix issue #1492 with PR #1491 does not work out well. The test `AttachContainerCmdIT.attachContainerWithTTY()` keeps failing from time to time.

This is the workaround for this test to pass.