### PR TITLE
Maintenance update to latest jackson available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
 		<jdk.target>1.8</jdk.target>
 
 		<jersey.version>2.30.1</jersey.version>
-		<jackson.version>2.10.3</jackson.version>
-		<jackson-jaxrs.version>2.10.3</jackson-jaxrs.version>
+		<jackson.version>2.13.1</jackson.version>
+		<jackson-jaxrs.version>2.13.1</jackson-jaxrs.version>
 		<httpclient.version>4.5.12</httpclient.version><!-- 4.5.1-4.5.2 broken -->
 		<commons-compress.version>1.21</commons-compress.version>
 		<commons-codec.version>1.11</commons-codec.version>


### PR DESCRIPTION
Currently other code may use an updated jackson version, thus it would be nice that docker-java is also aligned with more recent one.