### PR TITLE
Allow configuration of restart policy when updating containers.

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/UpdateContainerCmd.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/UpdateContainerCmd.java
@@ -1,6 +1,7 @@
 package com.github.dockerjava.api.command;
 
 import com.github.dockerjava.api.model.UpdateContainerResponse;
+import com.github.dockerjava.api.model.RestartPolicy;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -64,6 +65,11 @@ public interface UpdateContainerCmd extends SyncDockerCmd<UpdateContainerRespons
     Long getMemorySwap();
 
     UpdateContainerCmd withMemorySwap(Long memorySwap);
+
+    @CheckForNull
+    RestartPolicy getRestartPolicy();
+
+    UpdateContainerCmd withRestartPolicy(RestartPolicy restartPolicy);
 
     interface Exec extends DockerCmdSyncExec<UpdateContainerCmd, UpdateContainerResponse> {
     }

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/RestartPolicy.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/RestartPolicy.java
@@ -36,7 +36,7 @@ public class RestartPolicy extends DockerObject implements Serializable {
     private Integer maximumRetryCount = 0;
 
     @JsonProperty("Name")
-    private String name = "";
+    private String name = "no";
 
     public RestartPolicy() {
     }
@@ -132,7 +132,6 @@ public class RestartPolicy extends DockerObject implements Serializable {
      */
     @Override
     public String toString() {
-        String result = name.isEmpty() ? "no" : name;
-        return maximumRetryCount > 0 ? result + ":" + maximumRetryCount : result;
+        return maximumRetryCount > 0 ? name + ":" + maximumRetryCount : name;
     }
 }

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/UpdateContainerCmdImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/UpdateContainerCmdImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.dockerjava.api.command.UpdateContainerCmd;
 import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.RestartPolicy;
 import com.github.dockerjava.api.model.UpdateContainerResponse;
 import com.github.dockerjava.core.RemoteApiVersion;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -54,6 +55,9 @@ public class UpdateContainerCmdImpl extends AbstrDockerCmd<UpdateContainerCmd, U
 
     @JsonProperty("KernelMemory")
     private Long kernelMemory;
+
+    @JsonProperty("RestartPolicy")
+    private RestartPolicy restartPolicy;
 
     public UpdateContainerCmdImpl(UpdateContainerCmd.Exec exec, String containerId) {
         super(exec);
@@ -234,6 +238,22 @@ public class UpdateContainerCmdImpl extends AbstrDockerCmd<UpdateContainerCmd, U
      */
     public UpdateContainerCmd withMemorySwap(Long memorySwap) {
         this.memorySwap = memorySwap;
+        return this;
+    }
+
+    /**
+     * @see #restartPolicy
+     */
+    @CheckForNull
+    public RestartPolicy getRestartPolicy() {
+        return restartPolicy;
+    }
+
+    /**
+     * @see #restartPolicy
+     */
+    public UpdateContainerCmd withRestartPolicy(RestartPolicy restartPolicy) {
+        this.restartPolicy = restartPolicy;
         return this;
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/RestartPolicySerializingTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/RestartPolicySerializingTest.java
@@ -15,7 +15,7 @@ public class RestartPolicySerializingTest {
     // --restart no
     public void noRestart() throws Exception {
         String json = JSONTestHelper.getMapper().writeValueAsString(RestartPolicy.noRestart());
-        assertEquals(json, "{\"MaximumRetryCount\":0,\"Name\":\"\"}");
+        assertEquals(json, "{\"MaximumRetryCount\":0,\"Name\":\"no\"}");
     }
 
     @Test


### PR DESCRIPTION
Resolves #1077, which we also need. This patch has been running in production at [Anvil](https://anvil.works) for some time, and we consider it stable.