### PR TITLE
Add `DefaultDockerClientConfig.Builder#isDockerHostSetExplicitly`

### DIFF
--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
@@ -417,7 +417,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
             return this;
         }
 
-        public final boolean isDockerHostSetExplicit() {
+        public final boolean isDockerHostSetExplicitly() {
             return dockerHost != null;
         }
 

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
@@ -57,7 +57,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
     private static final Set<String> CONFIG_KEYS = new HashSet<>();
 
     static final Properties DEFAULT_PROPERTIES = new Properties();
-    public static final String DOCKER_HOST_IMPLICIT = "DOCKER_HOST_IMPLICIT";
+    public static final String DOCKER_HOST_SET_EXPLICIT = "DOCKER_HOST_EXPLICIT";
 
     static {
         CONFIG_KEYS.add(DOCKER_HOST);
@@ -74,7 +74,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
         DEFAULT_PROPERTIES.put(DOCKER_CONFIG, "${user.home}/.docker");
         DEFAULT_PROPERTIES.put(REGISTRY_URL, "https://index.docker.io/v1/");
         DEFAULT_PROPERTIES.put(REGISTRY_USERNAME, "${user.name}");
-        DEFAULT_PROPERTIES.put(DOCKER_HOST_IMPLICIT, "true");
+        DEFAULT_PROPERTIES.put(DOCKER_HOST_SET_EXPLICIT, "false");
     }
 
     private final URI dockerHost;
@@ -129,7 +129,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
 
     private static void checkAndMarkSettingDockerHost(Properties properties) {
         if (properties.containsKey(DOCKER_HOST)) {
-            properties.setProperty(DOCKER_HOST_IMPLICIT, "false");
+            properties.setProperty(DOCKER_HOST_SET_EXPLICIT, "true");
         }
     }
 
@@ -187,7 +187,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
             String value = env.get(DOCKER_HOST);
             if (value != null && value.trim().length() != 0) {
                 overriddenProperties.setProperty(DOCKER_HOST, value);
-                overriddenProperties.setProperty(DOCKER_HOST_IMPLICIT, "false");
+                overriddenProperties.setProperty(DOCKER_HOST_SET_EXPLICIT, "true");
             }
         }
 
@@ -222,7 +222,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
         }
 
         if (systemProperties.containsKey(DOCKER_HOST)) {
-            overriddenProperties.setProperty(DOCKER_HOST_IMPLICIT, "false");
+            overriddenProperties.setProperty(DOCKER_HOST_SET_EXPLICIT, "true");
         }
 
         return overriddenProperties;
@@ -351,7 +351,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
 
         private Boolean dockerTlsVerify;
 
-        private Boolean implicitDockerHost;
+        private Boolean dockerHostSetExplicit;
 
         private SSLConfig customSslConfig = null;
 
@@ -370,7 +370,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
                     .withRegistryPassword(p.getProperty(REGISTRY_PASSWORD))
                     .withRegistryEmail(p.getProperty(REGISTRY_EMAIL))
                     .withRegistryUrl(p.getProperty(REGISTRY_URL))
-                    .withImplicitDockerHost(p.getProperty(DOCKER_HOST_IMPLICIT));
+                    .withDockerHostSetExplicit(p.getProperty(DOCKER_HOST_SET_EXPLICIT));
         }
 
         /**
@@ -379,7 +379,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
         public final Builder withDockerHost(String dockerHost) {
             checkNotNull(dockerHost, "uri was not specified");
             this.dockerHost = URI.create(dockerHost);
-            this.implicitDockerHost = false;
+            this.dockerHostSetExplicit = true;
             return this;
         }
 
@@ -438,13 +438,13 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
             return this;
         }
 
-        private Builder withImplicitDockerHost(String implicitDockerHost) {
-            this.implicitDockerHost = Boolean.parseBoolean(implicitDockerHost);
+        private Builder withDockerHostSetExplicit(String explicitDockerHost) {
+            this.dockerHostSetExplicit = Boolean.parseBoolean(explicitDockerHost);
             return this;
         }
 
-        public final boolean usesImplicitDockerHost() {
-            return implicitDockerHost;
+        public final boolean isDockerHostSetExplicit() {
+            return dockerHostSetExplicit;
         }
 
         /**

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
@@ -204,7 +204,6 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
                 overriddenProperties.setProperty(key, systemProperties.getProperty(key));
             }
         }
-
         return overriddenProperties;
     }
 

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
@@ -114,9 +114,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
         p.putAll(DEFAULT_PROPERTIES);
         try (InputStream is = DefaultDockerClientConfig.class.getResourceAsStream("/" + DOCKER_JAVA_PROPERTIES)) {
             if (is != null) {
-                Properties loadedProperties = new Properties();
-                loadedProperties.load(is);
-                p.putAll(loadedProperties);
+                p.load(is);
             }
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -157,9 +155,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
                 "." + DOCKER_JAVA_PROPERTIES);
         if (usersDockerPropertiesFile.isFile()) {
             try (FileInputStream in = new FileInputStream(usersDockerPropertiesFile)) {
-                Properties loadedProperties = new Properties();
-                loadedProperties.load(in);
-                overriddenProperties.putAll(loadedProperties);
+                overriddenProperties.load(in);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
@@ -357,6 +357,14 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
             return this;
         }
 
+        /**
+         *  Considered default if dockerHost is set to the default value.
+         */
+        public final boolean hasDefaultDockerHost() {
+            URI defaultDockerHost = URI.create(DEFAULT_PROPERTIES.getProperty(DOCKER_HOST));
+            return this.dockerHost.equals(defaultDockerHost);
+        }
+
         public final Builder withApiVersion(RemoteApiVersion apiVersion) {
             this.apiVersion = apiVersion.getVersion();
             return this;

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
@@ -324,7 +324,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
     }
 
     public static class Builder {
-        private String dockerHost;
+        private URI dockerHost;
 
         private String apiVersion, registryUsername, registryPassword, registryEmail, registryUrl, dockerConfig,
                 dockerCertPath;
@@ -339,8 +339,12 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
          * registry.email, DOCKER_CERT_PATH, and DOCKER_CONFIG.
          */
         public Builder withProperties(Properties p) {
-            return withDockerHost(p.getProperty(DOCKER_HOST))
-                    .withDockerTlsVerify(p.getProperty(DOCKER_TLS_VERIFY))
+
+            if (p.getProperty(DOCKER_HOST) != null) {
+                withDockerHost(p.getProperty(DOCKER_HOST));
+            }
+
+            return withDockerTlsVerify(p.getProperty(DOCKER_TLS_VERIFY))
                     .withDockerConfig(p.getProperty(DOCKER_CONFIG))
                     .withDockerCertPath(p.getProperty(DOCKER_CERT_PATH))
                     .withApiVersion(p.getProperty(API_VERSION))
@@ -354,7 +358,8 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
          * configure DOCKER_HOST
          */
         public final Builder withDockerHost(String dockerHost) {
-            this.dockerHost = dockerHost;
+            checkNotNull(dockerHost, "uri was not specified");
+            this.dockerHost = URI.create(dockerHost);
             return this;
         }
 
@@ -440,8 +445,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
                 sslConfig = customSslConfig;
             }
 
-            String dockerHostToUse = (!StringUtils.isEmpty(dockerHost)) ? dockerHost : DEFAULT_DOCKER_HOST;
-            URI dockerHostUri = URI.create(dockerHostToUse);
+            URI dockerHostUri = (dockerHost != null) ? dockerHost : URI.create(DEFAULT_DOCKER_HOST);
 
             return new DefaultDockerClientConfig(dockerHostUri, dockerConfig, apiVersion, registryUrl, registryUsername,
                     registryPassword, registryEmail, sslConfig);

--- a/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
@@ -225,36 +225,36 @@ public class DefaultDockerClientConfigTest {
     }
 
     @Test
-    public void usesImplicitDockerHostRespectsSetter() {
+    public void dockerHostExplicitOnSetter() {
         DefaultDockerClientConfig.Builder builder = DefaultDockerClientConfig.createDefaultConfigBuilder();
-        assertThat(builder.usesImplicitDockerHost(), is(true));
+        assertThat(builder.isDockerHostSetExplicit(), is(false));
 
         builder.withDockerHost("tcp://foo");
-        assertThat(builder.usesImplicitDockerHost(), is(false));
+        assertThat(builder.isDockerHostSetExplicit(), is(true));
     }
 
     @Test
-    public void usesImplicittDockerHostRespectsSystemProperties() {
+    public void dockerHostExplicitOnSystemProperty() {
         Properties systemProperties = new Properties();
         systemProperties.put(DefaultDockerClientConfig.DOCKER_HOST, "tcp://foo");
 
         DefaultDockerClientConfig.Builder builder =  DefaultDockerClientConfig.createDefaultConfigBuilder(Collections.emptyMap(), systemProperties);
 
-        assertThat(builder.usesImplicitDockerHost(), is(false));
+        assertThat(builder.isDockerHostSetExplicit(), is(true));
     }
 
     @Test
-    public void usesImplicitDockerHostRespectsEnv() {
+    public void dockerHostExplicitOnEnv() {
         Map<String, String> env = new HashMap<>();
         env.put(DefaultDockerClientConfig.DOCKER_HOST, "tcp://foo");
 
         DefaultDockerClientConfig.Builder builder =  DefaultDockerClientConfig.createDefaultConfigBuilder(env, new Properties());
 
-        assertThat(builder.usesImplicitDockerHost(), is(false));
+        assertThat(builder.isDockerHostSetExplicit(), is(true));
     }
 
     @Test
-    public void usesImplicitDockerHostConsidersAsNotImplicitIfSetToDefaultByUser() {
+    public void dockerHostExplicitIfSetToDefaultByUser() {
         String defaultDockerHost = DefaultDockerClientConfig.DEFAULT_PROPERTIES
             .getProperty(DefaultDockerClientConfig.DOCKER_HOST);
 
@@ -263,7 +263,7 @@ public class DefaultDockerClientConfigTest {
 
         DefaultDockerClientConfig.Builder builder =  DefaultDockerClientConfig.createDefaultConfigBuilder(env, new Properties());
 
-        assertThat(builder.usesImplicitDockerHost(), is(false));
+        assertThat(builder.isDockerHostSetExplicit(), is(true));
     }
 
 

--- a/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
@@ -225,36 +225,36 @@ public class DefaultDockerClientConfigTest {
     }
 
     @Test
-    public void hasDefaultDockerHostRespectsSetter() {
+    public void usesImplicitDockerHostRespectsSetter() {
         DefaultDockerClientConfig.Builder builder = DefaultDockerClientConfig.createDefaultConfigBuilder();
-        assertThat(builder.hasDefaultDockerHost(), is(true));
+        assertThat(builder.usesImplicitDockerHost(), is(true));
 
         builder.withDockerHost("tcp://foo");
-        assertThat(builder.hasDefaultDockerHost(), is(false));
+        assertThat(builder.usesImplicitDockerHost(), is(false));
     }
 
     @Test
-    public void hasDefaultDockerHostRespectsSystemProperties() {
+    public void usesImplicittDockerHostRespectsSystemProperties() {
         Properties systemProperties = new Properties();
         systemProperties.put(DefaultDockerClientConfig.DOCKER_HOST, "tcp://foo");
 
         DefaultDockerClientConfig.Builder builder =  DefaultDockerClientConfig.createDefaultConfigBuilder(Collections.emptyMap(), systemProperties);
 
-        assertThat(builder.hasDefaultDockerHost(), is(false));
+        assertThat(builder.usesImplicitDockerHost(), is(false));
     }
 
     @Test
-    public void hasDefaultDockerHostRespectsEnv() {
+    public void usesImplicitDockerHostRespectsEnv() {
         Map<String, String> env = new HashMap<>();
         env.put(DefaultDockerClientConfig.DOCKER_HOST, "tcp://foo");
 
         DefaultDockerClientConfig.Builder builder =  DefaultDockerClientConfig.createDefaultConfigBuilder(env, new Properties());
 
-        assertThat(builder.hasDefaultDockerHost(), is(false));
+        assertThat(builder.usesImplicitDockerHost(), is(false));
     }
 
     @Test
-    public void hasDefaultDockerHostConsideredAsDefaultIfSetToDefault() {
+    public void usesImplicitDockerHostConsidersAsNotImplicitIfSetToDefaultByUser() {
         String defaultDockerHost = DefaultDockerClientConfig.DEFAULT_PROPERTIES
             .getProperty(DefaultDockerClientConfig.DOCKER_HOST);
 
@@ -263,7 +263,7 @@ public class DefaultDockerClientConfigTest {
 
         DefaultDockerClientConfig.Builder builder =  DefaultDockerClientConfig.createDefaultConfigBuilder(env, new Properties());
 
-        assertThat(builder.hasDefaultDockerHost(), is(true));
+        assertThat(builder.usesImplicitDockerHost(), is(false));
     }
 
 

--- a/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
@@ -98,8 +98,8 @@ public class DefaultDockerClientConfigTest {
         DefaultDockerClientConfig config = buildConfig(env, new Properties());
 
         assertEquals(
-            config.getDockerHost().toString(),
-            DefaultDockerClientConfig.DEFAULT_PROPERTIES.get(DefaultDockerClientConfig.DOCKER_HOST)
+            DefaultDockerClientConfig.DEFAULT_DOCKER_HOST,
+            config.getDockerHost().toString()
         );
     }
 
@@ -255,11 +255,8 @@ public class DefaultDockerClientConfigTest {
 
     @Test
     public void dockerHostExplicitIfSetToDefaultByUser() {
-        String defaultDockerHost = DefaultDockerClientConfig.DEFAULT_PROPERTIES
-            .getProperty(DefaultDockerClientConfig.DOCKER_HOST);
-
         Map<String, String> env = new HashMap<>();
-        env.put(DefaultDockerClientConfig.DOCKER_HOST, defaultDockerHost);
+        env.put(DefaultDockerClientConfig.DOCKER_HOST, DefaultDockerClientConfig.DEFAULT_DOCKER_HOST);
 
         DefaultDockerClientConfig.Builder builder =  DefaultDockerClientConfig.createDefaultConfigBuilder(env, new Properties());
 

--- a/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
@@ -225,6 +225,49 @@ public class DefaultDockerClientConfigTest {
     }
 
     @Test
+    public void hasDefaultDockerHostRespectsSetter() {
+        DefaultDockerClientConfig.Builder builder = DefaultDockerClientConfig.createDefaultConfigBuilder();
+        assertThat(builder.hasDefaultDockerHost(), is(true));
+
+        builder.withDockerHost("tcp://foo");
+        assertThat(builder.hasDefaultDockerHost(), is(false));
+    }
+
+    @Test
+    public void hasDefaultDockerHostRespectsSystemProperties() {
+        Properties systemProperties = new Properties();
+        systemProperties.put(DefaultDockerClientConfig.DOCKER_HOST, "tcp://foo");
+
+        DefaultDockerClientConfig.Builder builder =  DefaultDockerClientConfig.createDefaultConfigBuilder(Collections.emptyMap(), systemProperties);
+
+        assertThat(builder.hasDefaultDockerHost(), is(false));
+    }
+
+    @Test
+    public void hasDefaultDockerHostRespectsEnv() {
+        Map<String, String> env = new HashMap<>();
+        env.put(DefaultDockerClientConfig.DOCKER_HOST, "tcp://foo");
+
+        DefaultDockerClientConfig.Builder builder =  DefaultDockerClientConfig.createDefaultConfigBuilder(env, new Properties());
+
+        assertThat(builder.hasDefaultDockerHost(), is(false));
+    }
+
+    @Test
+    public void hasDefaultDockerHostConsideredAsDefaultIfSetToDefault() {
+        String defaultDockerHost = DefaultDockerClientConfig.DEFAULT_PROPERTIES
+            .getProperty(DefaultDockerClientConfig.DOCKER_HOST);
+
+        Map<String, String> env = new HashMap<>();
+        env.put(DefaultDockerClientConfig.DOCKER_HOST, defaultDockerHost);
+
+        DefaultDockerClientConfig.Builder builder =  DefaultDockerClientConfig.createDefaultConfigBuilder(env, new Properties());
+
+        assertThat(builder.hasDefaultDockerHost(), is(true));
+    }
+
+
+    @Test
     public void testGetAuthConfigurationsFromDockerCfg() throws URISyntaxException {
         File cfgFile = new File(Resources.getResource("com.github.dockerjava.core/registry.v1").toURI());
         DefaultDockerClientConfig clientConfig = new DefaultDockerClientConfig(URI.create(

--- a/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
@@ -225,42 +225,42 @@ public class DefaultDockerClientConfigTest {
     }
 
     @Test
-    public void dockerHostExplicitOnSetter() {
+    public void dockerHostSetExplicitlyOnSetter() {
         DefaultDockerClientConfig.Builder builder = DefaultDockerClientConfig.createDefaultConfigBuilder();
-        assertThat(builder.isDockerHostSetExplicit(), is(false));
+        assertThat(builder.isDockerHostSetExplicitly(), is(false));
 
         builder.withDockerHost("tcp://foo");
-        assertThat(builder.isDockerHostSetExplicit(), is(true));
+        assertThat(builder.isDockerHostSetExplicitly(), is(true));
     }
 
     @Test
-    public void dockerHostExplicitOnSystemProperty() {
+    public void dockerHostSetExplicitlyOnSystemProperty() {
         Properties systemProperties = new Properties();
         systemProperties.put(DefaultDockerClientConfig.DOCKER_HOST, "tcp://foo");
 
         DefaultDockerClientConfig.Builder builder =  DefaultDockerClientConfig.createDefaultConfigBuilder(Collections.emptyMap(), systemProperties);
 
-        assertThat(builder.isDockerHostSetExplicit(), is(true));
+        assertThat(builder.isDockerHostSetExplicitly(), is(true));
     }
 
     @Test
-    public void dockerHostExplicitOnEnv() {
+    public void dockerHostSetExplicitlyOnEnv() {
         Map<String, String> env = new HashMap<>();
         env.put(DefaultDockerClientConfig.DOCKER_HOST, "tcp://foo");
 
         DefaultDockerClientConfig.Builder builder =  DefaultDockerClientConfig.createDefaultConfigBuilder(env, new Properties());
 
-        assertThat(builder.isDockerHostSetExplicit(), is(true));
+        assertThat(builder.isDockerHostSetExplicitly(), is(true));
     }
 
     @Test
-    public void dockerHostExplicitIfSetToDefaultByUser() {
+    public void dockerHostSetExplicitlyIfSetToDefaultByUser() {
         Map<String, String> env = new HashMap<>();
         env.put(DefaultDockerClientConfig.DOCKER_HOST, DefaultDockerClientConfig.DEFAULT_DOCKER_HOST);
 
         DefaultDockerClientConfig.Builder builder =  DefaultDockerClientConfig.createDefaultConfigBuilder(env, new Properties());
 
-        assertThat(builder.isDockerHostSetExplicit(), is(true));
+        assertThat(builder.isDockerHostSetExplicitly(), is(true));
     }
 
 

--- a/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
@@ -226,7 +226,7 @@ public class DefaultDockerClientConfigTest {
 
     @Test
     public void dockerHostSetExplicitlyOnSetter() {
-        DefaultDockerClientConfig.Builder builder = DefaultDockerClientConfig.createDefaultConfigBuilder();
+        DefaultDockerClientConfig.Builder builder = DefaultDockerClientConfig.createDefaultConfigBuilder(Collections.emptyMap(), new Properties());
         assertThat(builder.isDockerHostSetExplicitly(), is(false));
 
         builder.withDockerHost("tcp://foo");


### PR DESCRIPTION
The current implementation specifies that `hasDefaultDockerHost()` returns `false`, if `dockerHost` has a value different from the default `DOCKER_HOST` value.

This means, this implementation will also return `true` if `dockerHost` is set through ENV or properties to the default value.

This PR would increase the robustness of https://github.com/testcontainers/testcontainers-java/pull/4387.