### PR TITLE
Fix #1258: Support copyUIDGID option in CopyArchiveToContainerCmd

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/CopyArchiveToContainerCmd.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/CopyArchiveToContainerCmd.java
@@ -16,6 +16,7 @@ public interface CopyArchiveToContainerCmd extends SyncDockerCmd<Void> {
 
     boolean isDirChildrenOnly();
 
+    boolean isCopyUIDGID();
     /**
      * Set container's id
      *
@@ -48,6 +49,14 @@ public interface CopyArchiveToContainerCmd extends SyncDockerCmd<Void> {
      *            flag to know if non directory can be overwritten
      */
     CopyArchiveToContainerCmd withNoOverwriteDirNonDir(boolean noOverwriteDirNonDir);
+
+    /**
+     * If set to true then ownership is set to the user and primary group at the destination
+     *
+     * @param copyUIDGID
+     *            flag to know if ownership should be set to the user and primary group at the destination
+     */
+    CopyArchiveToContainerCmd withCopyUIDGID(boolean copyUIDGID);
 
     /**
      * If this flag is set to true, all children of the local directory will be copied to the remote without the root directory. For ex: if

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/CopyArchiveToContainerCmdImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/CopyArchiveToContainerCmdImpl.java
@@ -31,6 +31,8 @@ public class CopyArchiveToContainerCmdImpl extends AbstrDockerCmd<CopyArchiveToC
 
     private boolean dirChildrenOnly = false;
 
+    private boolean copyUIDGID = false;
+
     public CopyArchiveToContainerCmdImpl(CopyArchiveToContainerCmd.Exec exec, String containerId) {
         super(exec);
         withContainerId(containerId);
@@ -53,6 +55,12 @@ public class CopyArchiveToContainerCmdImpl extends AbstrDockerCmd<CopyArchiveToC
     @Override
     public CopyArchiveToContainerCmd withNoOverwriteDirNonDir(boolean noOverwriteDirNonDir) {
         this.noOverwriteDirNonDir = noOverwriteDirNonDir;
+        return this;
+    }
+
+    @Override
+    public CopyArchiveToContainerCmd withCopyUIDGID(boolean copyUIDGID) {
+        this.copyUIDGID = copyUIDGID;
         return this;
     }
 
@@ -107,9 +115,14 @@ public class CopyArchiveToContainerCmdImpl extends AbstrDockerCmd<CopyArchiveToC
     }
 
     @Override
+    public boolean isCopyUIDGID() {
+        return this.copyUIDGID;
+    }
+
+    @Override
     public String toString() {
-        return new ToStringBuilder(this).append("cp ").append(hostResource).append(" ").append(containerId).append(":")
-                .append(remotePath).toString();
+        return new ToStringBuilder(this).append("cp ").append(String.format("-a=%b ", isCopyUIDGID()))
+            .append(hostResource).append(" ").append(containerId).append(":").append(remotePath).toString();
     }
 
     /**

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/exec/CopyArchiveToContainerCmdExec.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/exec/CopyArchiveToContainerCmdExec.java
@@ -28,7 +28,9 @@ public class CopyArchiveToContainerCmdExec extends AbstrSyncDockerCmdExec<CopyAr
         InputStream streamToUpload = command.getTarInputStream();
 
         webResource.queryParam("path", command.getRemotePath())
-                .queryParam("noOverwriteDirNonDir", command.isNoOverwriteDirNonDir()).request()
+                .queryParam("noOverwriteDirNonDir", command.isNoOverwriteDirNonDir())
+                .queryParam("copyUIDGID", command.isCopyUIDGID())
+                .request()
                 .put(streamToUpload, MediaType.APPLICATION_X_TAR);
 
         return null;

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveToContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveToContainerCmdIT.java
@@ -4,6 +4,7 @@ import com.github.dockerjava.api.command.CopyArchiveToContainerCmd;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.core.util.CompressArchiveUtil;
+import com.github.dockerjava.utils.LogContainerTestCallback;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -14,12 +15,16 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
 
 public class CopyArchiveToContainerCmdIT extends CmdIT {
     public static final Logger LOG = LoggerFactory.getLogger(CopyArchiveToContainerCmdIT.class);
@@ -143,4 +148,69 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
         assertThat(exitCode, equalTo(0));
     }
 
+    @Test
+    public void copyFileWithUIDGID() throws Exception {
+        Path withDir = Files.createTempDirectory("copyFileWithUIDGID");
+        Path with = Files.createFile(Files.createTempDirectory("copyFileWithUIDGID").resolve("uidgid.with"));
+        Files.write(with, "with".getBytes());
+
+        Path withoutDir = Files.createTempDirectory("copyFileWithUIDGID");
+        Path without = Files.createFile(Files.createTempDirectory("copyFileWithUIDGID").resolve("uidgid.without"));
+        Files.write(without, "with".getBytes());
+
+        String containerCmd = "while [ ! -f /home/uidgid.with ]; do true; done && stat -c %n:%u /home/uidgid.with /home/uidgid.without";
+        CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox")
+                .withName("copyFileWithUIDGID")
+                .withCmd("/bin/sh", "-c", containerCmd)
+                .exec();
+        // start the container
+        dockerRule.getClient().startContainerCmd(container.getId()).exec();
+
+        dockerRule.getClient().copyArchiveToContainerCmd(container.getId())
+                .withRemotePath("/home/")
+                .withHostResource(without.toString())
+                .withCopyUIDGID(false)
+                .exec();
+        dockerRule.getClient().copyArchiveToContainerCmd(container.getId())
+                .withRemotePath("/home/")
+                .withHostResource(with.toString())
+                .withCopyUIDGID(true)
+                .exec();
+
+        // await exit code
+        int exitCode = dockerRule.getClient().waitContainerCmd(container.getId())
+                .start()
+                .awaitStatusCode();
+        // check result
+        assertThat(exitCode, equalTo(0));
+
+        LogContainerTestCallback loggingCallback = new LogContainerTestCallback(true);
+
+        dockerRule.getClient().logContainerCmd(container.getId())
+            .withStdOut(true)
+            .withTailAll()
+            .exec(loggingCallback);
+
+        loggingCallback.awaitCompletion(3, TimeUnit.SECONDS);
+        assertThat(loggingCallback.toString(), containsString("/home/uidgid.with:0"));
+
+        Long hostUid = getHostUidIfPossible();
+        assumeThat("could not get the uid on host platform", hostUid, notNullValue(Long.class));
+        assertThat(loggingCallback.toString(), containsString(String.format("/home/uidgid.without:%d", hostUid)));
+    }
+
+    private static Long getHostUidIfPossible() {
+        try {
+            Class<?> unixSystemClazz = Class.forName("com.sun.security.auth.module.UnixSystem");
+            Object unixSystem = unixSystemClazz.newInstance();
+            Object uid = unixSystemClazz.getMethod("getUid").invoke(unixSystem);
+            if (uid == null) {
+                return null;
+            }
+
+            return uid instanceof Long ? (Long) uid : Long.parseLong(uid.toString());
+        } catch (Exception e) {
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
Signed-off-by: kwall <kwall@apache.org>