### PR TITLE
Add `loki` driver to `LoggingType` enum

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/LogConfig.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/LogConfig.java
@@ -76,7 +76,8 @@ public class LogConfig extends DockerObject implements Serializable {
         AWSLOGS("awslogs"),
         DB("db"), // Synology specific driver
         SPLUNK("splunk"),
-        GCPLOGS("gcplogs");
+        GCPLOGS("gcplogs"),
+        LOKI("loki");
 
         private String type;
 


### PR DESCRIPTION
[loki](https://github.com/grafana/loki), a log collecting system by grafana, has it's own [docker logging driver](https://grafana.com/docs/loki/latest/clients/docker-driver/configuration/). Similarly to https://github.com/docker-java/docker-java/pull/839, this PR adds it as a new available logging driver type.