### PR TITLE
Fix #1726 by disabling stale connection checking in AHC5

### DIFF
--- a/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/ApacheDockerHttpClientImpl.java
+++ b/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/ApacheDockerHttpClientImpl.java
@@ -30,6 +30,7 @@ import org.apache.hc.core5.http.io.entity.InputStreamEntity;
 import org.apache.hc.core5.http.protocol.BasicHttpContext;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.net.URIAuthority;
+import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,6 +102,7 @@ class ApacheDockerHttpClientImpl implements DockerHttpClient {
                 .setSoTimeout(Timeout.ZERO_MILLISECONDS)
                 .build()
         );
+        connectionManager.setValidateAfterInactivity(TimeValue.NEG_ONE_SECOND);
         connectionManager.setMaxTotal(maxConnections);
         connectionManager.setDefaultMaxPerRoute(maxConnections);
         RequestConfig.Builder defaultRequest = RequestConfig.custom();


### PR DESCRIPTION
As described in #1726 in order to make sure it doesn't fail on stale connection checking, it need to be disabled via the "setValidateAfterInactivity" setup (default is set to 2 seconds in the PoolingHttpClientConnectionManager.

Avoiding checking for stale resolve the issue for me