### PR TITLE
Support docker context

### DIFF
--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
@@ -1,6 +1,5 @@
 package com.github.dockerjava.core;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.AuthConfigurations;
@@ -91,8 +90,9 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
 
     private final DockerConfigFile dockerConfig;
 
-    DefaultDockerClientConfig(URI dockerHost, DockerConfigFile dockerConfigFile, String dockerConfigPath, String apiVersion, String registryUrl,
-                              String registryUsername, String registryPassword, String registryEmail, SSLConfig sslConfig) {
+    DefaultDockerClientConfig(URI dockerHost, DockerConfigFile dockerConfigFile, String dockerConfigPath, String apiVersion,
+                              String registryUrl, String registryUsername, String registryPassword, String registryEmail,
+                              SSLConfig sslConfig) {
         this.dockerHost = checkDockerHostScheme(dockerHost);
         this.dockerConfig = dockerConfigFile;
         this.dockerConfigPath = dockerConfigPath;

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
@@ -38,6 +38,8 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
 
     public static final String DOCKER_HOST = "DOCKER_HOST";
 
+    public static final String DOCKER_CONTEXT = "DOCKER_CONTEXT";
+
     public static final String DOCKER_TLS_VERIFY = "DOCKER_TLS_VERIFY";
 
     public static final String DOCKER_CONFIG = "DOCKER_CONFIG";

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
@@ -459,7 +459,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
             final String context = (dockerContext != null) ? dockerContext : dockerConfigFile.getCurrentContext();
             URI dockerHostUri = dockerHost != null
                 ? dockerHost
-                : dockerHostFromContextOrDefault(context);
+                : resolveDockerHost(context);
 
             return new DefaultDockerClientConfig(dockerHostUri, dockerConfigFile, dockerConfig, apiVersion, registryUrl, registryUsername,
                     registryPassword, registryEmail, sslConfig);
@@ -473,9 +473,9 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
             }
         }
 
-        private URI dockerHostFromContextOrDefault(String dockerContext) {
+        private URI resolveDockerHost(String dockerContext) {
             return URI.create(Optional.ofNullable(dockerContext)
-                .flatMap(context -> DockerContextMetaFile.loadContextMetaFile(
+                .flatMap(context -> DockerContextMetaFile.resolveContextMetaFile(
                     DockerClientConfig.getDefaultObjectMapper(), new File(dockerConfig), context))
                 .flatMap(DockerContextMetaFile::host)
                 .orElse(SystemUtils.IS_OS_WINDOWS ? WINDOWS_DEFAULT_DOCKER_HOST : DEFAULT_DOCKER_HOST));

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DefaultDockerClientConfig.java
@@ -460,7 +460,7 @@ public class DefaultDockerClientConfig implements Serializable, DockerClientConf
         private URI dockerHostFromContextOrDefault(DockerConfigFile dockerConfigFile) {
             final String currentContext = dockerConfigFile.getCurrentContext();
             return URI.create(Optional.ofNullable(currentContext)
-                .flatMap(context -> DockerContextMetaFile.findContextMetaFile(
+                .flatMap(context -> DockerContextMetaFile.loadContextMetaFile(
                     DockerClientConfig.getDefaultObjectMapper(), new File(dockerConfig), context))
                 .flatMap(DockerContextMetaFile::host)
                 .orElse(SystemUtils.IS_OS_WINDOWS ? WINDOWS_DEFAULT_DOCKER_HOST : DEFAULT_DOCKER_HOST));

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DockerConfigFile.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DockerConfigFile.java
@@ -54,6 +54,10 @@ public class DockerConfigFile {
         this.currentContext = currentContext;
     }
 
+    public String getCurrentContext() {
+        return currentContext;
+    }
+
     @CheckForNull
     public AuthConfig resolveAuthConfig(@CheckForNull String hostname) {
         if (StringUtils.isEmpty(hostname) || AuthConfig.DEFAULT_SERVER_ADDRESS.equals(hostname)) {

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DockerConfigFile.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DockerConfigFile.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.AuthConfigurations;
+import java.util.Objects;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -29,6 +30,9 @@ public class DockerConfigFile {
     @JsonProperty
     private final Map<String, AuthConfig> auths;
 
+    @JsonProperty
+    private String currentContext;
+
     public DockerConfigFile() {
         this(new HashMap<>());
     }
@@ -44,6 +48,10 @@ public class DockerConfigFile {
 
     void addAuthConfig(AuthConfig config) {
         auths.put(config.getRegistryAddress(), config);
+    }
+
+    void setCurrentContext(String currentContext) {
+        this.currentContext = currentContext;
     }
 
     @CheckForNull
@@ -104,6 +112,9 @@ public class DockerConfigFile {
                 return false;
         } else if (!auths.equals(other.auths))
             return false;
+        if (!Objects.equals(currentContext, other.currentContext)) {
+            return false;
+        }
         return true;
     }
 
@@ -111,7 +122,7 @@ public class DockerConfigFile {
 
     @Override
     public String toString() {
-        return "DockerConfigFile [auths=" + auths + "]";
+        return "DockerConfigFile [auths=" + auths + ", currentContext='" + currentContext + "']";
     }
 
     @Nonnull

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DockerContextMetaFile.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DockerContextMetaFile.java
@@ -63,14 +63,4 @@ public class DockerContextMetaFile {
             throw new IOException("Failed to parse docker context meta file " + dockerContextMetaFile, e);
         }
     }
-
-    public static void main(String[] args) {
-        ObjectMapper mapper = DefaultObjectMapperHolder.INSTANCE.getObjectMapper().copy();
-        Optional<DockerContextMetaFile> colima = loadContextMetaFile(mapper, new File("/Users/simon/.docker"), "colima");
-        String host = colima
-            .map(file -> file.endpoints.docker.host)
-            .orElse(null);
-
-        System.out.printf("Host is %s\n", host);
-    }
 }

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DockerContextMetaFile.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DockerContextMetaFile.java
@@ -45,18 +45,18 @@ public class DockerContextMetaFile {
             .resolve(metaHashFunction.hashString(context, StandardCharsets.UTF_8).toString())
             .resolve("meta.json")
             .toFile();
-        return Optional.ofNullable(loadContextMeta(objectMapper, path));
+        return Optional.ofNullable(loadContextMetaFile(objectMapper, path));
     }
 
-    public static DockerContextMetaFile loadContextMeta(ObjectMapper objectMapper, File dockerContextMetaFile) {
+    public static DockerContextMetaFile loadContextMetaFile(ObjectMapper objectMapper, File dockerContextMetaFile) {
         try {
-            return parseContextMeta(objectMapper, dockerContextMetaFile);
+            return parseContextMetaFile(objectMapper, dockerContextMetaFile);
         } catch (Exception exception) {
             return null;
         }
     }
 
-    public static DockerContextMetaFile parseContextMeta(ObjectMapper objectMapper, File dockerContextMetaFile) throws IOException {
+    public static DockerContextMetaFile parseContextMetaFile(ObjectMapper objectMapper, File dockerContextMetaFile) throws IOException {
         try {
             return objectMapper.readValue(dockerContextMetaFile, DockerContextMetaFile.class);
         } catch (IOException e) {

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DockerContextMetaFile.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DockerContextMetaFile.java
@@ -1,0 +1,55 @@
+package com.github.dockerjava.core;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.IOException;
+import javax.annotation.CheckForNull;
+
+public class DockerContextMetaFile {
+    @JsonProperty("Name")
+    String name;
+
+    @JsonProperty("Endpoints")
+    Endpoints endpoints;
+
+    public static class Endpoints {
+        @JsonProperty("docker")
+        Docker docker;
+
+        public static class Docker {
+            @JsonProperty("Host")
+            String host;
+
+            @JsonProperty("SkipTLSVerify")
+            boolean skipTLSVerify;
+        }
+    }
+
+    public static DockerContextMetaFile loadContextMeta(ObjectMapper objectMapper, File dockerContextMetaFile) throws IOException {
+        try {
+            return objectMapper.readValue(dockerContextMetaFile, DockerContextMetaFile.class);
+        } catch (IOException e) {
+            throw new IOException("Failed to parse docker context meta file " + dockerContextMetaFile, e);
+        }
+    }
+
+    public static void loadAllContextMetaFiles() {
+        // TODO
+    }
+
+    public static void findContextMetaFile(String context) {
+        // TODO
+    }
+    
+    public static void main(String[] args) {
+        ObjectMapper mapper = DefaultObjectMapperHolder.INSTANCE.getObjectMapper().copy();
+        try {
+            DockerContextMetaFile dockerContextMetaFile = loadContextMeta(mapper,
+                new File("/Users/simon/.docker/contexts/meta/f24fd3749c1368328e2b149bec149cb6795619f244c5b584e844961215dadd16/meta.json"));
+            System.out.println(dockerContextMetaFile.endpoints.docker.host);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DockerContextMetaFile.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DockerContextMetaFile.java
@@ -38,25 +38,25 @@ public class DockerContextMetaFile {
         return Optional.empty();
     }
 
-    public static Optional<DockerContextMetaFile> loadContextMetaFile(ObjectMapper objectMapper, File dockerConfigPath, String context) {
+    public static Optional<DockerContextMetaFile> resolveContextMetaFile(ObjectMapper objectMapper, File dockerConfigPath, String context) {
         final File path = dockerConfigPath.toPath()
             .resolve("contexts")
             .resolve("meta")
             .resolve(metaHashFunction.hashString(context, StandardCharsets.UTF_8).toString())
             .resolve("meta.json")
             .toFile();
-        return Optional.ofNullable(loadContextMetaOrNull(objectMapper, path));
+        return Optional.ofNullable(loadContextMeta(objectMapper, path));
     }
 
-    public static DockerContextMetaFile loadContextMetaOrNull(ObjectMapper objectMapper, File dockerContextMetaFile) {
+    public static DockerContextMetaFile loadContextMeta(ObjectMapper objectMapper, File dockerContextMetaFile) {
         try {
-            return loadContextMeta(objectMapper, dockerContextMetaFile);
+            return parseContextMeta(objectMapper, dockerContextMetaFile);
         } catch (Exception exception) {
             return null;
         }
     }
 
-    public static DockerContextMetaFile loadContextMeta(ObjectMapper objectMapper, File dockerContextMetaFile) throws IOException {
+    public static DockerContextMetaFile parseContextMeta(ObjectMapper objectMapper, File dockerContextMetaFile) throws IOException {
         try {
             return objectMapper.readValue(dockerContextMetaFile, DockerContextMetaFile.class);
         } catch (IOException e) {

--- a/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
@@ -69,6 +69,20 @@ public class DefaultDockerClientConfigTest {
     }
 
     @Test
+    public void environmentDockerContext() throws Exception {
+        // given docker context
+        Map<String, String> env = new HashMap<>();
+        env.put(DefaultDockerClientConfig.DOCKER_CONTEXT, "testcontext");
+
+        // when you build a config
+        DefaultDockerClientConfig config = buildConfig(env, new Properties());
+
+        // Then we want the host specified by the context. But hey, where is that even going to come from? We haven't set up any test
+        // fixtures for the context....
+        assertEquals("thetestcontexthost.com", config.getDockerHost());
+    }
+
+    @Test
     public void environment() throws Exception {
 
         // given a default config in env properties

--- a/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
@@ -1,6 +1,5 @@
 package com.github.dockerjava.core;
 
-import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.AuthConfigurations;
 import com.google.common.io.Resources;
@@ -32,7 +31,7 @@ public class DefaultDockerClientConfigTest {
 
         String dockerCertPath = dockerCertPath();
 
-        return new DefaultDockerClientConfig(URI.create("tcp://foo"), "dockerConfig", "apiVersion", "registryUrl", "registryUsername", "registryPassword", "registryEmail",
+        return new DefaultDockerClientConfig(URI.create("tcp://foo"), new DockerConfigFile(), "dockerConfig", "apiVersion", "registryUrl", "registryUsername", "registryPassword", "registryEmail",
                 new LocalDirectorySSLConfig(dockerCertPath));
     }
 
@@ -161,7 +160,7 @@ public class DefaultDockerClientConfigTest {
 
     @Test()
     public void testSslContextEmpty() throws Exception {
-        new DefaultDockerClientConfig(URI.create("tcp://foo"), "dockerConfig", "apiVersion", "registryUrl", "registryUsername", "registryPassword", "registryEmail",
+        new DefaultDockerClientConfig(URI.create("tcp://foo"), new DockerConfigFile(), "dockerConfig", "apiVersion", "registryUrl", "registryUsername", "registryPassword", "registryEmail",
                 null);
     }
 
@@ -169,14 +168,14 @@ public class DefaultDockerClientConfigTest {
 
     @Test()
     public void testTlsVerifyAndCertPath() throws Exception {
-        new DefaultDockerClientConfig(URI.create("tcp://foo"), "dockerConfig", "apiVersion", "registryUrl", "registryUsername", "registryPassword", "registryEmail",
+        new DefaultDockerClientConfig(URI.create("tcp://foo"), new DockerConfigFile(), "dockerConfig", "apiVersion", "registryUrl", "registryUsername", "registryPassword", "registryEmail",
                 new LocalDirectorySSLConfig(dockerCertPath()));
     }
 
     @Test()
     public void testAnyHostScheme() throws Exception {
         URI dockerHost = URI.create("a" + UUID.randomUUID().toString().replace("-", "") + "://foo");
-        new DefaultDockerClientConfig(dockerHost, "dockerConfig", "apiVersion", "registryUrl", "registryUsername", "registryPassword", "registryEmail",
+        new DefaultDockerClientConfig(dockerHost, new DockerConfigFile(), "dockerConfig", "apiVersion", "registryUrl", "registryUsername", "registryPassword", "registryEmail",
             null);
     }
 
@@ -252,7 +251,7 @@ public class DefaultDockerClientConfigTest {
     public void testGetAuthConfigurationsFromDockerCfg() throws URISyntaxException {
         File cfgFile = new File(Resources.getResource("com.github.dockerjava.core/registry.v1").toURI());
         DefaultDockerClientConfig clientConfig = new DefaultDockerClientConfig(URI.create(
-            "unix://foo"), cfgFile.getAbsolutePath(), "apiVersion", "registryUrl", "registryUsername", "registryPassword",
+            "unix://foo"), new DockerConfigFile(), cfgFile.getAbsolutePath(), "apiVersion", "registryUrl", "registryUsername", "registryPassword",
             "registryEmail", null);
 
         AuthConfigurations authConfigurations = clientConfig.getAuthConfigurations();
@@ -268,7 +267,7 @@ public class DefaultDockerClientConfigTest {
     public void testGetAuthConfigurationsFromConfigJson() throws URISyntaxException {
         File cfgFile = new File(Resources.getResource("com.github.dockerjava.core/registry.v2").toURI());
         DefaultDockerClientConfig clientConfig = new DefaultDockerClientConfig(URI.create(
-            "unix://foo"), cfgFile.getAbsolutePath(), "apiVersion", "registryUrl", "registryUsername", "registryPassword",
+            "unix://foo"), new DockerConfigFile(), cfgFile.getAbsolutePath(), "apiVersion", "registryUrl", "registryUsername", "registryPassword",
             "registryEmail", null);
 
         AuthConfigurations authConfigurations = clientConfig.getAuthConfigurations();

--- a/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
@@ -69,17 +69,34 @@ public class DefaultDockerClientConfigTest {
     }
 
     @Test
-    public void environmentDockerContext() throws Exception {
-        // given docker context
+    public void dockerContextFromConfig() throws Exception {
+        // given home directory with docker contexts configured
+        Properties systemProperties = new Properties();
+        systemProperties.setProperty("user.home", "target/test-classes/dockerContextHomeDir");
+
+        // and an empty environment
         Map<String, String> env = new HashMap<>();
-        env.put(DefaultDockerClientConfig.DOCKER_CONTEXT, "testcontext");
 
         // when you build a config
-        DefaultDockerClientConfig config = buildConfig(env, new Properties());
+        DefaultDockerClientConfig config = buildConfig(env, systemProperties);
 
-        // Then we want the host specified by the context. But hey, where is that even going to come from? We haven't set up any test
-        // fixtures for the context....
-        assertEquals("thetestcontexthost.com", config.getDockerHost());
+        assertEquals(URI.create("unix:///configcontext.sock"), config.getDockerHost());
+    }
+
+    @Test
+    public void dockerContextFromEnvironmentVariable() throws Exception {
+        // given home directory with docker contexts
+        Properties systemProperties = new Properties();
+        systemProperties.setProperty("user.home", "target/test-classes/dockerContextHomeDir");
+
+        // and an environment variable that overrides docker context
+        Map<String, String> env = new HashMap<>();
+        env.put(DefaultDockerClientConfig.DOCKER_CONTEXT, "envvarcontext");
+
+        // when you build a config
+        DefaultDockerClientConfig config = buildConfig(env, systemProperties);
+
+        assertEquals(URI.create("unix:///envvarcontext.sock"), config.getDockerHost());
     }
 
     @Test

--- a/docker-java/src/test/java/com/github/dockerjava/core/DockerClientBuilderTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DockerClientBuilderTest.java
@@ -78,30 +78,4 @@ public class DockerClientBuilderTest {
             return exception;
         }
     }
-
-    public static void main(String[] args) {
-        DefaultDockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder().build();
-
-        DockerHttpClient httpClient = new ApacheDockerHttpClient.Builder()
-            .dockerHost(config.getDockerHost())
-            .sslConfig(config.getSSLConfig())
-            .maxConnections(100)
-            .connectionTimeout(Duration.ofSeconds(30))
-            .responseTimeout(Duration.ofSeconds(45))
-            .build();
-
-        DockerClient dockerClient = DockerClientImpl.getInstance(config, httpClient);
-
-        dockerClient.pingCmd().exec();
-        System.out.println("Containers:");
-        dockerClient.listContainersCmd().exec().stream().forEach(container -> {
-            System.out.println(container.getCommand());
-        });
-        System.out.println("Images:");
-        dockerClient.listImagesCmd().exec().stream().forEach(image -> {
-            System.out.println(image.getId());
-        });
-
-    }
-
 }

--- a/docker-java/src/test/java/com/github/dockerjava/core/DockerClientBuilderTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DockerClientBuilderTest.java
@@ -3,6 +3,7 @@ package com.github.dockerjava.core;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.DockerCmdExecFactory;
+import com.github.dockerjava.api.model.PushResponseItem;
 import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
 import com.github.dockerjava.transport.DockerHttpClient;
 import java.time.Duration;
@@ -80,9 +81,7 @@ public class DockerClientBuilderTest {
 
     public static void main(String[] args) {
         // This is what we want to just work
-        DockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder()
-            .withDockerHost("unix:///Users/simon/.colima/default/docker.sock")
-            .build();
+        DefaultDockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder().build();
 
         DockerHttpClient httpClient = new ApacheDockerHttpClient.Builder()
             .dockerHost(config.getDockerHost())

--- a/docker-java/src/test/java/com/github/dockerjava/core/DockerClientBuilderTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DockerClientBuilderTest.java
@@ -80,7 +80,6 @@ public class DockerClientBuilderTest {
     }
 
     public static void main(String[] args) {
-        // This is what we want to just work
         DefaultDockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder().build();
 
         DockerHttpClient httpClient = new ApacheDockerHttpClient.Builder()

--- a/docker-java/src/test/java/com/github/dockerjava/core/DockerClientBuilderTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DockerClientBuilderTest.java
@@ -1,7 +1,11 @@
 package com.github.dockerjava.core;
 
 
+import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.DockerCmdExecFactory;
+import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
+import com.github.dockerjava.transport.DockerHttpClient;
+import java.time.Duration;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -73,4 +77,33 @@ public class DockerClientBuilderTest {
             return exception;
         }
     }
+
+    public static void main(String[] args) {
+        // This is what we want to just work
+        DockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder()
+            .withDockerHost("unix:///Users/simon/.colima/default/docker.sock")
+            .build();
+
+        DockerHttpClient httpClient = new ApacheDockerHttpClient.Builder()
+            .dockerHost(config.getDockerHost())
+            .sslConfig(config.getSSLConfig())
+            .maxConnections(100)
+            .connectionTimeout(Duration.ofSeconds(30))
+            .responseTimeout(Duration.ofSeconds(45))
+            .build();
+
+        DockerClient dockerClient = DockerClientImpl.getInstance(config, httpClient);
+
+        dockerClient.pingCmd().exec();
+        System.out.println("Containers:");
+        dockerClient.listContainersCmd().exec().stream().forEach(container -> {
+            System.out.println(container.getCommand());
+        });
+        System.out.println("Images:");
+        dockerClient.listImagesCmd().exec().stream().forEach(image -> {
+            System.out.println(image.getId());
+        });
+
+    }
+
 }

--- a/docker-java/src/test/java/com/github/dockerjava/core/DockerClientImplTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DockerClientImplTest.java
@@ -12,7 +12,8 @@ public class DockerClientImplTest {
     @Test
     public void configuredInstanceAuthConfig() throws Exception {
         // given a config with null serverAddress
-        DefaultDockerClientConfig dockerClientConfig = new DefaultDockerClientConfig(URI.create("tcp://foo"), null, null, null, "", "", "", null);
+        DefaultDockerClientConfig dockerClientConfig = new DefaultDockerClientConfig(URI.create("tcp://foo"),
+            new DockerConfigFile(), null, null, null, "", "", "", null);
         DockerClientImpl dockerClient = DockerClientImpl.getInstance(dockerClientConfig);
 
         // when we get the auth config

--- a/docker-java/src/test/java/com/github/dockerjava/core/DockerConfigFileTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DockerConfigFileTest.java
@@ -151,6 +151,14 @@ public class DockerConfigFileTest {
     }
 
     @Test
+    public void validDockerConfigWithCurrentContext() throws IOException {
+        DockerConfigFile expected = new DockerConfigFile();
+        expected.setCurrentContext("expectedContext");
+
+        assertThat(runTest("validDockerConfigWithCurrentContext"), is(expected));
+    }
+
+    @Test
     public void nonExistent() throws IOException {
         DockerConfigFile expected = new DockerConfigFile();
         assertThat(runTest("idontexist"), is(expected));

--- a/docker-java/src/test/resources/dockerContextHomeDir/.docker/config.json
+++ b/docker-java/src/test/resources/dockerContextHomeDir/.docker/config.json
@@ -1,0 +1,4 @@
+{
+	"auths": {},
+	"currentContext": "configcontext"
+}

--- a/docker-java/src/test/resources/dockerContextHomeDir/.docker/contexts/meta/51699a7c75211315f1dbf6ecc40dfb0ffdd4ee11ecb2ce7853c9751aea1f9444/meta.json
+++ b/docker-java/src/test/resources/dockerContextHomeDir/.docker/contexts/meta/51699a7c75211315f1dbf6ecc40dfb0ffdd4ee11ecb2ce7853c9751aea1f9444/meta.json
@@ -1,0 +1,12 @@
+{
+    "Name": "envvarcontext",
+    "Metadata": {
+        "Description": "envvarcontext"
+    },
+    "Endpoints": {
+        "docker": {
+            "Host": "unix:///envvarcontext.sock",
+            "SkipTLSVerify": false
+        }
+    }
+}

--- a/docker-java/src/test/resources/dockerContextHomeDir/.docker/contexts/meta/d090e08f0c9167acd72adef6d9fa07ec2de3a873cdd545dd8cb7fc7a10a1331a/meta.json
+++ b/docker-java/src/test/resources/dockerContextHomeDir/.docker/contexts/meta/d090e08f0c9167acd72adef6d9fa07ec2de3a873cdd545dd8cb7fc7a10a1331a/meta.json
@@ -1,0 +1,12 @@
+{
+    "Name": "configcontext",
+    "Metadata": {
+        "Description": "configcontext"
+    },
+    "Endpoints": {
+        "docker": {
+            "Host": "unix:///configcontext.sock",
+            "SkipTLSVerify": false
+        }
+    }
+}

--- a/docker-java/src/test/resources/someHomeDir/.docker/config.json
+++ b/docker-java/src/test/resources/someHomeDir/.docker/config.json
@@ -1,7 +1,7 @@
 {
     "auths":{
         "https://index.docker.io/v1/":{
-            "auth":"XXXX=",
+            "auth":"dXNlcm5hbWU6cGFzc3dvcmQ=",
             "email":"foo.bar@test.com"
         }
         

--- a/docker-java/src/test/resources/testAuthConfigFile/validDockerConfigWithCurrentContext/config.json
+++ b/docker-java/src/test/resources/testAuthConfigFile/validDockerConfigWithCurrentContext/config.json
@@ -1,0 +1,4 @@
+{
+	"auths": {},
+	"currentContext": "expectedContext"
+}


### PR DESCRIPTION
Opening up this proof-of-concept pull request to support docker contexts. The end goal for me would be to be able to run testcontainers tests running in a Docker environment such as [Colima](https://github.com/abiosoft/colima) without having to set specific environment variables like `DOCKER_HOST` and instead have it just work, but the use case can of course be other things.

I know this isn't up to par to get merged, regarding code style and test coverage, but before I work any further I'd love to get just some input on whether the general idea is right. 

So, what it does is that it's looking for the `currentContext` setting in the `~/.docker/config.json` file and then matching that to the context description file in `~/.docker/contexts/meta/`. This is briefly documented [here](https://docs.docker.com/engine/context/working-with-contexts/) but the details of the file format I have just inferred from looking at the files set up on my system. 

Implements issue #1946. 