### PR TITLE
Bump netty to 4.1.70 and depend on Linux aarch64 epoll library

### DIFF
--- a/docker-java-transport-netty/pom.xml
+++ b/docker-java-transport-netty/pom.xml
@@ -41,6 +41,12 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
             <version>${netty.version}</version>
+            <classifier>linux-aarch_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>${netty.version}</version>
             <classifier>linux-x86_64</classifier>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
 		<!-- test dependencies -->
 		<logback.version>1.2.3</logback.version>
-		<netty.version>4.1.46.Final</netty.version>
+		<netty.version>4.1.70.Final</netty.version>
 		<hamcrest.library.version>2.2</hamcrest.library.version>
 		<hamcrest.jpa-matchers>1.8</hamcrest.jpa-matchers>
 		<lambdaj.version>2.3.3</lambdaj.version>


### PR DESCRIPTION
I'd like to use the Jenkins plugin for Artifactory on aarch64 Linux. Please consider adding the necessary runtime library.

Thanks,
Gregor