### PR TITLE
Update OkHttp3 to 4.9.3

### DIFF
--- a/docker-java-transport-okhttp/pom.xml
+++ b/docker-java-transport-okhttp/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>3.14.9</version>
+			<version>4.9.3</version>
 		</dependency>
 
 		<dependency>

--- a/docker-java-transport-tck/pom.xml
+++ b/docker-java-transport-tck/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>mockwebserver</artifactId>
-			<version>3.14.9</version>
+			<version>4.9.3</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Updates OkHttp3 to 4.9.3.

When using the okhttp transport along side opentelemetry java otlp exporter, we have a version clash. OTEL is using a more recent one and if we do a native build it fails because of that.

Fixes https://github.com/docker-java/docker-java/issues/1867