### PR TITLE
docker on macOS might use port binding in form of 0.0.0.0:0:8080/tcp breaking parser

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/PortBinding.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/PortBinding.java
@@ -43,7 +43,17 @@ public class PortBinding implements Serializable {
             switch (parts.length) {
                 case 3:
                     // 127.0.0.1:80:8080/tcp
-                    return createFromSubstrings(parts[0] + ":" + parts[1], parts[2]);
+                    // 0.0.0.0:0:8080/tcp
+                    if (parts[0].equals("0.0.0.0"))
+                        if (parts[1].equals("0"))
+                            return createFromSubstrings("", parts[2]);
+                        else
+                            return createFromSubstrings(parts[1], parts[2]);
+                    else
+                        if (parts[1].equals("0"))
+                            return createFromSubstrings(parts[0], parts[2]);
+                        else
+                            return createFromSubstrings(parts[0] + ":" + parts[1], parts[2]);
                 case 2:
                     // 80:8080 // 127.0.0.1::8080
                     return createFromSubstrings(parts[0], parts[1]);

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/PortBinding.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/PortBinding.java
@@ -43,17 +43,20 @@ public class PortBinding implements Serializable {
             switch (parts.length) {
                 case 3:
                     // 127.0.0.1:80:8080/tcp
-                    // 0.0.0.0:0:8080/tcp
-                    if (parts[0].equals("0.0.0.0"))
-                        if (parts[1].equals("0"))
+                    // or 0.0.0.0:0:8080/tcp on some docker versions on macOS
+                    if ("0.0.0.0".equals(parts[0])) {
+                        if ("0".equals(parts[1])) {
                             return createFromSubstrings("", parts[2]);
-                        else
+                        } else {
                             return createFromSubstrings(parts[1], parts[2]);
-                    else
-                        if (parts[1].equals("0"))
+                        }
+                    } else {
+                        if ("0".equals(parts[1])) {
                             return createFromSubstrings(parts[0], parts[2]);
-                        else
+                        } else {
                             return createFromSubstrings(parts[0] + ":" + parts[1], parts[2]);
+                        }
+                    }
                 case 2:
                     // 80:8080 // 127.0.0.1::8080
                     return createFromSubstrings(parts[0], parts[1]);

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/PortBindingTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/PortBindingTest.java
@@ -17,47 +17,53 @@ public class PortBindingTest {
 
     @Test
     public void fullDefinition() {
-        assertEquals(PortBinding.parse("127.0.0.1:80:8080/tcp"),
-                new PortBinding(Binding.bindIpAndPort("127.0.0.1", 80), TCP_8080));
+        assertEquals(new PortBinding(Binding.bindIpAndPort("127.0.0.1", 80), TCP_8080),
+            PortBinding.parse("127.0.0.1:80:8080/tcp"));
     }
 
     @Test
     public void noProtocol() {
-        assertEquals(PortBinding.parse("127.0.0.1:80:8080"), new PortBinding(Binding.bindIpAndPort("127.0.0.1", 80), TCP_8080));
+        assertEquals(new PortBinding(Binding.bindIpAndPort("127.0.0.1", 80), TCP_8080),
+            PortBinding.parse("127.0.0.1:80:8080"));
     }
 
     @Test
     public void noHostIp() {
-        assertEquals(PortBinding.parse("80:8080/tcp"), new PortBinding(Binding.bindPort(80), TCP_8080));
+        assertEquals(new PortBinding(Binding.bindPort(80), TCP_8080), PortBinding.parse("80:8080/tcp"));
     }
 
     @Test
     public void portsOnly() {
-        assertEquals(PortBinding.parse("80:8080"), new PortBinding(Binding.bindPort(80), TCP_8080));
+        assertEquals(new PortBinding(Binding.bindPort(80), TCP_8080), PortBinding.parse("80:8080"));
     }
 
     @Test
     public void exposedPortOnly() {
-        assertEquals(PortBinding.parse("8080"), new PortBinding(Binding.empty(), TCP_8080));
+        assertEquals(new PortBinding(Binding.empty(), TCP_8080), PortBinding.parse("8080"));
+    }
+
+    @Test
+    public void dynamicPort() {
+        assertEquals(new PortBinding(Binding.empty(), TCP_8080), PortBinding.parse(":8080/tcp"));
     }
 
     @Test
     public void dynamicHostPort() {
-        assertEquals(PortBinding.parse("127.0.0.1::8080"), new PortBinding(Binding.bindIp("127.0.0.1"), TCP_8080));
+        assertEquals(new PortBinding(Binding.bindIp("127.0.0.1"), TCP_8080), PortBinding.parse("127.0.0.1::8080"));
     }
 
     @Test
-    public void macOSdynamicPortCase1() {
+    public void allIfacesdynamicPort() {
         assertEquals(new PortBinding(Binding.empty(), TCP_8080), PortBinding.parse("0.0.0.0:0:8080"));
     }
 
     @Test
-    public void macOSdynamicPortCase2b() {
+    public void allIfacesPortOnly() {
         assertEquals(new PortBinding(Binding.parse("80"), TCP_8080), PortBinding.parse("0.0.0.0:80:8080"));
     }
 
     @Test
-    public void macOSdynamicPortCase3() {
+    public void macOSdynamicPort() {
         assertEquals(new PortBinding(Binding.parse("127.0.0.1"), TCP_8080), PortBinding.parse("127.0.0.1:0:8080"));
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/PortBindingTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/PortBindingTest.java
@@ -47,6 +47,21 @@ public class PortBindingTest {
     }
 
     @Test
+    public void macOSdynamicPortCase1() {
+        assertEquals(new PortBinding(Binding.empty(), TCP_8080), PortBinding.parse("0.0.0.0:0:8080"));
+    }
+
+    @Test
+    public void macOSdynamicPortCase2b() {
+        assertEquals(new PortBinding(Binding.parse("80"), TCP_8080), PortBinding.parse("0.0.0.0:80:8080"));
+    }
+
+    @Test
+    public void macOSdynamicPortCase3() {
+        assertEquals(new PortBinding(Binding.parse("127.0.0.1"), TCP_8080), PortBinding.parse("127.0.0.1:0:8080"));
+    }
+
+    @Test
     @Ignore
     public void parseInvalidInput() {
         expectedEx.expect(IllegalArgumentException.class);


### PR DESCRIPTION
Some versions of docker on macOS use different notation for port mapping, which breaks mapping.
Before this fix you can get 0 as a requested port for those cases.

On Linux:
`20:51:06.146 [SUT-runner] INFO  org.testcontainers.containers.ContainerState - container/tet23s3uut1a_kvredis_1, portBinding=:30005/tcp`

on macOs
`00:24:04.624 [SUT-runner] INFO  org.testcontainers.containers.ContainerState - container/h6xyym867pgc_kvredis_1, portBinding=0.0.0.0:0:30005/tcp`