### PR TITLE
Use POSIX for tar long file mode and big number mode.

### DIFF
--- a/docker-java-core/src/main/java/com/github/dockerjava/core/util/CompressArchiveUtil.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/util/CompressArchiveUtil.java
@@ -54,7 +54,8 @@ public class CompressArchiveUtil {
             outputStream = new GzipCompressorOutputStream(outputStream);
         }
         TarArchiveOutputStream tarArchiveOutputStream = new TarArchiveOutputStream(outputStream);
-        tarArchiveOutputStream.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
+        tarArchiveOutputStream.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+        tarArchiveOutputStream.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
         return tarArchiveOutputStream;
     }
 


### PR DESCRIPTION
Got the same issue as described in #1747 but PR https://github.com/docker-java/docker-java/pull/1787 did not fix it for me.
I tested these modifications and it seems ok, but not sure if I overlooked anything.