### PR TITLE
Add support for `reference` query param in List Images

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/ListImagesCmd.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/ListImagesCmd.java
@@ -44,6 +44,13 @@ public interface ListImagesCmd extends SyncDockerCmd<List<Image>> {
      */
     ListImagesCmd withLabelFilter(Map<String, String> labels);
 
+    /**
+     * Filter images by reference
+     *
+     * @param reference string in the form {@code <image-name>[:<tag>]}
+     */
+    ListImagesCmd withReferenceFilter(String reference);
+
     interface Exec extends DockerCmdSyncExec<ListImagesCmd, List<Image>> {
     }
 

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/ListImagesCmdImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/ListImagesCmdImpl.java
@@ -72,6 +72,13 @@ public class ListImagesCmdImpl extends AbstrDockerCmd<ListImagesCmd, List<Image>
     }
 
     @Override
+    public ListImagesCmd withReferenceFilter(String reference) {
+        checkNotNull(reference, "reference filter not specified");
+        filters.withFilter("reference", reference);
+        return this;
+    }
+
+    @Override
     public String getImageNameFilter() {
         return this.imageNameFilter;
     }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/ListImagesCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/ListImagesCmdIT.java
@@ -15,6 +15,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
@@ -52,6 +53,13 @@ public class ListImagesCmdIT extends CmdIT {
         assertThat(images.size(), is(greaterThan(0)));
         Boolean imageInFilteredList = isImageInFilteredList(images, imageId);
         assertTrue(imageInFilteredList);
+    }
+
+    @Test
+    public void listImagesWithReferenceFilter() throws DockerException {
+        List<Image> images = dockerRule.getClient().listImagesCmd().withReferenceFilter("busybox")
+            .exec();
+        assertThat(images, hasSize(1));
     }
 
     private boolean isImageInFilteredList(List<Image> images, String expectedImageId) {


### PR DESCRIPTION
`filter` query param was removed in Docker API 1.41. Using `reference`
query param will allow to use format <image-name>[:<tag>].
