### PR TITLE
Adding the ablility to have path

### DIFF
--- a/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/OkDockerHttpClient.java
+++ b/docker-java-transport-okhttp/src/main/java/com/github/dockerjava/okhttp/OkDockerHttpClient.java
@@ -168,7 +168,8 @@ public final class OkDockerHttpClient implements DockerHttpClient {
                 baseUrlBuilder = new HttpUrl.Builder()
                     .scheme(isSSL ? "https" : "http")
                     .host(dockerHost.getHost())
-                    .port(dockerHost.getPort());
+                    .port(dockerHost.getPort())
+                    .addPathSegment(dockerHost.getPath());
                 break;
             default:
                 baseUrlBuilder = HttpUrl.get(dockerHost.toString()).newBuilder();


### PR DESCRIPTION
Our Docker Swarm have a unique URI that contains path(e.g. scheme://host:port/path/segment/).
So we need to add to OkHttp transports the ability to have path segment
