### PR TITLE
Add npipe as a valid mount type

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/MountType.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/MountType.java
@@ -14,6 +14,10 @@ public enum MountType {
 
     //@since 1.29
     @JsonProperty("tmpfs")
-    TMPFS
+    TMPFS,
+
+    //@since 1.40
+    @JsonProperty("npipe")
+    NPIPE
 
 }


### PR DESCRIPTION
Version 1.40 of the API (or at least I think it was that version, had to manually search through versions of the doc) added npipe as a valid mount type.  This is necessary for certain cases, like mounting the default docker pipe on Windows inside a container.

I've manually tested that this change works, but automated testing has proven a bit of a challenge.  It's kind of too trivial to write a meaningful unit test for (though I did go through and made sure the all the existing tests passed, on Windows, even), and there doesn't appear to be an obvious way to add an integration test for a Windows-only feature.