### PR TITLE
Update bouncycastle to 1.69

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 		<commons-lang.version>2.6</commons-lang.version>
 		<slf4j-api.version>1.7.30</slf4j-api.version>
 
-		<bouncycastle.version>1.69</bouncycastle.version>
+		<bouncycastle.version>1.70</bouncycastle.version>
 		<junixsocket.version>2.3.2</junixsocket.version>
 		<guava.version>19.0</guava.version> <!-- todo remove from project -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 		<commons-lang.version>2.6</commons-lang.version>
 		<slf4j-api.version>1.7.30</slf4j-api.version>
 
-		<bouncycastle.version>1.64</bouncycastle.version>
+		<bouncycastle.version>1.69</bouncycastle.version>
 		<junixsocket.version>2.3.2</junixsocket.version>
 		<guava.version>19.0</guava.version> <!-- todo remove from project -->
 


### PR DESCRIPTION
`bouncycastle` 1.64 is vulnerable. Let's upgrade it to the latest version, 1.69.

Example vulnerability: https://www.cvedetails.com/cve/CVE-2020-15522/