### PR TITLE
Support Memory_stats based on Mirantis Container Runtime on Windows 2022

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/MemoryStatsConfig.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/MemoryStatsConfig.java
@@ -32,6 +32,15 @@ public class MemoryStatsConfig extends DockerObject implements Serializable {
     @JsonProperty("limit")
     private Long limit;
 
+    @JsonProperty("commitbytes")
+    private Long commitbytes;
+
+    @JsonProperty("commitpeakbytes")
+    private Long commitpeakbytes;
+
+    @JsonProperty("privateworkingset")
+    private Long privateworkingset;
+
     /**
      * @see #stats
      */
@@ -69,5 +78,26 @@ public class MemoryStatsConfig extends DockerObject implements Serializable {
     @CheckForNull
     public Long getLimit() {
         return limit;
+    }
+
+    /**
+     * @see #commitbytes
+     */
+    public Long getCommitbytes() {
+        return commitbytes;
+    }
+
+    /**
+     * @see #commitpeakbytes
+     */
+    public Long getCommitpeakbytes() {
+        return commitpeakbytes;
+    }
+
+    /**
+     * @see #privateworkingset
+     */
+    public Long getPrivateworkingset() {
+        return privateworkingset;
     }
 }

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/StatisticsTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/StatisticsTest.java
@@ -83,6 +83,9 @@ public class StatisticsTest {
 
         assertThat(memoryStats.getLimit(), is(2095874048L));
         assertThat(memoryStats.getFailcnt(), is(0L));
+        assertThat(memoryStats.getPrivateworkingset(), is(206008320L));
+        assertThat(memoryStats.getCommitbytes(), is(252903424L));
+        assertThat(memoryStats.getCommitpeakbytes(), is(325029888L));
 
         final BlkioStatsConfig blkioStats = statistics.getBlkioStats();
         assertThat(blkioStats.getIoServiceBytesRecursive(), Matchers.<BlkioStatEntry>hasSize(5));

--- a/docker-java/src/test/resources/samples/1.27/containers/container/stats/stats1.json
+++ b/docker-java/src/test/resources/samples/1.27/containers/container/stats/stats1.json
@@ -172,7 +172,11 @@
       "writeback":0
     },
     "limit":2095874048,
-    "failcnt":0
+    "failcnt":0,
+    "commitbytes":252903424,
+    "commitpeakbytes":325029888,
+    "privateworkingset":206008320
+
   },
   "name":"/gallant_hamilton",
   "id":"b581d78b03e41d81c9fe941f03f5d35e23733ff96370456b58d2906e002b0deb",


### PR DESCRIPTION
Running Windows containers on Mirantis Container Runtime (MCR) on Windows Server does not produce the traditional memory_stats object.  This addition allows these specific attributes to be included when available.

An example Container stats looks like the following via the API:
```json
{
	"read": "2022-07-26T06:18:46.0429667-07:00",
	"preread": "2022-07-26T06:18:45.036105-07:00",
	"pids_stats": {},
	"blkio_stats": {
		"io_service_bytes_recursive": null,
		"io_serviced_recursive": null,
		"io_queue_recursive": null,
		"io_service_time_recursive": null,
		"io_wait_time_recursive": null,
		"io_merged_recursive": null,
		"io_time_recursive": null,
		"sectors_recursive": null
	},
	"num_procs": 8,
	"storage_stats": {
		"read_count_normalized": 5113,
		"read_size_bytes": 39343104,
		"write_count_normalized": 3969,
		"write_size_bytes": 27013120
	},
	"cpu_stats": {
		"cpu_usage": {
			"total_usage": 261093750,
			"usage_in_kernelmode": 174843750,
			"usage_in_usermode": 86250000
		},
		"throttling_data": {
			"periods": 0,
			"throttled_periods": 0,
			"throttled_time": 0
		}
	},
	"precpu_stats": {
		"cpu_usage": {
			"total_usage": 261093750,
			"usage_in_kernelmode": 174843750,
			"usage_in_usermode": 86250000
		},
		"throttling_data": {
			"periods": 0,
			"throttled_periods": 0,
			"throttled_time": 0
		}
	},
	"memory_stats": {
		"commitbytes": 149622784,
		"commitpeakbytes": 175665152,
		"privateworkingset": 104153088
	},
	"name": "/charming_greider",
	"id": "4e1163fb5c14ad3f2f94cb21ca3c80f91567b7ea2416e60e852218deeda56886",
	"networks": {
		"6C20C6DF-1ACA-499F-8158-012CA32E086A": {
			"rx_bytes": 539375,
			"rx_packets": 438,
			"rx_errors": 0,
			"rx_dropped": 43,
			"tx_bytes": 49320,
			"tx_packets": 388,
			"tx_errors": 0,
			"tx_dropped": 0
		}
	}
}
```