### PR TITLE
load testing resources from classpath path

### DIFF
--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveFromContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveFromContainerCmdIT.java
@@ -66,7 +66,7 @@ public class CopyArchiveFromContainerCmdIT extends CmdIT {
         assertThat(container.getId(), not(isEmptyOrNullString()));
 
         Path temp = Files.createTempFile("", ".tar.gz");
-        Path binaryFile = Paths.get("src/test/resources/testCopyFromArchive/binary.dat");
+        Path binaryFile = Paths.get(ClassLoader.getSystemResource("testCopyFromArchive/binary.dat").toURI());
         CompressArchiveUtil.tar(binaryFile, temp, true, false);
 
         try (InputStream uploadStream = Files.newInputStream(temp)) {

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveToContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveToContainerCmdIT.java
@@ -31,9 +31,9 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
         CompressArchiveUtil.tar(Paths.get(ClassLoader.getSystemResource("testReadFile").toURI()), temp, true, false);
         try (InputStream uploadStream = Files.newInputStream(temp)) {
             dockerRule.getClient()
-                .copyArchiveToContainerCmd(container.getId())
-                .withTarInputStream(uploadStream)
-                .exec();
+                    .copyArchiveToContainerCmd(container.getId())
+                    .withTarInputStream(uploadStream)
+                    .exec();
             assertFileCopied(container);
         }
     }
@@ -60,8 +60,8 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
 
     private CreateContainerResponse prepareContainerForCopy(String method) {
         CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox")
-            .withName("docker-java-itest-copyToContainer" + method)
-            .exec();
+                .withName("docker-java-itest-copyToContainer" + method)
+                .exec();
         LOG.info("Created container: {}", container);
         assertThat(container.getId(), not(isEmptyOrNullString()));
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
@@ -72,7 +72,7 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
     private void assertFileCopied(CreateContainerResponse container) throws IOException {
         try (InputStream response = dockerRule.getClient().copyArchiveFromContainerCmd(container.getId(), "testReadFile").exec()) {
             boolean bytesAvailable = response.read() != -1;
-            assertTrue("The file was not copied to the container.", bytesAvailable);
+            assertTrue( "The file was not copied to the container.", bytesAvailable);
         }
     }
 
@@ -83,7 +83,7 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
     }
 
     @Test
-    public void copyDirWithLastAddedTarEntryEmptyDir() throws Exception {
+    public void copyDirWithLastAddedTarEntryEmptyDir() throws Exception{
         // create a temp dir
         Path localDir = Files.createTempDirectory(null);
         localDir.toFile().deleteOnExit();
@@ -96,25 +96,25 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
 
         // create a test container
         CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox")
-            .withCmd("sleep", "9999")
-            .exec();
+                .withCmd("sleep", "9999")
+                .exec();
         // start the container
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
         // copy data from local dir to container
         dockerRule.getClient().copyArchiveToContainerCmd(container.getId())
-            .withHostResource(localDir.toString())
-            .exec();
+                .withHostResource(localDir.toString())
+                .exec();
 
         // cleanup dir
         FileUtils.deleteDirectory(localDir.toFile());
     }
-
+    
     @Test
     public void copyFileWithExecutePermission() throws Exception {
         // create script file, add permission to execute
         Path scriptPath = Files.createTempFile("run", ".sh");
         boolean executable = scriptPath.toFile().setExecutable(true, false);
-        if (!executable) {
+        if (!executable){
             throw new Exception("Execute permission on file not set!");
         }
         String snippet = "Running script with execute permission.";
@@ -125,20 +125,20 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
         // script to be copied to the container's home dir and then executes it
         String containerCmd = "sleep 3; /home/" + scriptPath.getFileName().toString();
         CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox")
-            .withName("copyFileWithExecutivePerm")
-            .withCmd("/bin/sh", "-c", containerCmd)
-            .exec();
+                .withName("copyFileWithExecutivePerm")
+                .withCmd("/bin/sh", "-c", containerCmd)
+                .exec();
         // start the container
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
         // copy script to container home dir
         dockerRule.getClient().copyArchiveToContainerCmd(container.getId())
-            .withRemotePath("/home")
-            .withHostResource(scriptPath.toString())
-            .exec();
+                .withRemotePath("/home")
+                .withHostResource(scriptPath.toString())
+                .exec();
         // await exid code
         int exitCode = dockerRule.getClient().waitContainerCmd(container.getId())
-            .start()
-            .awaitStatusCode();
+                .start()
+                .awaitStatusCode();
         // check result
         assertThat(exitCode, equalTo(0));
     }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveToContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveToContainerCmdIT.java
@@ -47,8 +47,8 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
     public void copyStreamToContainer() throws Exception {
         CreateContainerResponse container = prepareContainerForCopy("2");
         dockerRule.getClient().copyArchiveToContainerCmd(container.getId())
-            .withHostResource(Paths.get(ClassLoader.getSystemResource("testReadFile").toURI()).toString())
-            .exec();
+                .withHostResource(Paths.get(ClassLoader.getSystemResource("testReadFile").toURI()).toString())
+                .exec();
         assertFileCopied(container);
     }
 
@@ -56,7 +56,7 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
     public void copyStreamToContainerTwice() throws Exception {
         CreateContainerResponse container = prepareContainerForCopy("rerun");
         CopyArchiveToContainerCmd copyArchiveToContainerCmd = dockerRule.getClient().copyArchiveToContainerCmd(container.getId())
-            .withHostResource(Paths.get(ClassLoader.getSystemResource("testReadFile").toURI()).toString());
+                .withHostResource(Paths.get(ClassLoader.getSystemResource("testReadFile").toURI()).toString());
         copyArchiveToContainerCmd.exec();
         assertFileCopied(container);
         //run again to make sure no DockerClientException
@@ -82,9 +82,9 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
     }
 
     @Test(expected = NotFoundException.class)
-    public void copyToNonExistingContainer() {
+    public void copyToNonExistingContainer() throws Exception {
         dockerRule.getClient().copyArchiveToContainerCmd("non-existing")
-            .withHostResource(Paths.get(ClassLoader.getSystemResource("testReadFile").toURI()).toString()).exec();
+                .withHostResource(Paths.get(ClassLoader.getSystemResource("testReadFile").toURI()).toString()).exec();
     }
 
     @Test
@@ -113,7 +113,7 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
         // cleanup dir
         FileUtils.deleteDirectory(localDir.toFile());
     }
-    
+
     @Test
     public void copyFileWithExecutePermission() throws Exception {
         // create script file, add permission to execute

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveToContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveToContainerCmdIT.java
@@ -28,12 +28,12 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
     public void copyFileToContainer() throws Exception {
         CreateContainerResponse container = prepareContainerForCopy("1");
         Path temp = Files.createTempFile("", ".tar.gz");
-        CompressArchiveUtil.tar(Paths.get("src/test/resources/testReadFile"), temp, true, false);
+        CompressArchiveUtil.tar(Paths.get(ClassLoader.getSystemResource("testReadFile").toURI()), temp, true, false);
         try (InputStream uploadStream = Files.newInputStream(temp)) {
             dockerRule.getClient()
-                    .copyArchiveToContainerCmd(container.getId())
-                    .withTarInputStream(uploadStream)
-                    .exec();
+                .copyArchiveToContainerCmd(container.getId())
+                .withTarInputStream(uploadStream)
+                .exec();
             assertFileCopied(container);
         }
     }
@@ -42,16 +42,16 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
     public void copyStreamToContainer() throws Exception {
         CreateContainerResponse container = prepareContainerForCopy("2");
         dockerRule.getClient().copyArchiveToContainerCmd(container.getId())
-                .withHostResource("src/test/resources/testReadFile")
-                .exec();
+            .withHostResource(Paths.get(ClassLoader.getSystemResource("testReadFile").toURI()).toString())
+            .exec();
         assertFileCopied(container);
     }
 
     @Test
     public void copyStreamToContainerTwice() throws Exception {
         CreateContainerResponse container = prepareContainerForCopy("rerun");
-        CopyArchiveToContainerCmd copyArchiveToContainerCmd=dockerRule.getClient().copyArchiveToContainerCmd(container.getId())
-                .withHostResource("src/test/resources/testReadFile");
+        CopyArchiveToContainerCmd copyArchiveToContainerCmd = dockerRule.getClient().copyArchiveToContainerCmd(container.getId())
+            .withHostResource(Paths.get(ClassLoader.getSystemResource("testReadFile").toURI()).toString());
         copyArchiveToContainerCmd.exec();
         assertFileCopied(container);
         //run again to make sure no DockerClientException
@@ -60,8 +60,8 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
 
     private CreateContainerResponse prepareContainerForCopy(String method) {
         CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox")
-                .withName("docker-java-itest-copyToContainer" + method)
-                .exec();
+            .withName("docker-java-itest-copyToContainer" + method)
+            .exec();
         LOG.info("Created container: {}", container);
         assertThat(container.getId(), not(isEmptyOrNullString()));
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
@@ -72,18 +72,18 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
     private void assertFileCopied(CreateContainerResponse container) throws IOException {
         try (InputStream response = dockerRule.getClient().copyArchiveFromContainerCmd(container.getId(), "testReadFile").exec()) {
             boolean bytesAvailable = response.read() != -1;
-            assertTrue( "The file was not copied to the container.", bytesAvailable);
+            assertTrue("The file was not copied to the container.", bytesAvailable);
         }
     }
 
     @Test(expected = NotFoundException.class)
     public void copyToNonExistingContainer() throws Exception {
-
-        dockerRule.getClient().copyArchiveToContainerCmd("non-existing").withHostResource("src/test/resources/testReadFile").exec();
+        dockerRule.getClient().copyArchiveToContainerCmd("non-existing")
+            .withHostResource(Paths.get(ClassLoader.getSystemResource("testReadFile").toURI()).toString()).exec();
     }
 
     @Test
-    public void copyDirWithLastAddedTarEntryEmptyDir() throws Exception{
+    public void copyDirWithLastAddedTarEntryEmptyDir() throws Exception {
         // create a temp dir
         Path localDir = Files.createTempDirectory(null);
         localDir.toFile().deleteOnExit();
@@ -96,25 +96,25 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
 
         // create a test container
         CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox")
-                .withCmd("sleep", "9999")
-                .exec();
+            .withCmd("sleep", "9999")
+            .exec();
         // start the container
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
         // copy data from local dir to container
         dockerRule.getClient().copyArchiveToContainerCmd(container.getId())
-                .withHostResource(localDir.toString())
-                .exec();
+            .withHostResource(localDir.toString())
+            .exec();
 
         // cleanup dir
         FileUtils.deleteDirectory(localDir.toFile());
     }
-    
+
     @Test
     public void copyFileWithExecutePermission() throws Exception {
         // create script file, add permission to execute
         Path scriptPath = Files.createTempFile("run", ".sh");
         boolean executable = scriptPath.toFile().setExecutable(true, false);
-        if (!executable){
+        if (!executable) {
             throw new Exception("Execute permission on file not set!");
         }
         String snippet = "Running script with execute permission.";
@@ -125,20 +125,20 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
         // script to be copied to the container's home dir and then executes it
         String containerCmd = "sleep 3; /home/" + scriptPath.getFileName().toString();
         CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox")
-                .withName("copyFileWithExecutivePerm")
-                .withCmd("/bin/sh", "-c", containerCmd)
-                .exec();
+            .withName("copyFileWithExecutivePerm")
+            .withCmd("/bin/sh", "-c", containerCmd)
+            .exec();
         // start the container
         dockerRule.getClient().startContainerCmd(container.getId()).exec();
         // copy script to container home dir
         dockerRule.getClient().copyArchiveToContainerCmd(container.getId())
-                .withRemotePath("/home")
-                .withHostResource(scriptPath.toString())
-                .exec();
+            .withRemotePath("/home")
+            .withHostResource(scriptPath.toString())
+            .exec();
         // await exid code
         int exitCode = dockerRule.getClient().waitContainerCmd(container.getId())
-                .start()
-                .awaitStatusCode();
+            .start()
+            .awaitStatusCode();
         // check result
         assertThat(exitCode, equalTo(0));
     }

--- a/docker-java/src/test/java/com/github/dockerjava/utils/TestResources.java
+++ b/docker-java/src/test/java/com/github/dockerjava/utils/TestResources.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.utils;
 
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -8,7 +9,7 @@ public class TestResources {
     private TestResources() {
     }
 
-    public static Path getApiImagesLoadTestTarball() {
-        return Paths.get("src/test/resources/api/images/load/image.tar");
+    public static Path getApiImagesLoadTestTarball() throws URISyntaxException {
+        return Paths.get(ClassLoader.getSystemResource("api/images/load/image.tar").toURI());
     }
 }


### PR DESCRIPTION
I was importing the test-jar of com.github.docker-java:docker-java to reuse the test classes. I found the problem, that this was not possible until the files used in testing are loading from classpath instead of source path.