### PR TITLE
Add Imports for `DockerClientConfig` Documentation

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -18,9 +18,6 @@ The builder is available and allows you to configure every property of the clien
 ```java
 import com.github.dockerjava.core.DockerClientConfig
 import com.github.dockerjava.core.DefaultDockerClientConfig
-
-...
-
 DockerClientConfig standard = DefaultDockerClientConfig.createDefaultConfigBuilder().build();
 ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -16,10 +16,18 @@ You will need an instance of `DockerClientConfig` to tell the library how to acc
 
 The builder is available and allows you to configure every property of the client:
 ```java
+import com.github.dockerjava.core.DockerClientConfig
+import com.github.dockerjava.core.DefaultDockerClientConfig
+
+...
+
 DockerClientConfig standard = DefaultDockerClientConfig.createDefaultConfigBuilder().build();
 ```
 
 ```java
+import com.github.dockerjava.core.DockerClientConfig
+import com.github.dockerjava.core.DefaultDockerClientConfig
+
 DockerClientConfig custom = DefaultDockerClientConfig.createDefaultConfigBuilder()
     .withDockerHost("tcp://docker.somewhere.tld:2376")
     .withDockerTlsVerify(true)


### PR DESCRIPTION
Make things a bit easier by specifying some imports in `getting_started.md`