### PR TITLE
Add `Name` to `ContainerNetworkConfig`

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Network.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Network.java
@@ -97,6 +97,12 @@ public class Network extends DockerObject implements Serializable {
     public static class ContainerNetworkConfig extends DockerObject implements Serializable {
         private static final long serialVersionUID = 1L;
 
+        /**
+         * @since {@link RemoteApiVersion#VERSION_1_30}
+         */
+        @JsonProperty("Name")
+        private String name;
+
         @JsonProperty("EndpointID")
         private String endpointId;
 
@@ -108,6 +114,10 @@ public class Network extends DockerObject implements Serializable {
 
         @JsonProperty("IPv6Address")
         private String ipv6Address;
+
+        public String getName() {
+            return name;
+        }
 
         public String getEndpointId() {
             return endpointId;

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Network.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Network.java
@@ -98,7 +98,7 @@ public class Network extends DockerObject implements Serializable {
         private static final long serialVersionUID = 1L;
 
         /**
-         * @since {@link RemoteApiVersion#VERSION_1_30}
+         * @since {@link RemoteApiVersion#VERSION_1_22}
          */
         @JsonProperty("Name")
         private String name;


### PR DESCRIPTION
I have a use case where this property would be very helpful:

In a Quarkus integration test, I have to find a container in a temporary network based on its name.
With the current codebase, I have to inspect each container in the network in order to find the matching container.
Having the container name available in `ContainerNetworkConfig` would simplify the  search.

The `Name` property appears first in the [v1.30 Docker api docs](https://docs.docker.com/engine/api/v1.30/#tag/Network/operation/NetworkInspect).