### PR TITLE
Add a boolean parameter to indicate if Frame is complete

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Frame.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Frame.java
@@ -15,9 +15,18 @@ public class Frame extends DockerObject implements Serializable {
 
     private final byte[] payload;
 
+    private final boolean isComplete;
+
     public Frame(StreamType streamType, byte[] payload) {
         this.streamType = streamType;
         this.payload = payload;
+        this.isComplete = true;
+    }
+
+    public Frame(StreamType streamType, byte[] payload, boolean isComplete) {
+        this.streamType = streamType;
+        this.payload = payload;
+        this.isComplete = isComplete;
     }
 
     public StreamType getStreamType() {
@@ -28,8 +37,12 @@ public class Frame extends DockerObject implements Serializable {
         return payload;
     }
 
+    public  boolean getIsComplete() {
+        return isComplete;
+    }
+
     @Override
     public String toString() {
-        return String.format("%s: %s", streamType, new String(payload).trim());
+        return String.format("%s: %s; isComplete: %s", streamType, new String(payload).trim(), isComplete);
     }
 }

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Frame.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Frame.java
@@ -43,6 +43,6 @@ public class Frame extends DockerObject implements Serializable {
 
     @Override
     public String toString() {
-        return String.format("%s: %s; isComplete: %s", streamType, new String(payload).trim(), isComplete);
+        return String.format("%s: %s", streamType, new String(payload).trim());
     }
 }

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/FramedInputStreamConsumer.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/FramedInputStreamConsumer.java
@@ -72,12 +72,12 @@ class FramedInputStreamConsumer implements Consumer<DockerHttpClient.Response> {
                         return;
                     }
 
-                    if (readBytes == buffer.length) {
-                        resultCallback.onNext(new Frame(streamType, buffer));
-                    } else {
-                        resultCallback.onNext(new Frame(streamType, Arrays.copyOf(buffer, readBytes)));
-                    }
                     bytesToRead -= readBytes;
+                    if (readBytes == buffer.length) {
+                        resultCallback.onNext(new Frame(streamType, buffer, bytesToRead == 0));
+                    } else {
+                        resultCallback.onNext(new Frame(streamType, Arrays.copyOf(buffer, readBytes), bytesToRead == 0));
+                    }
                 } while (bytesToRead > 0);
             }
         } catch (Exception e) {


### PR DESCRIPTION
In my previous PR (https://github.com/docker-java/docker-java/pull/1754), already had some discussions with @bsideup  about the `FrameInputConsumer`.

In previous thread: https://github.com/docker-java/docker-java/pull/1754#issuecomment-1042119345:
```
Frames are not guaranteed to arrive in full and should be glued
```

Since as the client side, we already lose the information to know what is the payload size. We need a way at the client side to know if frames are complete and thus glue multiple frames together. Thus, I want to add a boolean parameter in the `Frame` thus we can do the concatenation at out end