### PR TITLE
Fix missing equals and toString annotation for Statistics Objects

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/CpuStatsConfig.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/CpuStatsConfig.java
@@ -1,6 +1,8 @@
 package com.github.dockerjava.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import javax.annotation.CheckForNull;
 import java.io.Serializable;
@@ -10,6 +12,8 @@ import java.io.Serializable;
  *
  * @author Yuting Liu
  */
+@EqualsAndHashCode
+@ToString
 public class CpuStatsConfig implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/CpuUsageConfig.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/CpuUsageConfig.java
@@ -1,6 +1,8 @@
 package com.github.dockerjava.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import javax.annotation.CheckForNull;
 import java.io.Serializable;
@@ -11,6 +13,8 @@ import java.util.List;
  *
  * @author Yuting Liu
  */
+@EqualsAndHashCode
+@ToString
 public class CpuUsageConfig implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/MemoryStatsConfig.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/MemoryStatsConfig.java
@@ -1,6 +1,8 @@
 package com.github.dockerjava.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import javax.annotation.CheckForNull;
 import java.io.Serializable;
@@ -10,6 +12,8 @@ import java.io.Serializable;
  *
  * @author Yuting Liu
  */
+@EqualsAndHashCode
+@ToString
 public class MemoryStatsConfig implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/StatsConfig.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/StatsConfig.java
@@ -1,10 +1,14 @@
 package com.github.dockerjava.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import javax.annotation.CheckForNull;
 import java.io.Serializable;
 
+@EqualsAndHashCode
+@ToString
 public class StatsConfig implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/ThrottlingDataConfig.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/ThrottlingDataConfig.java
@@ -1,6 +1,8 @@
 package com.github.dockerjava.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import javax.annotation.CheckForNull;
 import java.io.Serializable;
@@ -10,6 +12,8 @@ import java.io.Serializable;
  *
  * @author Yuting Liu
  */
+@EqualsAndHashCode
+@ToString
 public class ThrottlingDataConfig implements Serializable {
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
With missing EqualsAndHashCode and ToString, it's currently has no way to compare two these objects and decide whether they are equal