### PR TITLE
chore: commons-io 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<httpclient.version>4.5.12</httpclient.version><!-- 4.5.1-4.5.2 broken -->
 		<commons-compress.version>1.21</commons-compress.version>
 		<commons-codec.version>1.11</commons-codec.version>
-		<commons-io.version>2.6</commons-io.version>
+		<commons-io.version>2.11.0</commons-io.version>
 		<commons-lang3.version>3.12.0</commons-lang3.version>
 		<slf4j-api.version>1.7.30</slf4j-api.version>
 


### PR DESCRIPTION
Resolves the CVE https://security.snyk.io/vuln/SNYK-JAVA-COMMONSIO-1277109