### PR TITLE
Allow overriding timeouts of Apache HttpClient5 transport

### DIFF
--- a/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/ApacheDockerHttpClient.java
+++ b/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/ApacheDockerHttpClient.java
@@ -3,6 +3,7 @@ package com.github.dockerjava.httpclient5;
 import com.github.dockerjava.transport.SSLConfig;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.Objects;
 
 public final class ApacheDockerHttpClient extends ApacheDockerHttpClientImpl {
@@ -14,6 +15,10 @@ public final class ApacheDockerHttpClient extends ApacheDockerHttpClientImpl {
         private SSLConfig sslConfig = null;
 
         private int maxConnections = Integer.MAX_VALUE;
+
+        private Duration connectionTimeout;
+
+        private Duration responseTimeout;
 
         public Builder dockerHost(URI value) {
             this.dockerHost = Objects.requireNonNull(value, "dockerHost");
@@ -30,13 +35,24 @@ public final class ApacheDockerHttpClient extends ApacheDockerHttpClientImpl {
             return this;
         }
 
+        public Builder connectionTimeout(Duration connectionTimeout) {
+            this.connectionTimeout = connectionTimeout;
+            return this;
+        }
+
+        public Builder responseTimeout(Duration responseTimeout) {
+            this.responseTimeout = responseTimeout;
+            return this;
+        }
+
         public ApacheDockerHttpClient build() {
             Objects.requireNonNull(dockerHost, "dockerHost");
-            return new ApacheDockerHttpClient(dockerHost, sslConfig, maxConnections);
+            return new ApacheDockerHttpClient(dockerHost, sslConfig, maxConnections, connectionTimeout, responseTimeout);
         }
     }
 
-    private ApacheDockerHttpClient(URI dockerHost, SSLConfig sslConfig, int maxConnections) {
-        super(dockerHost, sslConfig, maxConnections);
+    private ApacheDockerHttpClient(URI dockerHost, SSLConfig sslConfig, int maxConnections, Duration connectionTimeout,
+        Duration responseTimeout) {
+        super(dockerHost, sslConfig, maxConnections, connectionTimeout, responseTimeout);
     }
 }

--- a/docker-java-transport-zerodep/src/main/java/com/github/dockerjava/httpclient5/ZerodepDockerHttpClient.java
+++ b/docker-java-transport-zerodep/src/main/java/com/github/dockerjava/httpclient5/ZerodepDockerHttpClient.java
@@ -1,9 +1,9 @@
 package com.github.dockerjava.httpclient5;
 
-import com.github.dockerjava.transport.SSLConfig;
-
 import java.net.URI;
+import java.time.Duration;
 import java.util.Objects;
+import com.github.dockerjava.transport.SSLConfig;
 
 @SuppressWarnings("unused")
 public final class ZerodepDockerHttpClient extends ApacheDockerHttpClientImpl {
@@ -15,6 +15,10 @@ public final class ZerodepDockerHttpClient extends ApacheDockerHttpClientImpl {
         private SSLConfig sslConfig = null;
 
         private int maxConnections = Integer.MAX_VALUE;
+
+        private Duration connectionTimeout;
+
+        private Duration responseTimeout;
 
         public Builder dockerHost(URI value) {
             this.dockerHost = Objects.requireNonNull(value, "dockerHost");
@@ -31,13 +35,24 @@ public final class ZerodepDockerHttpClient extends ApacheDockerHttpClientImpl {
             return this;
         }
 
+        public Builder connectionTimeout(Duration connectionTimeout) {
+            this.connectionTimeout = connectionTimeout;
+            return this;
+        }
+
+        public Builder responseTimeout(Duration responseTimeout) {
+            this.responseTimeout = responseTimeout;
+            return this;
+        }
+
         public ZerodepDockerHttpClient build() {
             Objects.requireNonNull(dockerHost, "dockerHost");
-            return new ZerodepDockerHttpClient(dockerHost, sslConfig, maxConnections);
+            return new ZerodepDockerHttpClient(dockerHost, sslConfig, maxConnections, connectionTimeout, responseTimeout);
         }
     }
 
-    protected ZerodepDockerHttpClient(URI dockerHost, SSLConfig sslConfig, int maxConnections) {
-        super(dockerHost, sslConfig, maxConnections);
+    private ZerodepDockerHttpClient(URI dockerHost, SSLConfig sslConfig, int maxConnections, Duration connectionTimeout,
+        Duration responseTimeout) {
+        super(dockerHost, sslConfig, maxConnections, connectionTimeout, responseTimeout);
     }
 }

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -91,6 +91,8 @@ DockerHttpClient httpClient = new ApacheDockerHttpClient.Builder()
     .dockerHost(config.getDockerHost())
     .sslConfig(config.getSSLConfig())
     .maxConnections(100)
+    .connectionTimeout(Duration.ofSeconds(30))
+    .responseTimeout(Duration.ofSeconds(45))
     .build();
 ```
 


### PR DESCRIPTION
**Content**
* Provided two new parameters Connection/Response timeouts
* Updated getting started page to show how to use them