### PR TITLE
Fix unit test failures on Windows

### DIFF
--- a/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
@@ -5,6 +5,7 @@ import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.AuthConfigurations;
 import com.google.common.io.Resources;
 import org.apache.commons.lang3.SerializationUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Test;
 
 import java.io.File;
@@ -97,8 +98,11 @@ public class DefaultDockerClientConfigTest {
 
         DefaultDockerClientConfig config = buildConfig(env, new Properties());
 
+        String expectedDefaultHost = SystemUtils.IS_OS_WINDOWS ? DefaultDockerClientConfig.WINDOWS_DEFAULT_DOCKER_HOST
+            : DefaultDockerClientConfig.DEFAULT_DOCKER_HOST;
+
         assertEquals(
-            DefaultDockerClientConfig.DEFAULT_DOCKER_HOST,
+            expectedDefaultHost,
             config.getDockerHost().toString()
         );
     }
@@ -119,7 +123,9 @@ public class DefaultDockerClientConfigTest {
         DefaultDockerClientConfig config = buildConfig(Collections.<String, String> emptyMap(), systemProperties);
 
         // then the cert path is as expected
-        assertEquals(config.getDockerHost(), URI.create("unix:///var/run/docker.sock"));
+        URI expectedDefaultURI = SystemUtils.IS_OS_WINDOWS ? URI.create(DefaultDockerClientConfig.WINDOWS_DEFAULT_DOCKER_HOST)
+            : URI.create(DefaultDockerClientConfig.DEFAULT_DOCKER_HOST);
+        assertEquals(config.getDockerHost(), expectedDefaultURI);
         assertEquals(config.getRegistryUsername(), "someUserName");
         assertEquals(config.getRegistryUrl(), AuthConfig.DEFAULT_SERVER_ADDRESS);
         assertEquals(config.getApiVersion(), RemoteApiVersion.unknown());

--- a/docker-java/src/test/java/com/github/dockerjava/core/util/CompressArchiveUtilTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/util/CompressArchiveUtilTest.java
@@ -2,6 +2,7 @@ package com.github.dockerjava.core.util;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -22,6 +23,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 public class CompressArchiveUtilTest {
 
@@ -69,6 +71,7 @@ public class CompressArchiveUtilTest {
 
     @Test
     public void tarWithSymbolicLinkFileAsInput() throws IOException {
+        assumeSymbolicLinksAreUnrestrictedByDefault();
         Path archiveSourceFile = tempFolder.getRoot().toPath().resolve("symlinkFile");
         Path linkTargetFile = tempFolder.newFile("link-target").toPath();
         Files.createSymbolicLink(archiveSourceFile, linkTargetFile);
@@ -139,6 +142,7 @@ public class CompressArchiveUtilTest {
 
     @Test
     public void tarWithfolderAsInputAndNestedSymbolicLinkFile() throws Exception {
+        assumeSymbolicLinksAreUnrestrictedByDefault();
         Path archiveSourceDir = tempFolder.newFolder("archive-source").toPath();
         Path linkTargetFile = tempFolder.newFile("link-target").toPath();
         Path symlinkFile = archiveSourceDir.resolve("symlinkFile");
@@ -160,6 +164,7 @@ public class CompressArchiveUtilTest {
 
     @Test
     public void tarWithfolderAsInputAndNestedSymbolicLinkDir() throws Exception {
+        assumeSymbolicLinksAreUnrestrictedByDefault();
         Path archiveSourceDir = tempFolder.newFolder("archive-source").toPath();
         Path linkTargetDir = tempFolder.newFolder("link-target").toPath();
         Path symlinkFile = archiveSourceDir.resolve("symlinkFile");
@@ -204,6 +209,7 @@ public class CompressArchiveUtilTest {
 
     @Test
     public void archiveTARFilesWithSymbolicLinkFile() throws Exception {
+        assumeSymbolicLinksAreUnrestrictedByDefault();
         Path linkTargetFile = tempFolder.newFile("link-target").toPath();
         Path symlinkFile = tempFolder.getRoot().toPath().resolve("symlinkFile");
         Files.createSymbolicLink(symlinkFile, linkTargetFile);
@@ -215,6 +221,7 @@ public class CompressArchiveUtilTest {
 
     @Test
     public void archiveTARFilesWithSymbolicLinkDir() throws Exception {
+        assumeSymbolicLinksAreUnrestrictedByDefault();
         Path linkTargetDir = tempFolder.newFolder("link-target").toPath();
         Path symlinkFile = tempFolder.getRoot().toPath().resolve("symlinkFile");
         Files.createSymbolicLink(symlinkFile, linkTargetDir);
@@ -316,5 +323,9 @@ public class CompressArchiveUtilTest {
             }
         }
         return numberOfEntries;
+    }
+
+    private static void assumeSymbolicLinksAreUnrestrictedByDefault(){
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
     }
 }


### PR DESCRIPTION
Splitting this out from #1788 since it requires more discussion.

Since I was working on #1788 on Windows so that I could test things, I ran into a few failures of the unit test suite on Windows.  I made a few fixes to them so that they could pass on both Linux and Windows.

This does _not_ attempt to do anything about the integration tests.  It is probably not possible or desirable for that suite to be cross platform.  Any hypothetical Windows integration tests likely would deserve their own suite.