### PR TITLE
Use anchor instead of building toString() for debug logging

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/BuildImageResultCallback.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/BuildImageResultCallback.java
@@ -31,7 +31,7 @@ public class BuildImageResultCallback extends ResultCallbackTemplate<BuildImageR
         } else if (item.isErrorIndicated()) {
             this.error = item.getError();
         }
-        LOGGER.debug(item.toString());
+        LOGGER.debug("{}", item);
     }
 
     /**

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/LoadImageCallback.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/LoadImageCallback.java
@@ -22,7 +22,7 @@ public class LoadImageCallback extends ResultCallbackTemplate<LoadImageCallback,
             this.error = item.getError();
         }
 
-        LOGGER.debug(item.toString());
+        LOGGER.debug("{}", item);
     }
 
     public String awaitMessage() {

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/PullImageResultCallback.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/PullImageResultCallback.java
@@ -41,7 +41,7 @@ public class PullImageResultCallback extends ResultCallback.Adapter<PullResponse
             handleDockerClientResponse(item);
         }
 
-        LOGGER.debug(item.toString());
+        LOGGER.debug("{}", item);
     }
 
     private void checkForDockerSwarmResponse(PullResponseItem item) {

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/WaitContainerResultCallback.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/WaitContainerResultCallback.java
@@ -27,7 +27,7 @@ public class WaitContainerResultCallback extends ResultCallbackTemplate<WaitCont
     @Override
     public void onNext(WaitResponse waitResponse) {
         this.waitResponse = waitResponse;
-        LOGGER.debug(waitResponse.toString());
+        LOGGER.debug("{}", waitResponse);
     }
 
     /**


### PR DESCRIPTION
Instead of building the String for each object, then throwing it away if debug logger is not enabled, use an anchor that is only populated if debug is enabled.  Saves on not creating the object toString value every time.

https://www.slf4j.org/faq.html#logging_performance