### PR TITLE
Add support for Windows npipe volume mounts

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/MountType.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/MountType.java
@@ -16,4 +16,7 @@ public enum MountType {
     @JsonProperty("tmpfs")
     TMPFS
 
+    @JsonProperty("npipe")
+    NPIPE
+
 }


### PR DESCRIPTION
Currently, having a service that has a NPipe volume mount breaks the `/services` endpoint:

```
Caused by: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `com.github.dockerjava.api.model.MountType` from String "npipe": not one of the values accepted for Enum class: [volume, tmpfs, bind]
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: java.util.ArrayList[12]->com.github.dockerjava.api.model.Service["Spec"]->com.github.dockerjava.api.model.ServiceSpec["TaskTemplate"]->com.github.dockerjava.api.model.TaskSpec["ContainerSpec"]->com.github.dockerjava.api.model.ContainerSpec["Mounts"]->java.util.ArrayList[0]->com.github.dockerjava.api.model.Mount["Type"])
at com.fasterxml.jackson.databind.exc.InvalidFormatException.from(InvalidFormatException.java:67)
at com.fasterxml.jackson.databind.DeserializationContext.weirdStringException(DeserializationContext.java:1679)
at com.fasterxml.jackson.databind.DeserializationContext.handleWeirdStringValue(DeserializationContext.java:935)
at com.fasterxml.jackson.databind.deser.std.EnumDeserializer._deserializeAltString(EnumDeserializer.java:255)
at com.fasterxml.jackson.databind.deser.std.EnumDeserializer.deserialize(EnumDeserializer.java:179)
at com.fasterxml.jackson.databind.deser.impl.FieldProperty.deserializeAndSet(FieldProperty.java:138)
at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:288)
at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151)
at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:286)
at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:245)
at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:27)
at com.fasterxml.jackson.databind.deser.impl.FieldProperty.deserializeAndSet(FieldProperty.java:138)
at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:288)
at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151)
at com.fasterxml.jackson.databind.deser.impl.FieldProperty.deserializeAndSet(FieldProperty.java:138)
at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:288)
at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151)
at com.fasterxml.jackson.databind.deser.impl.FieldProperty.deserializeAndSet(FieldProperty.java:138)
at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:288)
at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151)
at com.fasterxml.jackson.databind.deser.impl.FieldProperty.deserializeAndSet(FieldProperty.java:138)
at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:288)
at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151)
at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:4189)
at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2476)
at com.fasterxml.jackson.databind.ObjectMapper.treeToValue(ObjectMapper.java:2929)
at com.github.dockerjava.core.DockerObjectDeserializer.deserialize(DockerClientConfig.java:132)
at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:286)
at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:245)
at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:27)
at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4218)
at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3259)
at com.github.dockerjava.core.DefaultInvocationBuilder.get(DefaultInvocationBuilder.java:75)
... 7 more
```

This PR adds NPipe as a volume mount type, see also the [Docker API description](https://docs.docker.com/engine/api/v1.41/#operation/ServiceCreate):

> The mount type. Available types:
> 
>    - bind Mounts a file or directory from the host into the container. Must exist prior to creating the container.
>    - volume Creates a volume with the given name and options (or uses a pre-existing volume with the same name and options). These are not removed when the container is removed.
>    - tmpfs Create a tmpfs with the given options. The mount source cannot be specified for tmpfs.
>    - **npipe Mounts a named pipe from the host into the container. Must exist prior to creating the container.**
