### PR TITLE
Use POSIX extensions for tar archives

### DIFF
--- a/docker-java-core/src/main/java/com/github/dockerjava/core/util/CompressArchiveUtil.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/util/CompressArchiveUtil.java
@@ -98,7 +98,8 @@ public class CompressArchiveUtil {
         tarFile.deleteOnExit();
         try (TarArchiveOutputStream tos = new TarArchiveOutputStream(new GZIPOutputStream(new BufferedOutputStream(
                 new FileOutputStream(tarFile))))) {
-            tos.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
+            tos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+            tos.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
             for (File file : files) {
                 // relativize with method using Path otherwise method with File resolves the symlinks
                 // and this is not want we want. If the file is a symlink, the relativized path should


### PR DESCRIPTION
Issue https://github.com/docker-java/docker-java/issues/1747

triggered error like 
```
group id '1718009175' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit
```

Use POSIX/PAX extensions to store big numbers in the archive.
Use POSIX/PAX extensions to store long file names in the archive.