### PR TITLE
Add load async operation

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/DockerClient.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/DockerClient.java
@@ -42,6 +42,7 @@ import com.github.dockerjava.api.command.ListServicesCmd;
 import com.github.dockerjava.api.command.ListSwarmNodesCmd;
 import com.github.dockerjava.api.command.ListTasksCmd;
 import com.github.dockerjava.api.command.ListVolumesCmd;
+import com.github.dockerjava.api.command.LoadImageAsyncCmd;
 import com.github.dockerjava.api.command.LoadImageCmd;
 import com.github.dockerjava.api.command.LogContainerCmd;
 import com.github.dockerjava.api.command.LogSwarmObjectCmd;
@@ -130,6 +131,8 @@ public interface DockerClient extends Closeable {
      * @since {@link RemoteApiVersion#VERSION_1_7}
      */
     LoadImageCmd loadImageCmd(@Nonnull InputStream imageStream);
+
+    LoadImageAsyncCmd loadImageAsyncCmd(@Nonnull InputStream imageStream);
 
     SearchImagesCmd searchImagesCmd(@Nonnull String term);
 

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/DockerClientDelegate.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/DockerClientDelegate.java
@@ -42,6 +42,7 @@ import com.github.dockerjava.api.command.ListServicesCmd;
 import com.github.dockerjava.api.command.ListSwarmNodesCmd;
 import com.github.dockerjava.api.command.ListTasksCmd;
 import com.github.dockerjava.api.command.ListVolumesCmd;
+import com.github.dockerjava.api.command.LoadImageAsyncCmd;
 import com.github.dockerjava.api.command.LoadImageCmd;
 import com.github.dockerjava.api.command.LogContainerCmd;
 import com.github.dockerjava.api.command.LogSwarmObjectCmd;
@@ -151,6 +152,11 @@ public class DockerClientDelegate implements DockerClient {
     @Override
     public LoadImageCmd loadImageCmd(@Nonnull InputStream imageStream) {
         return getDockerClient().loadImageCmd(imageStream);
+    }
+
+    @Override
+    public LoadImageAsyncCmd loadImageAsyncCmd(@Nonnull InputStream imageStream) {
+        return getDockerClient().loadImageAsyncCmd(imageStream);
     }
 
     @Override

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/DelegatingDockerCmdExecFactory.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/DelegatingDockerCmdExecFactory.java
@@ -76,6 +76,11 @@ public class DelegatingDockerCmdExecFactory implements DockerCmdExecFactory {
     }
 
     @Override
+    public LoadImageAsyncCmd.Exec createLoadImageAsyncCmdExec() {
+        return getDockerCmdExecFactory().createLoadImageAsyncCmdExec();
+    }
+
+    @Override
     public SearchImagesCmd.Exec createSearchImagesCmdExec() {
         return getDockerCmdExecFactory().createSearchImagesCmdExec();
     }

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/DockerCmdExecFactory.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/DockerCmdExecFactory.java
@@ -27,6 +27,8 @@ public interface DockerCmdExecFactory extends Closeable {
 
     LoadImageCmd.Exec createLoadImageCmdExec();
 
+    LoadImageAsyncCmd.Exec createLoadImageAsyncCmdExec();
+
     SearchImagesCmd.Exec createSearchImagesCmdExec();
 
     RemoveImageCmd.Exec createRemoveImageCmdExec();

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/LoadImageAsyncCmd.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/LoadImageAsyncCmd.java
@@ -1,0 +1,22 @@
+package com.github.dockerjava.api.command;
+
+import com.github.dockerjava.api.model.LoadResponseItem;
+
+import java.io.InputStream;
+
+public interface LoadImageAsyncCmd extends AsyncDockerCmd<LoadImageAsyncCmd, LoadResponseItem> {
+    InputStream getImageStream();
+
+    /**
+     * @param imageStream the InputStream of the tar file
+     */
+    LoadImageAsyncCmd withImageStream(InputStream imageStream);
+
+    @Override
+    default LoadImageCallback start() {
+        return exec(new LoadImageCallback());
+    }
+
+    interface Exec extends DockerCmdAsyncExec<LoadImageAsyncCmd, LoadResponseItem> {
+    }
+}

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/LoadImageCallback.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/LoadImageCallback.java
@@ -1,0 +1,16 @@
+package com.github.dockerjava.api.command;
+
+import com.github.dockerjava.api.async.ResultCallbackTemplate;
+import com.github.dockerjava.api.model.LoadResponseItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LoadImageCallback extends ResultCallbackTemplate<LoadImageCallback, LoadResponseItem> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoadImageCallback.class);
+
+    @Override
+    public void onNext(LoadResponseItem item) {
+        LOGGER.debug(item.toString());
+    }
+}

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/LoadImageCallback.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/LoadImageCallback.java
@@ -1,6 +1,7 @@
 package com.github.dockerjava.api.command;
 
 import com.github.dockerjava.api.async.ResultCallbackTemplate;
+import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.model.LoadResponseItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,8 +10,40 @@ public class LoadImageCallback extends ResultCallbackTemplate<LoadImageCallback,
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LoadImageCallback.class);
 
+    private String message;
+
+    private String error;
+
     @Override
     public void onNext(LoadResponseItem item) {
+        if (item.isBuildSuccessIndicated()) {
+            this.message = item.getMessage();
+        } else if (item.isErrorIndicated()) {
+            this.error = item.getError();
+        }
+
         LOGGER.debug(item.toString());
+    }
+
+    public String awaitMessage() {
+        try {
+            awaitCompletion();
+        } catch (InterruptedException e) {
+            throw new DockerClientException("", e);
+        }
+
+        return getMessage();
+    }
+
+    private String getMessage() {
+        if (this.message != null) {
+            return this.message;
+        }
+
+        if (this.error == null) {
+            throw new DockerClientException("Could not build image");
+        }
+
+        throw new DockerClientException("Could not build image: " + this.error);
     }
 }

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/LoadResponseItem.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/LoadResponseItem.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class LoadResponseItem extends ResponseItem {
 
+    private static final long serialVersionUID = 1L;
+
     private static final String IMPORT_SUCCESS = "Loaded image:";
 
     /**
@@ -16,5 +18,16 @@ public class LoadResponseItem extends ResponseItem {
         }
 
         return getStream().contains(IMPORT_SUCCESS);
+    }
+
+    @JsonIgnore
+    public String getMessage() {
+        if (!isBuildSuccessIndicated()) {
+            return null;
+        } else if (getStream().contains(IMPORT_SUCCESS)) {
+            return getStream();
+        }
+
+        return null;
     }
 }

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/LoadResponseItem.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/LoadResponseItem.java
@@ -1,0 +1,20 @@
+package com.github.dockerjava.api.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class LoadResponseItem extends ResponseItem {
+
+    private static final String IMPORT_SUCCESS = "Loaded image:";
+
+    /**
+     * Returns whether the stream field indicates a successful build operation
+     */
+    @JsonIgnore
+    public boolean isBuildSuccessIndicated() {
+        if (isErrorIndicated() || getStream() == null) {
+            return false;
+        }
+
+        return getStream().contains(IMPORT_SUCCESS);
+    }
+}

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/AbstractDockerCmdExecFactory.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/AbstractDockerCmdExecFactory.java
@@ -44,6 +44,7 @@ import com.github.dockerjava.api.command.ListServicesCmd;
 import com.github.dockerjava.api.command.ListSwarmNodesCmd;
 import com.github.dockerjava.api.command.ListTasksCmd;
 import com.github.dockerjava.api.command.ListVolumesCmd;
+import com.github.dockerjava.api.command.LoadImageAsyncCmd;
 import com.github.dockerjava.api.command.LoadImageCmd;
 import com.github.dockerjava.api.command.LogContainerCmd;
 import com.github.dockerjava.api.command.LogSwarmObjectCmd;
@@ -101,6 +102,7 @@ import com.github.dockerjava.core.exec.ExecCreateCmdExec;
 import com.github.dockerjava.core.exec.ExecStartCmdExec;
 import com.github.dockerjava.core.exec.InspectConfigCmdExec;
 import com.github.dockerjava.core.exec.ListConfigsCmdExec;
+import com.github.dockerjava.core.exec.LoadImageAsyncCmdExec;
 import com.github.dockerjava.core.exec.RemoveConfigCmdExec;
 import com.github.dockerjava.core.exec.ResizeContainerCmdExec;
 import com.github.dockerjava.core.exec.ResizeExecCmdExec;
@@ -253,6 +255,11 @@ public abstract class AbstractDockerCmdExecFactory implements DockerCmdExecFacto
     @Override
     public LoadImageCmd.Exec createLoadImageCmdExec() {
         return new LoadImageCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public LoadImageAsyncCmd.Exec createLoadImageAsyncCmdExec() {
+        return new LoadImageAsyncCmdExec(getBaseResource(), getDockerClientConfig());
     }
 
     @Override

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
@@ -44,6 +44,7 @@ import com.github.dockerjava.api.command.ListServicesCmd;
 import com.github.dockerjava.api.command.ListSwarmNodesCmd;
 import com.github.dockerjava.api.command.ListTasksCmd;
 import com.github.dockerjava.api.command.ListVolumesCmd;
+import com.github.dockerjava.api.command.LoadImageAsyncCmd;
 import com.github.dockerjava.api.command.LoadImageCmd;
 import com.github.dockerjava.api.command.LogContainerCmd;
 import com.github.dockerjava.api.command.LogSwarmObjectCmd;
@@ -127,6 +128,7 @@ import com.github.dockerjava.core.command.ListServicesCmdImpl;
 import com.github.dockerjava.core.command.ListSwarmNodesCmdImpl;
 import com.github.dockerjava.core.command.ListTasksCmdImpl;
 import com.github.dockerjava.core.command.ListVolumesCmdImpl;
+import com.github.dockerjava.core.command.LoadImageAsyncCmdImpl;
 import com.github.dockerjava.core.command.LoadImageCmdImpl;
 import com.github.dockerjava.core.command.LogContainerCmdImpl;
 import com.github.dockerjava.core.command.LogSwarmObjectImpl;
@@ -348,6 +350,11 @@ public class DockerClientImpl implements Closeable, DockerClient {
     @Override
     public LoadImageCmd loadImageCmd(@Nonnull InputStream imageStream) {
         return new LoadImageCmdImpl(getDockerCmdExecFactory().createLoadImageCmdExec(), imageStream);
+    }
+
+    @Override
+    public LoadImageAsyncCmd loadImageAsyncCmd(@Nonnull InputStream imageStream) {
+        return new LoadImageAsyncCmdImpl(getDockerCmdExecFactory().createLoadImageAsyncCmdExec(), imageStream);
     }
 
     @Override

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/LoadImageAsyncCmdImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/LoadImageAsyncCmdImpl.java
@@ -1,0 +1,42 @@
+package com.github.dockerjava.core.command;
+
+import com.github.dockerjava.api.command.LoadImageAsyncCmd;
+import com.github.dockerjava.api.model.LoadResponseItem;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class LoadImageAsyncCmdImpl extends AbstrAsyncDockerCmd<LoadImageAsyncCmd, LoadResponseItem> implements LoadImageAsyncCmd {
+
+    private InputStream inputStream;
+
+    public LoadImageAsyncCmdImpl(LoadImageAsyncCmd.Exec exec, InputStream inputStream) {
+        super(exec);
+        this.inputStream = inputStream;
+    }
+
+    @Override
+    public InputStream getImageStream() {
+        return this.inputStream;
+    }
+
+    @Override
+    public LoadImageAsyncCmd withImageStream(InputStream imageStream) {
+        checkNotNull(imageStream, "imageStream was not specified");
+        this.inputStream = imageStream;
+        return this;
+    }
+
+    @Override
+    public void close() {
+        super.close();
+
+        try {
+            this.inputStream.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/exec/LoadImageAsyncCmdExec.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/exec/LoadImageAsyncCmdExec.java
@@ -1,0 +1,30 @@
+package com.github.dockerjava.core.exec;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.LoadImageAsyncCmd;
+import com.github.dockerjava.api.model.LoadResponseItem;
+import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.core.WebTarget;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LoadImageAsyncCmdExec extends AbstrAsyncDockerCmdExec<LoadImageAsyncCmd, LoadResponseItem> implements LoadImageAsyncCmd.Exec {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoadImageAsyncCmdExec.class);
+
+    public LoadImageAsyncCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
+    }
+
+    @Override
+    protected Void execute0(LoadImageAsyncCmd command, ResultCallback<LoadResponseItem> resultCallback) {
+        WebTarget webTarget = getBaseResource().path("/images/load");
+
+        LOGGER.trace("POST: {}", webTarget);
+
+        webTarget.request().post(new TypeReference<LoadResponseItem>() { }, resultCallback, command.getImageStream());
+
+        return null;
+    }
+}

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/LoadImageCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/LoadImageCmdIT.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.cmd;
 
+import com.github.dockerjava.api.command.LoadImageCallback;
 import com.github.dockerjava.api.model.Image;
 import com.github.dockerjava.utils.TestResources;
 import net.jcip.annotations.NotThreadSafe;
@@ -51,6 +52,19 @@ public class LoadImageCmdIT extends CmdIT {
         assertThat("Can't find expected image after loading from a tar archive!", image, notNullValue());
         assertThat("Image after loading from a tar archive has wrong tags!",
                 asList(image.getRepoTags()), equalTo(singletonList("docker-java/load:1.0")));
+    }
+
+    @Test
+    public void loadImageFromTarAsync() throws Exception {
+        try (InputStream uploadStream = Files.newInputStream(TestResources.getApiImagesLoadTestTarball())) {
+            dockerRule.getClient().loadImageAsyncCmd(uploadStream).exec(new LoadImageCallback()).awaitMessage();
+        }
+
+        final Image image = findImageWithId(expectedImageId, dockerRule.getClient().listImagesCmd().exec());
+
+        assertThat("Can't find expected image after loading from a tar archive!", image, notNullValue());
+        assertThat("Image after loading from a tar archive has wrong tags!",
+                   asList(image.getRepoTags()), equalTo(singletonList("docker-java/load:1.0")));
     }
 
     private Image findImageWithId(final String id, final List<Image> images) {


### PR DESCRIPTION
In order to testcontainers-java integrate with Jib and work well with bigger images when using `load` operation. An async version of the existing one is added.