### PR TITLE
generate module-info.class and manifest

### DIFF
--- a/docker-java-api/pom.xml
+++ b/docker-java-api/pom.xml
@@ -16,7 +16,9 @@
 	<description>Java API Client for Docker</description>
 
 	<properties>
-		<automatic.module.name>com.github.dockerjava.api</automatic.module.name>
+		<symbolic.name>com.github.dockerjava.api</symbolic.name>
+		<bnd.instruction>Export-Package: \
+							com.github.dockerjava.api.*</bnd.instruction>
 	</properties>
 
 	<dependencies>
@@ -69,18 +71,4 @@
 		</dependency>
 	</dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<extensions>true</extensions>
-				<configuration>
-					<instructions>
-						<Export-Package>com.github.dockerjava.api.*</Export-Package>
-					</instructions>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/docker-java-core/pom.xml
+++ b/docker-java-core/pom.xml
@@ -16,7 +16,9 @@
 	<description>Java API Client for Docker</description>
 
 	<properties>
-		<automatic.module.name>com.github.dockerjava.core</automatic.module.name>
+		<symbolic.name>com.github.dockerjava.core</symbolic.name>
+		<bnd.instruction>Export-Package: \
+							com.github.dockerjava.core.*</bnd.instruction>
 	</properties>
 
 	<dependencies>
@@ -83,16 +85,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<extensions>true</extensions>
-				<configuration>
-					<instructions>
-						<Export-Package>com.github.dockerjava.core.*</Export-Package>
-					</instructions>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/docker-java-transport-httpclient5/pom.xml
+++ b/docker-java-transport-httpclient5/pom.xml
@@ -16,7 +16,9 @@
 	<description>Java API Client for Docker</description>
 
 	<properties>
-		<automatic.module.name>com.github.dockerjava.transport.httpclient5</automatic.module.name>
+		<symbolic.name>com.github.dockerjava.transport.httpclient5</symbolic.name>
+		<bnd.instruction>Export-Package: \
+							com.github.dockerjava.httpclient5.*</bnd.instruction>
 	</properties>
 
 	<dependencies>
@@ -60,17 +62,6 @@
 				<configuration>
 					<!-- TODO remove once this module is released -->
 					<skip>true</skip>
-				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<extensions>true</extensions>
-				<configuration>
-					<instructions>
-						<Export-Package>com.github.dockerjava.httpclient5.*</Export-Package>
-					</instructions>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/docker-java-transport-jersey/pom.xml
+++ b/docker-java-transport-jersey/pom.xml
@@ -16,7 +16,9 @@
 	<description>Java API Client for Docker</description>
 
 	<properties>
-		<automatic.module.name>com.github.dockerjava.transport.jersey</automatic.module.name>
+		<symbolic.name>com.github.dockerjava.transport.jersey</symbolic.name>
+		<bnd.instruction>Export-Package: \
+							com.github.dockerjava.jaxrs.*</bnd.instruction>
 	</properties>
 
 	<dependencies>
@@ -114,17 +116,6 @@
 							</overrideCompatibilityChangeParameter>
 						</overrideCompatibilityChangeParameters>
 					</parameter>
-				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<extensions>true</extensions>
-				<configuration>
-					<instructions>
-						<Export-Package>com.github.dockerjava.jaxrs.*</Export-Package>
-					</instructions>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/docker-java-transport-netty/pom.xml
+++ b/docker-java-transport-netty/pom.xml
@@ -16,7 +16,9 @@
 	<description>Java API Client for Docker</description>
 
 	<properties>
-		<automatic.module.name>com.github.dockerjava.transport.netty</automatic.module.name>
+		<symbolic.name>com.github.dockerjava.transport.netty</symbolic.name>
+		<bnd.instruction>Export-Package: \
+							com.github.dockerjava.netty.*</bnd.instruction>
 	</properties>
 
 	<dependencies>
@@ -55,18 +57,4 @@
         </dependency>
 	</dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<extensions>true</extensions>
-				<configuration>
-					<instructions>
-						<Export-Package>com.github.dockerjava.netty.*</Export-Package>
-					</instructions>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/docker-java-transport-okhttp/pom.xml
+++ b/docker-java-transport-okhttp/pom.xml
@@ -16,7 +16,9 @@
 	<description>Java API Client for Docker</description>
 
 	<properties>
-		<automatic.module.name>com.github.dockerjava.transport.okhttp</automatic.module.name>
+		<symbolic.name>com.github.dockerjava.transport.okhttp</symbolic.name>
+		<bnd.instruction>Export-Package: \
+							com.github.dockerjava.okhttp.*</bnd.instruction>
 	</properties>
 
 	<dependencies>
@@ -64,17 +66,6 @@
 							<exclude>com.github.dockerjava.okhttp.UnixDomainSocket$SockAddr</exclude>
 						</excludes>
 					</parameter>
-				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<extensions>true</extensions>
-				<configuration>
-					<instructions>
-						<Export-Package>com.github.dockerjava.okhttp.*</Export-Package>
-					</instructions>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/docker-java-transport-tck/pom.xml
+++ b/docker-java-transport-tck/pom.xml
@@ -16,7 +16,7 @@
 	<description>Java API Client for Docker</description>
 
 	<properties>
-		<automatic.module.name>com.github.dockerjava.transport.tck</automatic.module.name>
+		<symbolic.name>com.github.dockerjava.transport.tck</symbolic.name>
 	</properties>
 
 	<dependencies>

--- a/docker-java-transport-zerodep/pom.xml
+++ b/docker-java-transport-zerodep/pom.xml
@@ -16,7 +16,9 @@
 	<description>Java API Client for Docker</description>
 
 	<properties>
-		<automatic.module.name>com.github.dockerjava.transport.zerodep</automatic.module.name>
+		<symbolic.name>com.github.dockerjava.transport.zerodep</symbolic.name>
+		<bnd.instruction>Export-Package: \
+							com.github.dockerjava.httpclient5</bnd.instruction>
 	</properties>
 
 	<dependencies>
@@ -35,17 +37,6 @@
 				<configuration>
 					<!-- TODO remove once this module is released -->
 					<skip>true</skip>
-				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<extensions>true</extensions>
-				<configuration>
-					<instructions>
-						<Export-Package>com.github.dockerjava.zerodep.*</Export-Package>
-					</instructions>
 				</configuration>
 			</plugin>
 

--- a/docker-java-transport/pom.xml
+++ b/docker-java-transport/pom.xml
@@ -16,7 +16,9 @@
 	<description>Java API Client for Docker</description>
 
 	<properties>
-		<automatic.module.name>com.github.dockerjava.transport</automatic.module.name>
+		<symbolic.name>com.github.dockerjava.transport</symbolic.name>
+		<bnd.instruction>Export-Package: \
+							com.github.dockerjava.transport.*</bnd.instruction>
 	</properties>
 
 	<dependencies>
@@ -42,18 +44,4 @@
 		</dependency>
 	</dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<extensions>true</extensions>
-				<configuration>
-					<instructions>
-						<Export-Package>com.github.dockerjava.transport.*</Export-Package>
-					</instructions>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/docker-java/pom.xml
+++ b/docker-java/pom.xml
@@ -16,7 +16,19 @@
 	<description>Java API Client for Docker</description>
 
 	<properties>
-		<automatic.module.name>com.github.dockerjava</automatic.module.name>
+		<symbolic.name>com.github.dockerjava</symbolic.name>
+		<bnd.instruction>-privatepackage: \
+							com.github.dockerjava.jaxrs.*,\
+							com.github.dockerjava.netty.*
+						Export-Package: \
+							com.github.dockerjava.api.*,\
+							com.github.dockerjava.core.*
+						Import-Package: \
+							!javax.annotation,\
+							!javax.net.ssl,\
+							!edu.umd.cs.findbugs.annotations\
+							org.newsclub.net.unix;resolution:="optional",\
+							*</bnd.instruction>
 	</properties>
 
 	<dependencies>
@@ -175,18 +187,6 @@
 					<trimStackTrace>false</trimStackTrace>
 					<rerunFailingTestsCount>5</rerunFailingTestsCount>
 					<groups>com.github.dockerjava.junit.category.Integration</groups>
-				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<extensions>true</extensions>
-				<configuration>
-					<instructions>
-						<Export-Package>!com.github.dockerjava.jaxrs.*,!com.github.dockerjava.netty.*,com.github.dockerjava.*</Export-Package>
-						<Import-Package>org.newsclub.net.unix;resolution:="optional",*</Import-Package>
-					</instructions>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
 		<jdk.source>1.8</jdk.source>
 		<jdk.target>1.8</jdk.target>
 
+		<bnd.version>6.3.1</bnd.version>
 		<jersey.version>2.30.1</jersey.version>
 		<jackson.version>2.10.3</jackson.version>
 		<jackson-jaxrs.version>2.10.3</jackson-jaxrs.version>
@@ -80,7 +81,6 @@
 		<mockito.version>3.3.0</mockito.version>
 
 
-		<maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>
 		<maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
@@ -153,23 +153,24 @@
 				</plugin>
 
 				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-jar-plugin</artifactId>
-					<version>${maven-jar-plugin.version}</version>
+					<groupId>biz.aQute.bnd</groupId>
+					<artifactId>bnd-maven-plugin</artifactId>
+					<version>${bnd.version}</version>
+					<extensions>true</extensions>
 					<executions>
 						<execution>
+							<id>bnd-jar</id>
+							<goals>
+								<goal>jar</goal>
+							</goals>
+						</execution>	
+						<execution>
+							<id>bnd-test-jar</id>
 							<goals>
 								<goal>test-jar</goal>
 							</goals>
 						</execution>
 					</executions>
-					<configuration>
-						<archive>
-							<manifestEntries>
-								<Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
-							</manifestEntries>
-						</archive>
-					</configuration>
 				</plugin>
 
 				<plugin>
@@ -220,25 +221,23 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.10.4</version>
-					<configuration>
-						<additionalparam>-Xdoclint:none</additionalparam>
-					</configuration>
+					<version>3.4.1</version>
 					<executions>
 						<execution>
 							<id>attach-javadocs</id>
+							<phase>verify</phase>
 							<goals>
 								<goal>jar</goal>
 							</goals>
 						</execution>
 					</executions>
+					<configuration>
+						<detectJavaApiLink>false</detectJavaApiLink>
+						<doclint>none</doclint>
+						<notimestamp>true</notimestamp>
+						<sourcepath>src/main/java,target/generated-sources/annotations</sourcepath>
+					</configuration>
 				</plugin>
-				<plugin>
-					<groupId>org.apache.felix</groupId>
-					<artifactId>maven-bundle-plugin</artifactId>
-					<version>4.2.1</version>
-				</plugin>
-
 
 				<plugin>
 					<!-- use with "mvn -DskipTests clean verify" -->
@@ -289,6 +288,19 @@
 			</plugins>
 		</pluginManagement>
 		<plugins>
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<configuration>
+					<bnd><![CDATA[
+					Bundle-Name: ${project.name}
+					Bundle-SymbolicName: ${symbolic.name}
+					Automatic-Module-Name: ${symbolic.name}
+					-jpms-module-info: ${symbolic.name}
+					${bnd.instruction}
+					]]></bnd>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
- replace `maven-bundle-plugin` with `bnd-maven-plugin`
- generate `module-info.class` (e.g. exports could be handles using Annotations)
- generate  manifest for OSGi compatibility ( broken osgi support is now fixed)

[documentation](https://bnd.bndtools.org/chapters/330-jpms.html)


generated module-info.class:
```
open module com.github.dockerjava.core {
  requires transitive com.fasterxml.jackson.annotation;
  requires transitive com.fasterxml.jackson.core;
  requires transitive com.fasterxml.jackson.databind;
  requires transitive com.github.dockerjava.api;
  requires transitive com.github.dockerjava.transport;
  requires transitive guava;
  requires transitive java.base;
  requires transitive jsr305;
  requires transitive org.apache.commons.compress;
  requires transitive org.apache.commons.io;
  requires org.apache.commons.lang3;
  requires org.bouncycastle.pkix;
  requires org.bouncycastle.provider;
  requires org.slf4j;
  
  exports com.github.dockerjava.core;
  exports com.github.dockerjava.core.async;
  exports com.github.dockerjava.core.command;
  exports com.github.dockerjava.core.dockerfile;
  exports com.github.dockerjava.core.exception;
  exports com.github.dockerjava.core.exec;
  exports com.github.dockerjava.core.util;
}

```