### PR TITLE
Update apache commons-lang (2) to current commons-lang3

### DIFF
--- a/docker-java-core/pom.xml
+++ b/docker-java-core/pom.xml
@@ -46,9 +46,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>${commons-lang.version}</version>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>${commons-lang3.version}</version>
 		</dependency>
 
 		<dependency>

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
@@ -5,12 +5,12 @@ import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.AuthConfigurations;
 import com.github.dockerjava.core.NameParser.HostnameReposName;
 import com.github.dockerjava.core.NameParser.ReposTag;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.SystemUtils;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -26,7 +26,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.apache.commons.lang.BooleanUtils.isTrue;
+import static org.apache.commons.lang3.BooleanUtils.isTrue;
 
 /**
  * Respects some of the docker CLI options. See https://docs.docker.com/engine/reference/commandline/cli/#environment-variables

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerCmdExecFactory.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerCmdExecFactory.java
@@ -9,7 +9,7 @@ import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.SetMultimap;
 import com.google.common.escape.Escaper;
 import com.google.common.net.UrlEscapers;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.util.Map;

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DockerConfigFile.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DockerConfigFile.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.AuthConfigurations;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/GoLangFileMatch.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/GoLangFileMatch.java
@@ -14,7 +14,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.github.dockerjava.core.exception.GoLangFileMatchException;
 

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/NameParser.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/NameParser.java
@@ -5,10 +5,10 @@ package com.github.dockerjava.core;
 
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.core.exception.InvalidRepositoryNameException;

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/AbstrDockerCmd.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/AbstrDockerCmd.java
@@ -5,8 +5,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.io.IOException;
 import java.util.Base64;
 
-import org.apache.commons.lang.builder.ReflectionToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/CopyArchiveToContainerCmdImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/CopyArchiveToContainerCmdImpl.java
@@ -8,8 +8,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import com.github.dockerjava.api.command.CopyArchiveToContainerCmd;
 import com.github.dockerjava.api.exception.DockerClientException;

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java
@@ -14,9 +14,9 @@ import com.github.dockerjava.api.model.HealthCheck;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.api.model.Volumes;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import javax.annotation.CheckForNull;
 import java.util.Arrays;

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/InitializeSwarmCmdImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/InitializeSwarmCmdImpl.java
@@ -4,9 +4,9 @@ package com.github.dockerjava.core.command;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.dockerjava.api.command.InitializeSwarmCmd;
 import com.github.dockerjava.api.model.SwarmSpec;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import javax.annotation.CheckForNull;
 

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/JoinSwarmCmdImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/JoinSwarmCmdImpl.java
@@ -3,9 +3,9 @@ package com.github.dockerjava.core.command;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.dockerjava.api.command.JoinSwarmCmd;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import javax.annotation.CheckForNull;
 import java.util.List;

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/ListImagesCmdImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/ListImagesCmdImpl.java
@@ -5,8 +5,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.builder.ReflectionToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import com.github.dockerjava.api.command.ListImagesCmd;
 import com.github.dockerjava.api.model.Image;

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/LogContainerCmdImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/LogContainerCmdImpl.java
@@ -2,8 +2,8 @@ package com.github.dockerjava.core.command;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.apache.commons.lang.builder.ReflectionToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import com.github.dockerjava.api.command.LogContainerCmd;
 import com.github.dockerjava.api.model.Frame;

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/UpdateContainerCmdImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/UpdateContainerCmdImpl.java
@@ -6,9 +6,9 @@ import com.github.dockerjava.api.command.UpdateContainerCmd;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.UpdateContainerResponse;
 import com.github.dockerjava.core.RemoteApiVersion;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/UpdateServiceCmdImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/UpdateServiceCmdImpl.java
@@ -4,10 +4,10 @@ import com.github.dockerjava.api.command.UpdateServiceCmd;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.ServiceSpec;
 import com.github.dockerjava.core.RemoteApiVersion;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/UpdateSwarmNodeCmdImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/UpdateSwarmNodeCmdImpl.java
@@ -4,10 +4,10 @@ import com.github.dockerjava.api.command.UpdateSwarmNodeCmd;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.SwarmNodeSpec;
 import com.github.dockerjava.core.RemoteApiVersion;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/dockerfile/DockerfileStatement.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/dockerfile/DockerfileStatement.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.github.dockerjava.api.exception.DockerClientException;
 import com.google.common.base.MoreObjects;

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/exec/BuildImageCmdExec.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/exec/BuildImageCmdExec.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.CheckForNull;
 
 import static com.github.dockerjava.core.util.CacheFromEncoder.jsonEncode;
-import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class BuildImageCmdExec extends AbstrAsyncDockerCmdExec<BuildImageCmd, BuildResponseItem> implements
         BuildImageCmd.Exec {

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/exec/TopContainerCmdExec.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/exec/TopContainerCmdExec.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core.exec;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/docker-java-transport-netty/src/main/java/com/github/dockerjava/netty/NettyDockerCmdExecFactory.java
+++ b/docker-java-transport-netty/src/main/java/com/github/dockerjava/netty/NettyDockerCmdExecFactory.java
@@ -16,7 +16,7 @@ import javax.net.ssl.SSLParameters;
 
 import com.github.dockerjava.core.AbstractDockerCmdExecFactory;
 import com.github.dockerjava.core.WebTarget;
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 
 import com.github.dockerjava.api.command.DockerCmdExecFactory;
 import com.github.dockerjava.core.DockerClientConfig;

--- a/docker-java-transport-netty/src/main/java/com/github/dockerjava/netty/NettyWebTarget.java
+++ b/docker-java-transport-netty/src/main/java/com/github/dockerjava/netty/NettyWebTarget.java
@@ -17,7 +17,7 @@ import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.WebTarget;
 import com.google.common.collect.ImmutableSet;
 import io.netty.handler.codec.http.HttpConstants;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/docker-java/src/test/java/com/github/dockerjava/api/ModelsSerializableTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/ModelsSerializableTest.java
@@ -8,7 +8,7 @@ import com.github.dockerjava.api.model.PullResponseItem;
 import com.github.dockerjava.api.model.PushResponseItem;
 import com.github.dockerjava.api.model.ResponseItem;
 import com.google.common.reflect.ClassPath.ClassInfo;
-import org.apache.commons.lang.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 import org.slf4j.Logger;

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/TagImageCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/TagImageCmdIT.java
@@ -1,7 +1,7 @@
 package com.github.dockerjava.cmd;
 
 import com.github.dockerjava.api.exception.NotFoundException;
-import org.apache.commons.lang.math.RandomUtils;
+import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,7 +12,7 @@ public class TagImageCmdIT extends CmdIT {
 
     @Test
     public void tagImage() throws Exception {
-        String tag = "" + RandomUtils.nextInt(Integer.MAX_VALUE);
+        String tag = "" + RandomUtils.nextInt(0, Integer.MAX_VALUE);
 
         dockerRule.getClient().tagImageCmd("busybox:latest", "docker-java/busybox", tag).exec();
 
@@ -22,7 +22,7 @@ public class TagImageCmdIT extends CmdIT {
     @Test(expected = NotFoundException.class)
     public void tagNonExistingImage() throws Exception {
 
-        String tag = "" + RandomUtils.nextInt(Integer.MAX_VALUE);
+        String tag = "" + RandomUtils.nextInt(0, Integer.MAX_VALUE);
         dockerRule.getClient().tagImageCmd("non-existing", "docker-java/busybox", tag).exec();
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/VersionCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/VersionCmdIT.java
@@ -2,7 +2,7 @@ package com.github.dockerjava.cmd;
 
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.Version;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/CreateConfigCmdExecIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/CreateConfigCmdExecIT.java
@@ -2,7 +2,7 @@ package com.github.dockerjava.cmd.swarm;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateConfigResponse;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/CreateSecretCmdExecIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/CreateSecretCmdExecIT.java
@@ -5,7 +5,7 @@ import com.github.dockerjava.api.command.CreateSecretResponse;
 import com.github.dockerjava.api.model.Secret;
 import com.github.dockerjava.api.model.SecretSpec;
 import com.google.common.collect.Lists;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.junit.Test;
 import org.slf4j.Logger;

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/InspectConfigCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/InspectConfigCmdIT.java
@@ -4,7 +4,7 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateConfigResponse;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.Config;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/ListConfigCmdExecIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/ListConfigCmdExecIT.java
@@ -4,7 +4,7 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateConfigResponse;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.Config;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/ListSecretCmdExecIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/ListSecretCmdExecIT.java
@@ -6,7 +6,7 @@ import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.Secret;
 import com.github.dockerjava.api.model.SecretSpec;
 import com.google.common.collect.Lists;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
@@ -4,7 +4,7 @@ import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.AuthConfigurations;
 import com.google.common.io.Resources;
-import org.apache.commons.lang.SerializationUtils;
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Test;
 
 import java.io.File;

--- a/docker-java/src/test/java/com/github/dockerjava/core/NameParserTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/NameParserTest.java
@@ -7,7 +7,7 @@ import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.core.NameParser.HostnameReposName;
 import com.github.dockerjava.core.NameParser.ReposTag;
 import com.github.dockerjava.core.exception.InvalidRepositoryNameException;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/docker-java/src/test/java/com/github/dockerjava/core/RemoteApiVersionTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/RemoteApiVersionTest.java
@@ -1,6 +1,6 @@
 package com.github.dockerjava.core;
 
-import org.apache.commons.lang.SerializationUtils;
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/docker-java/src/test/java/com/github/dockerjava/utils/TestUtils.java
+++ b/docker-java/src/test/java/com/github/dockerjava/utils/TestUtils.java
@@ -5,7 +5,7 @@ import com.github.dockerjava.api.model.Network;
 import com.github.dockerjava.core.RemoteApiVersion;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/docker-java/template.mf
+++ b/docker-java/template.mf
@@ -13,7 +13,7 @@ Import-Template:
  javax.ws.rs.*;version="[2.0.0, 2.1.0)",
  org.apache.commons.compress.*;version="${commons-compress.version:short}",
  org.apache.commons.io.*;version="${commons-io.version:short}",
- org.apache.commons.lang33.*;version="${commons-lang3.version:short}",
+ org.apache.commons.lang3.*;version="${commons-lang3.version:short}",
  org.apache.http.*;version="[4.4.0, 4.6.0)",
  org.bouncycastle.*;version="${bouncycastle.version:short}",
  org.glassfish.jersey.*;version="${jersey.version:default}",

--- a/docker-java/template.mf
+++ b/docker-java/template.mf
@@ -13,7 +13,7 @@ Import-Template:
  javax.ws.rs.*;version="[2.0.0, 2.1.0)",
  org.apache.commons.compress.*;version="${commons-compress.version:short}",
  org.apache.commons.io.*;version="${commons-io.version:short}",
- org.apache.commons.lang.*;version="${commons-lang.version:short}",
+ org.apache.commons.lang33.*;version="${commons-lang3.version:short}",
  org.apache.http.*;version="[4.4.0, 4.6.0)",
  org.bouncycastle.*;version="${bouncycastle.version:short}",
  org.glassfish.jersey.*;version="${jersey.version:default}",

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 		<commons-compress.version>1.21</commons-compress.version>
 		<commons-codec.version>1.11</commons-codec.version>
 		<commons-io.version>2.6</commons-io.version>
-		<commons-lang.version>2.6</commons-lang.version>
+		<commons-lang3.version>3.12.0</commons-lang3.version>
 		<slf4j-api.version>1.7.30</slf4j-api.version>
 
 		<bouncycastle.version>1.64</bouncycastle.version>


### PR DESCRIPTION
Updated from commons-lang (2) to commons-lang3.
This is required to fix an issue with the Artifactory Jenkins plugin, see https://github.com/jfrog/jenkins-artifactory-plugin/pull/567