### PR TITLE
Enable logging in docker-java-api unit tests

### DIFF
--- a/docker-java-api/pom.xml
+++ b/docker-java-api/pom.xml
@@ -67,6 +67,13 @@
 			<version>0.18.0</version>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>${slf4j-api.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Removes a warning from the build process and allow the following line to be emitted:

```
[main] INFO com.tngtech.archunit.core.PluginLoader - Detected Java version 11.0.17
```