### PR TITLE
Support pulling Podman images

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/PullResponseItem.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/PullResponseItem.java
@@ -18,6 +18,8 @@ public class PullResponseItem extends ResponseItem {
     private static final String DOWNLOAD_COMPLETE = "Download complete";
 
     private static final String DOWNLOADED_SWARM = ": downloaded";
+    
+    private static final String PULLING_IMAGE_FROM = "pulling image () from";
 
     /**
      * Returns whether the status indicates a successful pull operation
@@ -34,7 +36,8 @@ public class PullResponseItem extends ResponseItem {
                 getStatus().contains(IMAGE_UP_TO_DATE) ||
                 getStatus().contains(DOWNLOADED_NEWER_IMAGE) ||
                 getStatus().contains(LEGACY_REGISTRY) ||
-                getStatus().contains(DOWNLOADED_SWARM)
+                getStatus().contains(DOWNLOADED_SWARM) ||
+                getStatus().contains(PULLING_IMAGE_FROM)
         );
     }
 }


### PR DESCRIPTION
Generally it's Podman's job to maintain Docker compat, but in this case, determining whether pulling an image was successful is determined by matching on this open-ended status property. And Podman happens to use a different status.

```
"origin":"com.github.dockerjava.api.command.PullImageResultCallback","thread":"docker-java-stream--711544265","message":"ResponseItem(stream=null, status=pulling image () from <registry>/<image>:<tag>, progressDetail=ResponseItem.ProgressDetail(current=null, total=null, start=null), progress=, id=4c26c2507b63797223fc4755e8325581a1d32c20892dc51f66522c0d0d998a22, from=null, time=null, errorDetail=null, error=, aux=null)"
``` 