### PR TITLE
Add unrecognizedFields to Task

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Task.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Task.java
@@ -1,6 +1,8 @@
 package com.github.dockerjava.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonAnySetter; 
+import com.fasterxml.jackson.annotation.JsonAnyGetter; 
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -54,6 +56,18 @@ public class Task implements Serializable {
 
     @JsonProperty("DesiredState")
     private TaskState desiredState = null;
+    
+    private Map<String, Object> unrecognizedFields = new HashMap<>();
+
+    @JsonAnyGetter
+    public Map<String, Object> getUnrecognizedFields() {
+        return this.unrecognizedFields;
+    }
+
+    @JsonAnySetter
+    public void setUnrecognizedFields(String key, Object value) {
+        this.unrecognizedFields.put(key, value);
+    }
 
     /**
      * The ID of the task.

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Task.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Task.java
@@ -9,6 +9,7 @@ import lombok.ToString;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 
 /**
  * @since {@link RemoteApiVersion#VERSION_1_24}


### PR DESCRIPTION
It looks like the task class does not contain the NetworksAttachments field.

As a stop gap, wouldn't it make sense for all models to implement the unrecognizedFields  logic below? That way if the Docker API changes the content will be captured?