### PR TITLE
Support Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
           DOCKER_VERSION: ${{matrix.dockerVersion}}
           DOCKER_HOST: ${{matrix.dockerHost}}
         run: .ci/setup_docker.sh
+      - name: Print Docker info
+        run: docker info
       - name: Build with Maven
         env:
           DOCKER_HOST: ${{matrix.dockerHost}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,15 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ${{matrix.os}}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { name: "default" }
-          - { name: "over TCP", dockerHost: "tcp://127.0.0.1:2375" }
-          - { name: "Docker 18.06.3", dockerVersion: "18.06.3~ce~3-0~ubuntu" }
+          - { name: "default", os: "ubuntu-18.04" }
+          - { name: "over TCP", dockerHost: "tcp://127.0.0.1:2375", os: "ubuntu-18.04" }
+          - { name: "Docker 18.06.3", dockerVersion: "18.06.3~ce~3-0~ubuntu", os: "ubuntu-18.04" }
+          - { name: "Windows", os: "windows-2019" }
 
     steps:
       - uses: actions/checkout@v2
@@ -22,6 +23,7 @@ jobs:
         with:
           java-version: 8
       - name: Configure Docker
+        if: startsWith(matrix.os, 'ubuntu')
         env:
           DOCKER_VERSION: ${{matrix.dockerVersion}}
           DOCKER_HOST: ${{matrix.dockerHost}}
@@ -31,7 +33,7 @@ jobs:
           DOCKER_HOST: ${{matrix.dockerHost}}
         run: ./mvnw --no-transfer-progress verify
       - name: Aggregate test reports with ciMate
-        if: always()
+        if: startsWith(matrix.os, 'ubuntu')
         continue-on-error: true
         env:
           CIMATE_PROJECT_ID: lodr9d83

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Ignore all build/dist directories
 target
+*/dependency-reduced-pom.xml
 
 # Ignore InteliJ Idea project files
 .idea/


### PR DESCRIPTION
I'm trying development on Windows. Some of our libs ([A](https://github.com/atlassian-labs/db-replica), [B](https://github.com/atlassian/virtual-users)) use `docker-java` for testing. Unfortunately, the tests don't work out of the box due to Unix-centric defaults, resulting in:

<details>
<summary>java.io.IOException: Unix domain sockets are not supported on Windows</summary>

```java
java.lang.RuntimeException: java.lang.RuntimeException: java.io.IOException: Unix domain sockets are not supported on Windows
java.lang.RuntimeException: java.lang.RuntimeException: java.lang.RuntimeException: java.io.IOException: Unix domain sockets are not supported on Windows
	at com.atlassian.db.replica.internal.LazyReference.get(LazyReference.java:22)
	at com.atlassian.db.replica.internal.ReplicaStatement.getReadStatement(ReplicaStatement.java:521)
	at com.atlassian.db.replica.internal.ReplicaPreparedStatement.getReadStatement(ReplicaPreparedStatement.java:548)
	at com.atlassian.db.replica.internal.ReplicaPreparedStatement.executeQuery(ReplicaPreparedStatement.java:81)
	at com.atlassian.db.replica.internal.circuitbreaker.BreakerHandler.handle(BreakerHandler.java:17)
	at com.atlassian.db.replica.internal.circuitbreaker.BreakerPreparedStatement.executeQuery(BreakerPreparedStatement.java:39)
	at com.atlassian.db.replica.it.DualConnectionIT.shouldUseReplica(DualConnectionIT.java:17)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:119)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:182)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:164)
	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:414)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
	at java.lang.Thread.run(Thread.java:748)
	Suppressed: java.lang.RuntimeException: java.io.IOException: Unix domain sockets are not supported on Windows
		at com.github.dockerjava.httpclient5.ApacheDockerHttpClientImpl.execute(ApacheDockerHttpClientImpl.java:162)
		at com.github.dockerjava.httpclient5.ApacheDockerHttpClient.execute(ApacheDockerHttpClient.java:8)
		at com.github.dockerjava.core.DefaultInvocationBuilder.execute(DefaultInvocationBuilder.java:228)
		at com.github.dockerjava.core.DefaultInvocationBuilder.get(DefaultInvocationBuilder.java:202)
		at com.github.dockerjava.core.DefaultInvocationBuilder.get(DefaultInvocationBuilder.java:74)
		at com.github.dockerjava.core.exec.ListContainersCmdExec.execute(ListContainersCmdExec.java:44)
		at com.github.dockerjava.core.exec.ListContainersCmdExec.execute(ListContainersCmdExec.java:15)
		at com.github.dockerjava.core.exec.AbstrSyncDockerCmdExec.exec(AbstrSyncDockerCmdExec.java:21)
		at com.github.dockerjava.core.command.AbstrDockerCmd.exec(AbstrDockerCmd.java:35)
		at com.atlassian.db.replica.it.PostgresConnectionProvider.cleanUp(PostgresConnectionProvider.java:153)
		at com.atlassian.db.replica.it.PostgresConnectionProvider.close(PostgresConnectionProvider.java:81)
		at com.atlassian.db.replica.it.DualConnectionIT.shouldUseReplica(DualConnectionIT.java:21)
		... 47 more
	Caused by: java.io.IOException: Unix domain sockets are not supported on Windows
		at com.github.dockerjava.httpclient5.UnixDomainSocket.<init>(UnixDomainSocket.java:93)
		at com.github.dockerjava.httpclient5.ApacheDockerHttpClientImpl$2.createSocket(ApacheDockerHttpClientImpl.java:120)
		at org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:125)
		at org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:409)
		at org.apache.hc.client5.http.impl.classic.InternalExecRuntime.connectEndpoint(InternalExecRuntime.java:164)
		at org.apache.hc.client5.http.impl.classic.InternalExecRuntime.connectEndpoint(InternalExecRuntime.java:174)
		at org.apache.hc.client5.http.impl.classic.ConnectExec.execute(ConnectExec.java:135)
		at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
		at org.apache.hc.client5.http.impl.classic.ExecChainElement$1.proceed(ExecChainElement.java:57)
		at org.apache.hc.client5.http.impl.classic.ProtocolExec.execute(ProtocolExec.java:165)
		at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
		at org.apache.hc.client5.http.impl.classic.ExecChainElement$1.proceed(ExecChainElement.java:57)
		at org.apache.hc.client5.http.impl.classic.HttpRequestRetryExec.execute(HttpRequestRetryExec.java:93)
		at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
		at org.apache.hc.client5.http.impl.classic.ExecChainElement$1.proceed(ExecChainElement.java:57)
		at org.apache.hc.client5.http.impl.classic.RedirectExec.execute(RedirectExec.java:116)
		at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
		at org.apache.hc.client5.http.impl.classic.ExecChainElement$1.proceed(ExecChainElement.java:57)
		at org.apache.hc.client5.http.impl.classic.ContentCompressionExec.execute(ContentCompressionExec.java:128)
		at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
		at org.apache.hc.client5.http.impl.classic.InternalHttpClient.doExecute(InternalHttpClient.java:178)
		at org.apache.hc.client5.http.impl.classic.CloseableHttpClient.execute(CloseableHttpClient.java:67)
		at com.github.dockerjava.httpclient5.ApacheDockerHttpClientImpl.execute(ApacheDockerHttpClientImpl.java:158)
		... 58 more
Caused by: java.lang.RuntimeException: java.lang.RuntimeException: java.io.IOException: Unix domain sockets are not supported on Windows
	at com.atlassian.db.replica.internal.LazyReference.get(LazyReference.java:22)
	at com.atlassian.db.replica.internal.ReplicaConnectionProvider.getWriteConnection(ReplicaConnectionProvider.java:206)
	at com.atlassian.db.replica.internal.ReplicaConnectionProvider.getReadConnection(ReplicaConnectionProvider.java:179)
	at com.atlassian.db.replica.internal.ReplicaStatement$1.create(ReplicaStatement.java:38)
	at com.atlassian.db.replica.internal.ReplicaStatement$1.create(ReplicaStatement.java:35)
	at com.atlassian.db.replica.internal.LazyReference.get(LazyReference.java:20)
	... 53 more
Caused by: java.lang.RuntimeException: java.io.IOException: Unix domain sockets are not supported on Windows
	at com.github.dockerjava.httpclient5.ApacheDockerHttpClientImpl.execute(ApacheDockerHttpClientImpl.java:162)
	at com.github.dockerjava.httpclient5.ApacheDockerHttpClient.execute(ApacheDockerHttpClient.java:8)
	at com.github.dockerjava.core.DefaultInvocationBuilder.execute(DefaultInvocationBuilder.java:228)
	at com.github.dockerjava.core.DefaultInvocationBuilder.get(DefaultInvocationBuilder.java:202)
	at com.github.dockerjava.core.DefaultInvocationBuilder.get(DefaultInvocationBuilder.java:74)
	at com.github.dockerjava.core.exec.ListContainersCmdExec.execute(ListContainersCmdExec.java:44)
	at com.github.dockerjava.core.exec.ListContainersCmdExec.execute(ListContainersCmdExec.java:15)
	at com.github.dockerjava.core.exec.AbstrSyncDockerCmdExec.exec(AbstrSyncDockerCmdExec.java:21)
	at com.github.dockerjava.core.command.AbstrDockerCmd.exec(AbstrDockerCmd.java:35)
	at com.atlassian.db.replica.it.PostgresConnectionProvider.cleanUp(PostgresConnectionProvider.java:153)
	at com.atlassian.db.replica.it.PostgresConnectionProvider.initialize(PostgresConnectionProvider.java:65)
	at com.atlassian.db.replica.it.PostgresConnectionProvider.getMainConnection(PostgresConnectionProvider.java:34)
	at com.atlassian.db.replica.internal.ReplicaConnectionProvider$2.create(ReplicaConnectionProvider.java:41)
	at com.atlassian.db.replica.internal.ReplicaConnectionProvider$2.create(ReplicaConnectionProvider.java:38)
	at com.atlassian.db.replica.internal.LazyReference.get(LazyReference.java:20)
	... 58 more
Caused by: java.io.IOException: Unix domain sockets are not supported on Windows
	at com.github.dockerjava.httpclient5.UnixDomainSocket.<init>(UnixDomainSocket.java:93)
	at com.github.dockerjava.httpclient5.ApacheDockerHttpClientImpl$2.createSocket(ApacheDockerHttpClientImpl.java:120)
	at org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:125)
	at org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:409)
	at org.apache.hc.client5.http.impl.classic.InternalExecRuntime.connectEndpoint(InternalExecRuntime.java:164)
	at org.apache.hc.client5.http.impl.classic.InternalExecRuntime.connectEndpoint(InternalExecRuntime.java:174)
	at org.apache.hc.client5.http.impl.classic.ConnectExec.execute(ConnectExec.java:135)
	at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
	at org.apache.hc.client5.http.impl.classic.ExecChainElement$1.proceed(ExecChainElement.java:57)
	at org.apache.hc.client5.http.impl.classic.ProtocolExec.execute(ProtocolExec.java:165)
	at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
	at org.apache.hc.client5.http.impl.classic.ExecChainElement$1.proceed(ExecChainElement.java:57)
	at org.apache.hc.client5.http.impl.classic.HttpRequestRetryExec.execute(HttpRequestRetryExec.java:93)
	at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
	at org.apache.hc.client5.http.impl.classic.ExecChainElement$1.proceed(ExecChainElement.java:57)
	at org.apache.hc.client5.http.impl.classic.RedirectExec.execute(RedirectExec.java:116)
	at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
	at org.apache.hc.client5.http.impl.classic.ExecChainElement$1.proceed(ExecChainElement.java:57)
	at org.apache.hc.client5.http.impl.classic.ContentCompressionExec.execute(ContentCompressionExec.java:128)
	at org.apache.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
	at org.apache.hc.client5.http.impl.classic.InternalHttpClient.doExecute(InternalHttpClient.java:178)
	at org.apache.hc.client5.http.impl.classic.CloseableHttpClient.execute(CloseableHttpClient.java:67)
	at com.github.dockerjava.httpclient5.ApacheDockerHttpClientImpl.execute(ApacheDockerHttpClientImpl.java:158)
	... 72 more
```
</details>

Same with `docker-java-transport-okhttp`.

I plan to detect Windows and adjust default `DOCKER_HOST` to `npipe:////./pipe/docker_engine` (generic address) or `tcp://localhost:2375` (wider transport support).

I'm opening this as draft for early feedback on rationale and testing.