### PR TITLE
Fix parameter order in `assertEquals`

### DIFF
--- a/docker-java/src/test/java/com/github/dockerjava/api/ModelsSerializableTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/ModelsSerializableTest.java
@@ -9,7 +9,6 @@ import com.github.dockerjava.api.model.PushResponseItem;
 import com.github.dockerjava.api.model.ResponseItem;
 import com.google.common.reflect.ClassPath.ClassInfo;
 import org.apache.commons.lang3.reflect.FieldUtils;
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/docker-java/src/test/java/com/github/dockerjava/api/command/InspectContainerResponseTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/command/InspectContainerResponseTest.java
@@ -56,11 +56,11 @@ public class InspectContainerResponseTest {
         final InspectContainerResponse response = responses[0];
 
         // Check volumes: https://github.com/docker-java/docker-java/issues/211
-        assertEquals(response.getVolumes().length, 2);
-        assertEquals(response.getVolumesRW().length, 2);
-        assertEquals(response.getVolumes()[1].getContainerPath(), "/bar/foo/myvol2");
-        assertEquals(response.getVolumes()[1].getHostPath(), "/path2");
-        assertEquals(response.getVolumesRW()[1].getVolume().getPath(), "/bar/foo/myvol2");
+        assertEquals(2, response.getVolumes().length);
+        assertEquals(2, response.getVolumesRW().length);
+        assertEquals("/bar/foo/myvol2" ,response.getVolumes()[1].getContainerPath());
+        assertEquals("/path2", response.getVolumes()[1].getHostPath());
+        assertEquals("/bar/foo/myvol2", response.getVolumesRW()[1].getVolume().getPath());
         assertFalse(response.getVolumesRW()[1].getAccessMode().toBoolean());
         assertTrue(response.getVolumesRW()[0].getAccessMode().toBoolean());
         assertThat(response.getLogPath(), is("/mnt/sda1/var/lib/docker/containers/469e5edd8d5b33e3c905a7ffc97360ec6ee211d6782815fbcd144568045819e1/469e5edd8d5b33e3c905a7ffc97360ec6ee211d6782815fbcd144568045819e1-json.log"));
@@ -76,11 +76,11 @@ public class InspectContainerResponseTest {
             type
         );
 
-        assertEquals(response.getState().getHealth().getStatus(), "healthy");
-        assertEquals(response.getState().getHealth().getFailingStreak(), new Integer(0));
-        assertEquals(response.getState().getHealth().getLog().size(), 2);
-        assertEquals(response.getState().getHealth().getLog().get(0).getOutput(), "Hello");
-        assertEquals(response.getState().getHealth().getLog().get(1).getOutput(), "World");
+        assertEquals("healthy", response.getState().getHealth().getStatus());
+        assertEquals(new Integer(0), response.getState().getHealth().getFailingStreak());
+        assertEquals(2, response.getState().getHealth().getLog().size());
+        assertEquals("Hello", response.getState().getHealth().getLog().get(0).getOutput());
+        assertEquals("World", response.getState().getHealth().getLog().get(1).getOutput());
     }
 
     @Test
@@ -108,11 +108,11 @@ public class InspectContainerResponseTest {
         final InspectContainerResponse response = responses[0];
 
         final List<InspectContainerResponse.Mount> mounts = response.getMounts();
-        assertEquals(mounts.size(), 1);
+        assertEquals(1, mounts.size());
 
         final InspectContainerResponse.Mount mount = mounts.get(0);
         final Volume volume = mount.getDestination();
-        assertEquals(volume.getPath(), "/var/lib/postgresql/data");
+        assertEquals("/var/lib/postgresql/data", volume.getPath());
     }
 
     @Test
@@ -124,11 +124,11 @@ public class InspectContainerResponseTest {
         final InspectContainerResponse response = responses[0];
 
         final List<InspectContainerResponse.Mount> mounts = response.getMounts();
-        assertEquals(mounts.size(), 1);
+        assertEquals(1, mounts.size());
 
         final InspectContainerResponse.Mount mount = mounts.get(0);
         final Volume volume = mount.getDestination();
-        assertEquals(volume.getPath(), "/srv/test");
+        assertEquals("/srv/test", volume.getPath());
     }
 
     @Test

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/AccessModeTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/AccessModeTest.java
@@ -15,17 +15,17 @@ public class AccessModeTest {
 
     @Test
     public void defaultAccessMode() {
-        assertEquals(AccessMode.DEFAULT, rw);
+        assertEquals(rw, AccessMode.DEFAULT);
     }
 
     @Test
     public void stringify() {
-        assertEquals(AccessMode.rw.toString(), "rw");
+        assertEquals("rw", AccessMode.rw.toString());
     }
 
     @Test
     public void fromString() {
-        assertEquals(AccessMode.valueOf("rw"), rw);
+        assertEquals(rw, AccessMode.valueOf("rw"));
     }
 
     @Test

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/AuthConfigTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/AuthConfigTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertEquals;
 public class AuthConfigTest {
 
     @Test
-    public void defaultServerAddress() throws Exception {
+    public void defaultServerAddress() {
         assertEquals(new AuthConfig().getRegistryAddress(), "https://index.docker.io/v1/");
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/CapabilityTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/CapabilityTest.java
@@ -11,13 +11,13 @@ public class CapabilityTest {
     @Test
     public void serializeCapability() throws Exception {
         String json = JSONTestHelper.getMapper().writeValueAsString(Capability.ALL);
-        assertEquals(json, "\"ALL\"");
+        assertEquals("\"ALL\"", json);
     }
 
     @Test
     public void deserializeCapability() throws Exception {
         Capability capability = JSONTestHelper.getMapper().readValue("\"ALL\"", Capability.class);
-        assertEquals(capability, Capability.ALL);
+        assertEquals(Capability.ALL, capability);
     }
 
     @Test(expected = JsonMappingException.class)

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/DeviceTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/DeviceTest.java
@@ -54,7 +54,7 @@ public class DeviceTest {
     }};
 
     @Test
-    public void testParse() throws Exception {
+    public void testParse() {
         assertThat(Device.parse("/dev/sda:/dev/xvdc:r"),
                 equalTo(new Device("r", "/dev/xvdc", "/dev/sda")));
 

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/ExposedPortTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/ExposedPortTest.java
@@ -16,13 +16,13 @@ public class ExposedPortTest {
     @Test
     public void parsePortAndProtocol() {
         ExposedPort exposedPort = ExposedPort.parse("80/tcp");
-        assertEquals(exposedPort, new ExposedPort(80, TCP));
+        assertEquals(new ExposedPort(80, TCP), exposedPort);
     }
 
     @Test
     public void parsePortOnly() {
         ExposedPort exposedPort = ExposedPort.parse("80");
-        assertEquals(exposedPort, new ExposedPort(80, DEFAULT));
+        assertEquals(new ExposedPort(80, DEFAULT), exposedPort);
     }
 
     @Test
@@ -43,7 +43,7 @@ public class ExposedPortTest {
 
     @Test
     public void stringify() {
-        assertEquals(ExposedPort.parse("80/tcp").toString(), "80/tcp");
+        assertEquals("80/tcp", ExposedPort.parse("80/tcp").toString());
     }
 
 }

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/ExposedPortsTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/ExposedPortsTest.java
@@ -51,7 +51,7 @@ public class ExposedPortsTest {
     }
 
     @Test
-    public void usesFromJsonWithDuplicate() throws Exception {
+    public void usesFromJsonWithDuplicate() {
         ExposedPorts ports = new ExposedPorts(
             new ExposedPort(80, InternetProtocol.UDP),
             new ExposedPort(80),

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/HostConfigTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/HostConfigTest.java
@@ -8,7 +8,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class HostConfigTest {
 
     @Test
-    public void testNewObjectsEqual() throws Exception {
+    public void testNewObjectsEqual() {
         assertThat(HostConfig.newHostConfig(),
                 equalTo(HostConfig.newHostConfig()));
     }

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/IdentifierTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/IdentifierTest.java
@@ -17,26 +17,26 @@ public class IdentifierTest {
         Identifier i3A = Identifier.fromCompoundString("10.0.0.1:123/jim:latest");
 
         assertTrue(!i1.tag.isPresent());
-        assertEquals(i1.repository.name, "10.0.0.1/jim");
+        assertEquals("10.0.0.1/jim", i1.repository.name);
 
         assertTrue(i2.tag.isPresent());
-        assertEquals(i2.tag.get(), "123");
-        assertEquals(i2.repository.name, "10.0.0.1/jim");
+        assertEquals("123", i2.tag.get());
+        assertEquals("10.0.0.1/jim", i2.repository.name);
 
         assertTrue(i3.tag.isPresent());
-        assertEquals(i3.tag.get(), "124");
-        assertEquals(i3.repository.name, "10.0.0.1:123/jim");
-        assertEquals(i3.repository.getURL().getPort(), 123);
-        assertEquals(i3A.tag.get(), "latest");
+        assertEquals("124", i3.tag.get());
+        assertEquals("10.0.0.1:123/jim", i3.repository.name);
+        assertEquals(123, i3.repository.getURL().getPort());
+        assertEquals("latest", i3A.tag.get());
 
         Identifier i4 = Identifier.fromCompoundString("centos:latest");
         assertTrue(i4.tag.isPresent());
-        assertEquals(i4.tag.get(), "latest");
+        assertEquals("latest", i4.tag.get());
 
         Identifier i5 = Identifier.fromCompoundString("busybox");
         assertTrue(!i5.tag.isPresent());
 
         Identifier i6 = Identifier.fromCompoundString("10.0.0.1:5000/my-test-image:1234");
-        assertEquals(i6.repository.getPath(), "my-test-image");
+        assertEquals("my-test-image", i6.repository.getPath());
     }
 }

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/InternetProtocolTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/InternetProtocolTest.java
@@ -13,22 +13,22 @@ public class InternetProtocolTest {
 
     @Test
     public void defaultProtocol() {
-        assertEquals(InternetProtocol.DEFAULT, TCP);
+        assertEquals(TCP, InternetProtocol.DEFAULT);
     }
 
     @Test
     public void stringify() {
-        assertEquals(TCP.toString(), "tcp");
+        assertEquals("tcp", TCP.toString());
     }
 
     @Test
     public void parseUpperCase() {
-        assertEquals(InternetProtocol.parse("TCP"), TCP);
+        assertEquals(TCP, InternetProtocol.parse("TCP"));
     }
 
     @Test
     public void parseLowerCase() {
-        assertEquals(InternetProtocol.parse("tcp"), TCP);
+        assertEquals(TCP, InternetProtocol.parse("tcp"));
     }
 
     @Test

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/LinkTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/LinkTest.java
@@ -14,15 +14,15 @@ public class LinkTest {
     @Test
     public void parse() {
         Link link = Link.parse("name:alias");
-        assertEquals(link.getName(), "name");
-        assertEquals(link.getAlias(), "alias");
+        assertEquals("name", link.getName());
+        assertEquals("alias", link.getAlias());
     }
 
     @Test
     public void parseWithContainerNames() {
         Link link = Link.parse("/name:/conatiner/alias");
-        assertEquals(link.getName(), "name");
-        assertEquals(link.getAlias(), "alias");
+        assertEquals("name", link.getName());
+        assertEquals("alias", link.getAlias());
     }
 
     @Test
@@ -43,7 +43,7 @@ public class LinkTest {
 
     @Test
     public void stringify() {
-        assertEquals(Link.parse("name:alias").toString(), "name:alias");
+        assertEquals("name:alias", Link.parse("name:alias").toString());
     }
 
 }

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/PortBindingTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/PortBindingTest.java
@@ -23,27 +23,27 @@ public class PortBindingTest {
 
     @Test
     public void noProtocol() {
-        assertEquals(PortBinding.parse("127.0.0.1:80:8080"), new PortBinding(Binding.bindIpAndPort("127.0.0.1", 80), TCP_8080));
+        assertEquals(new PortBinding(Binding.bindIpAndPort("127.0.0.1", 80), TCP_8080), PortBinding.parse("127.0.0.1:80:8080"));
     }
 
     @Test
     public void noHostIp() {
-        assertEquals(PortBinding.parse("80:8080/tcp"), new PortBinding(Binding.bindPort(80), TCP_8080));
+        assertEquals(new PortBinding(Binding.bindPort(80), TCP_8080), PortBinding.parse("80:8080/tcp"));
     }
 
     @Test
     public void portsOnly() {
-        assertEquals(PortBinding.parse("80:8080"), new PortBinding(Binding.bindPort(80), TCP_8080));
+        assertEquals(new PortBinding(Binding.bindPort(80), TCP_8080), PortBinding.parse("80:8080"));
     }
 
     @Test
     public void exposedPortOnly() {
-        assertEquals(PortBinding.parse("8080"), new PortBinding(Binding.empty(), TCP_8080));
+        assertEquals(new PortBinding(Binding.empty(), TCP_8080), PortBinding.parse("8080"));
     }
 
     @Test
     public void dynamicHostPort() {
-        assertEquals(PortBinding.parse("127.0.0.1::8080"), new PortBinding(Binding.bindIp("127.0.0.1"), TCP_8080));
+        assertEquals(new PortBinding(Binding.bindIp("127.0.0.1"), TCP_8080), PortBinding.parse("127.0.0.1::8080"));
     }
 
     @Test

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/PortsAddBindingsTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/PortsAddBindingsTest.java
@@ -36,9 +36,9 @@ public class PortsAddBindingsTest {
 
         Map<ExposedPort, Binding[]> bindings = ports.getBindings();
         // two keys with one value each
-        assertEquals(bindings.size(), 2);
-        assertArrayEquals(bindings.get(TCP_80), new Binding[] {BINDING_8080});
-        assertArrayEquals(bindings.get(TCP_90), new Binding[] {BINDING_9090});
+        assertEquals(2, bindings.size());
+        assertArrayEquals(new Binding[] {BINDING_8080}, bindings.get(TCP_80));
+        assertArrayEquals(new Binding[] {BINDING_9090}, bindings.get(TCP_90));
     }
 
     @Test
@@ -47,8 +47,8 @@ public class PortsAddBindingsTest {
 
         Map<ExposedPort, Binding[]> bindings = ports.getBindings();
         // one key with two values
-        assertEquals(bindings.size(), 1);
-        assertArrayEquals(bindings.get(TCP_80), new Binding[] {BINDING_8080, BINDING_9090});
+        assertEquals(1, bindings.size());
+        assertArrayEquals(new Binding[] {BINDING_8080, BINDING_9090}, bindings.get(TCP_80));
     }
 
     @Test
@@ -56,7 +56,7 @@ public class PortsAddBindingsTest {
         ports.add(new PortBinding(null, TCP_80));
         Map<ExposedPort, Binding[]> bindings = ports.getBindings();
         // one key with two values
-        assertEquals(bindings.size(), 1);
+        assertEquals(1, bindings.size());
         assertNull(bindings.get(TCP_80));
     }
 }

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/PortsSerializingTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/PortsSerializingTest.java
@@ -19,12 +19,12 @@ public class PortsSerializingTest {
     public void deserializingPortWithMultipleBindings() throws Exception {
         Ports ports = JSONTestHelper.getMapper().readValue(jsonWithDoubleBindingForOnePort, Ports.class);
         Map<ExposedPort, Binding[]> map = ports.getBindings();
-        assertEquals(map.size(), 1);
+        assertEquals(1, map.size());
 
         Binding[] bindings = map.get(ExposedPort.tcp(80));
-        assertEquals(bindings.length, 2);
-        assertEquals(bindings[0], new Binding("10.0.0.1", "80"));
-        assertEquals(bindings[1], new Binding("10.0.0.2", "80"));
+        assertEquals(2, bindings.length);
+        assertEquals(new Binding("10.0.0.1", "80"), bindings[0]);
+        assertEquals(new Binding("10.0.0.2", "80"), bindings[1]);
     }
 
     @Test
@@ -32,20 +32,20 @@ public class PortsSerializingTest {
         Ports ports = new Ports();
         ports.bind(ExposedPort.tcp(80), new Binding("10.0.0.1", "80"));
         ports.bind(ExposedPort.tcp(80), new Binding("10.0.0.2", "80"));
-        assertEquals(JSONTestHelper.getMapper().writeValueAsString(ports), jsonWithDoubleBindingForOnePort);
+        assertEquals(jsonWithDoubleBindingForOnePort, JSONTestHelper.getMapper().writeValueAsString(ports));
     }
 
     @Test
     public void serializingEmptyBinding() throws Exception {
         Ports ports = new Ports(ExposedPort.tcp(80), new Binding(null, null));
-        assertEquals(JSONTestHelper.getMapper().writeValueAsString(ports), "{\"80/tcp\":[{\"HostIp\":\"\",\"HostPort\":\"\"}]}");
+        assertEquals("{\"80/tcp\":[{\"HostIp\":\"\",\"HostPort\":\"\"}]}", JSONTestHelper.getMapper().writeValueAsString(ports));
     }
 
     @Test
     public void deserializingPortWithNullBindings() throws Exception {
         Ports ports = JSONTestHelper.getMapper().readValue(jsonWithNullBindingForOnePort, Ports.class);
         Map<ExposedPort, Binding[]> map = ports.getBindings();
-        assertEquals(map.size(), 1);
+        assertEquals(1, map.size());
 
         assertNull(map.get(ExposedPort.tcp(80)));
     }
@@ -54,6 +54,6 @@ public class PortsSerializingTest {
     public void serializingWithNullBindings() throws Exception {
         Ports ports = new Ports();
         ports.bind(ExposedPort.tcp(80), null);
-        assertEquals(JSONTestHelper.getMapper().writeValueAsString(ports), jsonWithNullBindingForOnePort);
+        assertEquals(jsonWithNullBindingForOnePort, JSONTestHelper.getMapper().writeValueAsString(ports));
     }
 }

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/RestartPolicyParsingTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/RestartPolicyParsingTest.java
@@ -13,32 +13,32 @@ public class RestartPolicyParsingTest {
 
 
     @Test
-    public void noRestart() throws Exception {
+    public void noRestart() {
         assertEquals(RestartPolicy.noRestart(), RestartPolicy.parse("no"));
     }
 
     @Test
-    public void alwaysRestart() throws Exception {
+    public void alwaysRestart() {
         assertEquals(RestartPolicy.alwaysRestart(), RestartPolicy.parse("always"));
     }
 
     @Test
-    public void unlessStoppedRestart() throws Exception {
+    public void unlessStoppedRestart() {
         assertEquals(RestartPolicy.unlessStoppedRestart(), RestartPolicy.parse("unless-stopped"));
     }
 
     @Test
-    public void onFailureRestart() throws Exception {
+    public void onFailureRestart() {
         assertEquals(RestartPolicy.onFailureRestart(0), RestartPolicy.parse("on-failure"));
     }
 
     @Test
-    public void onFailureRestartWithCount() throws Exception {
+    public void onFailureRestartWithCount() {
         assertEquals(RestartPolicy.onFailureRestart(2), RestartPolicy.parse("on-failure:2"));
     }
 
     @Test
-    public void illegalSyntax() throws Exception {
+    public void illegalSyntax() {
         expectedEx.expect(IllegalArgumentException.class);
         expectedEx.expectMessage("Error parsing RestartPolicy 'nonsense'");
 
@@ -46,7 +46,7 @@ public class RestartPolicyParsingTest {
     }
 
     @Test
-    public void illegalRetryCount() throws Exception {
+    public void illegalRetryCount() {
         expectedEx.expect(IllegalArgumentException.class);
         expectedEx.expectMessage("Error parsing RestartPolicy 'on-failure:X'");
 

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/RestartPolicyParsingTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/RestartPolicyParsingTest.java
@@ -14,27 +14,27 @@ public class RestartPolicyParsingTest {
 
     @Test
     public void noRestart() throws Exception {
-        assertEquals(RestartPolicy.parse("no"), RestartPolicy.noRestart());
+        assertEquals(RestartPolicy.noRestart(), RestartPolicy.parse("no"));
     }
 
     @Test
     public void alwaysRestart() throws Exception {
-        assertEquals(RestartPolicy.parse("always"), RestartPolicy.alwaysRestart());
+        assertEquals(RestartPolicy.alwaysRestart(), RestartPolicy.parse("always"));
     }
 
     @Test
     public void unlessStoppedRestart() throws Exception {
-        assertEquals(RestartPolicy.parse("unless-stopped"), RestartPolicy.unlessStoppedRestart());
+        assertEquals(RestartPolicy.unlessStoppedRestart(), RestartPolicy.parse("unless-stopped"));
     }
 
     @Test
     public void onFailureRestart() throws Exception {
-        assertEquals(RestartPolicy.parse("on-failure"), RestartPolicy.onFailureRestart(0));
+        assertEquals(RestartPolicy.onFailureRestart(0), RestartPolicy.parse("on-failure"));
     }
 
     @Test
     public void onFailureRestartWithCount() throws Exception {
-        assertEquals(RestartPolicy.parse("on-failure:2"), RestartPolicy.onFailureRestart(2));
+        assertEquals(RestartPolicy.onFailureRestart(2), RestartPolicy.parse("on-failure:2"));
     }
 
     @Test

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/RestartPolicySerializingTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/RestartPolicySerializingTest.java
@@ -15,35 +15,35 @@ public class RestartPolicySerializingTest {
     // --restart no
     public void noRestart() throws Exception {
         String json = JSONTestHelper.getMapper().writeValueAsString(RestartPolicy.noRestart());
-        assertEquals(json, "{\"MaximumRetryCount\":0,\"Name\":\"\"}");
+        assertEquals("{\"MaximumRetryCount\":0,\"Name\":\"\"}", json);
     }
 
     @Test
     // --restart always
     public void alwaysRestart() throws Exception {
         String json = JSONTestHelper.getMapper().writeValueAsString(RestartPolicy.alwaysRestart());
-        assertEquals(json, "{\"MaximumRetryCount\":0,\"Name\":\"always\"}");
+        assertEquals("{\"MaximumRetryCount\":0,\"Name\":\"always\"}", json);
     }
 
     @Test
     // --restart unless-stopped
     public void unlessStoppedRestart() throws Exception {
         String json = JSONTestHelper.getMapper().writeValueAsString(RestartPolicy.unlessStoppedRestart());
-        assertEquals(json, "{\"MaximumRetryCount\":0,\"Name\":\"unless-stopped\"}");
+        assertEquals("{\"MaximumRetryCount\":0,\"Name\":\"unless-stopped\"}", json);
     }
 
     @Test
     // --restart on-failure
     public void onFailureRestart() throws Exception {
         String json = JSONTestHelper.getMapper().writeValueAsString(RestartPolicy.onFailureRestart(0));
-        assertEquals(json, "{\"MaximumRetryCount\":0,\"Name\":\"on-failure\"}");
+        assertEquals("{\"MaximumRetryCount\":0,\"Name\":\"on-failure\"}", json);
     }
 
     @Test
     // --restart on-failure:2
     public void onFailureRestartWithCount() throws Exception {
         String json = JSONTestHelper.getMapper().writeValueAsString(RestartPolicy.onFailureRestart(2));
-        assertEquals(json, "{\"MaximumRetryCount\":2,\"Name\":\"on-failure\"}");
+        assertEquals("{\"MaximumRetryCount\":2,\"Name\":\"on-failure\"}", json);
     }
 
 }

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/RestartPolicyToStringTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/RestartPolicyToStringTest.java
@@ -19,7 +19,7 @@ public class RestartPolicyToStringTest {
 
     @Test
     public void serializationWithoutCount() throws Exception {
-        assertEquals(RestartPolicy.parse(policy).toString(), policy);
+        assertEquals(policy, RestartPolicy.parse(policy).toString());
     }
 
 }

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/RestartPolicyToStringTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/RestartPolicyToStringTest.java
@@ -18,7 +18,7 @@ public class RestartPolicyToStringTest {
     public String policy;
 
     @Test
-    public void serializationWithoutCount() throws Exception {
+    public void serializationWithoutCount() {
         assertEquals(policy, RestartPolicy.parse(policy).toString());
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/VolumeBindsTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/VolumeBindsTest.java
@@ -28,9 +28,9 @@ public class VolumeBindsTest {
         String s = "{\"/data\":\"/some/path\"}";
         VolumeBinds volumeBinds = JSONTestHelper.getMapper().readValue(s, VolumeBinds.class);
         VolumeBind[] binds = volumeBinds.getBinds();
-        assertEquals(binds.length, 1);
-        assertEquals(binds[0].getHostPath(), "/some/path");
-        assertEquals(binds[0].getContainerPath(), "/data");
+        assertEquals(1, binds.length);
+        assertEquals("/some/path", binds[0].getHostPath());
+        assertEquals("/data", binds[0].getContainerPath());
     }
 
     @Test(expected = JsonMappingException.class)

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/VolumeFromSerializingTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/VolumeFromSerializingTest.java
@@ -18,7 +18,7 @@ public class VolumeFromSerializingTest {
     @Test
     public void serializing() throws Exception {
         VolumesFrom volumeFrom = new VolumesFrom("container1", AccessMode.ro);
-        assertEquals(JSONTestHelper.getMapper().writeValueAsString(volumeFrom), json);
+        assertEquals(json, JSONTestHelper.getMapper().writeValueAsString(volumeFrom));
     }
 
 }

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/VolumeTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/VolumeTest.java
@@ -7,6 +7,6 @@ import static org.junit.Assert.assertEquals;
 public class VolumeTest {
     @Test
     public void getPath() {
-        assertEquals(new Volume("/path").getPath(), "/path");
+        assertEquals("/path", new Volume("/path").getPath());
     }
 }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
@@ -61,7 +61,7 @@ public class AttachContainerCmdIT extends CmdIT {
         AttachContainerTestCallback callback = new AttachContainerTestCallback() {
             @Override
             public void onNext(Frame frame) {
-                assertEquals(frame.getStreamType(), StreamType.STDOUT);
+                assertEquals(StreamType.STDOUT, frame.getStreamType());
                 super.onNext(frame);
             }
         };

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/AttachContainerCmdIT.java
@@ -5,16 +5,13 @@ import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.StreamType;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.InputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.util.concurrent.CountDownLatch;

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/AuthCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/AuthCmdIT.java
@@ -19,7 +19,7 @@ import static org.junit.Assume.assumeThat;
 public class AuthCmdIT extends CmdIT {
 
     @Test
-    public void testAuth() throws Exception {
+    public void testAuth() {
         assumeThat("Fails on 1.22. Temporary disabled.", dockerRule, apiVersionGreater(VERSION_1_22));
 
         AuthResponse response = dockerRule.getClient().authCmd().exec();
@@ -30,7 +30,7 @@ public class AuthCmdIT extends CmdIT {
 
     @Ignore("Disabled because of 500/InternalServerException")
     @Test
-    public void testAuthInvalid() throws Exception {
+    public void testAuthInvalid() {
         assertThrows("Wrong login/password, please try again", UnauthorizedException.class, () -> {
             DockerClientBuilder.getInstance(dockerRule.config("garbage"))
                 .build()

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/BuildImageCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/BuildImageCmdIT.java
@@ -163,21 +163,21 @@ public class BuildImageCmdIT extends CmdIT {
     }
 
     @Test(expected = DockerClientException.class)
-    public void dockerignoreDockerfileIgnored() throws Exception {
+    public void dockerignoreDockerfileIgnored() {
         File baseDir = fileFromBuildTestResource("dockerignore/DockerfileIgnored");
 
         dockerRule.getClient().buildImageCmd(baseDir).withNoCache(true).start().awaitImageId();
     }
 
     @Test
-    public void dockerignoreDockerfileNotIgnored() throws Exception {
+    public void dockerignoreDockerfileNotIgnored() {
         File baseDir = fileFromBuildTestResource("dockerignore/DockerfileNotIgnored");
 
         dockerRule.getClient().buildImageCmd(baseDir).withNoCache(true).start().awaitImageId();
     }
 
     @Test(expected = DockerClientException.class)
-    public void dockerignoreInvalidDockerIgnorePattern() throws Exception {
+    public void dockerignoreInvalidDockerIgnorePattern() {
         File baseDir = fileFromBuildTestResource("dockerignore/InvalidDockerignorePattern");
 
         dockerRule.getClient().buildImageCmd(baseDir).withNoCache(true).start().awaitImageId();
@@ -241,7 +241,7 @@ public class BuildImageCmdIT extends CmdIT {
     }
 
     @Test
-    public void buildArgs() throws Exception {
+    public void buildArgs() {
         File baseDir = fileFromBuildTestResource("buildArgs");
 
         String imageId = dockerRule.getClient().buildImageCmd(baseDir).withNoCache(true).withBuildArg("testArg", "abc !@#$%^&*()_+")
@@ -256,7 +256,7 @@ public class BuildImageCmdIT extends CmdIT {
     }
 
     @Test
-    public void labels() throws Exception {
+    public void labels() {
         assumeThat("API version should be >= 1.23", dockerRule, isGreaterOrEqual(VERSION_1_23));
 
         File baseDir = fileFromBuildTestResource("labels");
@@ -274,7 +274,7 @@ public class BuildImageCmdIT extends CmdIT {
     }
 
     @Test
-    public void multipleTags() throws Exception {
+    public void multipleTags() {
         assumeThat("API version should be >= 1.23", dockerRule, isGreaterOrEqual(VERSION_1_21));
 
 
@@ -295,7 +295,7 @@ public class BuildImageCmdIT extends CmdIT {
     }
 
     @Test
-    public void cacheFrom() throws Exception {
+    public void cacheFrom() {
         assumeThat(dockerRule, isGreaterOrEqual(VERSION_1_27));
 
         File baseDir1 = fileFromBuildTestResource("CacheFrom/test1");

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveFromContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveFromContainerCmdIT.java
@@ -78,7 +78,7 @@ public class CopyArchiveFromContainerCmdIT extends CmdIT {
         try (TarArchiveInputStream tarInputStream = new TarArchiveInputStream(response)) {
             TarArchiveEntry nextTarEntry = tarInputStream.getNextTarEntry();
 
-            assertEquals(nextTarEntry.getName(), "binary.dat");
+            assertEquals("binary.dat", nextTarEntry.getName());
             try (InputStream binaryFileInputStream = Files.newInputStream(binaryFile, StandardOpenOption.READ)) {
                 assertTrue(IOUtils.contentEquals(binaryFileInputStream, tarInputStream));
             }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveFromContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveFromContainerCmdIT.java
@@ -30,7 +30,7 @@ public class CopyArchiveFromContainerCmdIT extends CmdIT {
     public static final Logger LOG = LoggerFactory.getLogger(CopyArchiveFromContainerCmdIT.class);
 
     @Test
-    public void copyFromContainer() throws Exception {
+    public void copyFromContainer() {
         // TODO extract this into a shared method
         CreateContainerResponse container = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
                 .withName("copyFromContainer")
@@ -51,7 +51,7 @@ public class CopyArchiveFromContainerCmdIT extends CmdIT {
     }
 
     @Test(expected = NotFoundException.class)
-    public void copyFromNonExistingContainer() throws Exception {
+    public void copyFromNonExistingContainer() {
 
         dockerRule.getClient().copyArchiveFromContainerCmd("non-existing", "/test").exec();
     }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveToContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CopyArchiveToContainerCmdIT.java
@@ -82,7 +82,7 @@ public class CopyArchiveToContainerCmdIT extends CmdIT {
     }
 
     @Test(expected = NotFoundException.class)
-    public void copyToNonExistingContainer() throws Exception {
+    public void copyToNonExistingContainer() {
 
         dockerRule.getClient().copyArchiveToContainerCmd("non-existing").withHostResource("src/test/resources/testReadFile").exec();
     }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CopyFileFromContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CopyFileFromContainerCmdIT.java
@@ -23,7 +23,7 @@ public class CopyFileFromContainerCmdIT extends CmdIT {
     public static final Logger LOG = LoggerFactory.getLogger(CopyFileFromContainerCmdIT.class);
 
     @Test
-    public void copyFromContainer() throws Exception {
+    public void copyFromContainer() {
         assumeThat("Doesn't work since 1.24", dockerRule, not(isGreaterOrEqual(VERSION_1_24)));
 
         assumeNotSwarm("", dockerRule);
@@ -51,7 +51,7 @@ public class CopyFileFromContainerCmdIT extends CmdIT {
     }
 
     @Test(expected = NotFoundException.class)
-    public void copyFromNonExistingContainer() throws Exception {
+    public void copyFromNonExistingContainer() {
 
         dockerRule.getClient().copyFileFromContainerCmd("non-existing", "/test").exec();
     }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CreateContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CreateContainerCmdIT.java
@@ -23,7 +23,6 @@ import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Link;
 import com.github.dockerjava.api.model.LogConfig;
 import com.github.dockerjava.api.model.Network;
-import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.Ports.Binding;
 import com.github.dockerjava.api.model.RestartPolicy;

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CreateNetworkCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CreateNetworkCmdIT.java
@@ -52,7 +52,7 @@ public class CreateNetworkCmdIT extends CmdIT {
         assertNotNull(createNetworkResponse.getId());
 
         Network network = dockerRule.getClient().inspectNetworkCmd().withNetworkId(createNetworkResponse.getId()).exec();
-        assertEquals(network.getName(), networkName);
+        assertEquals(networkName, network.getName());
         assertEquals("bridge", network.getDriver());
         assertEquals(subnet, network.getIpam().getConfig().iterator().next().getSubnet());
     }
@@ -83,6 +83,6 @@ public class CreateNetworkCmdIT extends CmdIT {
         CreateNetworkResponse createNetworkResponse = dockerRule.getClient().createNetworkCmd().withName(networkName).withLabels(labels).exec();
         assertNotNull(createNetworkResponse.getId());
         Network network = dockerRule.getClient().inspectNetworkCmd().withNetworkId(createNetworkResponse.getId()).exec();
-        assertEquals(network.getLabels(), labels);
+        assertEquals(labels, network.getLabels());
     }
 }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/CustomCommandIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/CustomCommandIT.java
@@ -1,6 +1,5 @@
 package com.github.dockerjava.cmd;
 
-import com.github.dockerjava.core.DockerClientImpl;
 import com.github.dockerjava.core.DockerRule;
 import com.github.dockerjava.transport.DockerHttpClient;
 import com.github.dockerjava.transport.DockerHttpClient.Request;

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/DisconnectFromNetworkCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/DisconnectFromNetworkCmdIT.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertTrue;
 public class DisconnectFromNetworkCmdIT extends CmdIT {
 
     @Test
-    public void disconnectFromNetwork() throws InterruptedException {
+    public void disconnectFromNetwork() {
         assumeNotSwarm("no network in swarm", dockerRule);
 
         CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox").withCmd("sleep", "9999").exec();
@@ -35,7 +35,7 @@ public class DisconnectFromNetworkCmdIT extends CmdIT {
     }
 
     @Test
-    public void forceDisconnectFromNetwork() throws InterruptedException {
+    public void forceDisconnectFromNetwork() {
         assumeNotSwarm("no network in swarm", dockerRule);
 
         CreateNetworkResponse network = dockerRule.getClient().createNetworkCmd().withName("testNetwork2").exec();

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/InspectContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/InspectContainerCmdIT.java
@@ -45,7 +45,7 @@ public class InspectContainerCmdIT extends CmdIT {
         assertThat(container.getId(), not(is(emptyString())));
 
         InspectContainerResponse containerInfo = dockerRule.getClient().inspectContainerCmd(container.getId()).exec();
-        assertEquals(containerInfo.getId(), container.getId());
+        assertEquals(container.getId(), containerInfo.getId());
 
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/InspectExecCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/InspectExecCmdIT.java
@@ -79,7 +79,7 @@ public class InspectExecCmdIT extends CmdIT {
     }
 
     @Test
-    public void inspectExecNetworkSettings() throws IOException {
+    public void inspectExecNetworkSettings() {
         final RemoteApiVersion apiVersion = getVersion(dockerRule.getClient());
 
         String containerName = "generated_" + new SecureRandom().nextInt();

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/ListContainersCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/ListContainersCmdIT.java
@@ -59,7 +59,7 @@ public class ListContainersCmdIT extends CmdIT {
     }
 
     @Test
-    public void testListContainers() throws Exception {
+    public void testListContainers() {
         List<Container> containers = dockerRule.getClient().listContainersCmd()
                 .withLabelFilter(testLabel)
                 .withShowAll(true)
@@ -106,7 +106,7 @@ public class ListContainersCmdIT extends CmdIT {
     }
 
     @Test
-    public void testListContainersWithLabelsFilter() throws Exception {
+    public void testListContainersWithLabelsFilter() {
         // list with filter by Map label
         dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE).withCmd("echo")
                 .withLabels(testLabel)
@@ -138,7 +138,7 @@ public class ListContainersCmdIT extends CmdIT {
     }
 
     @Test
-    public void testNameFilter() throws Exception {
+    public void testNameFilter() {
         String testUUID = testLabel.get("test");
 
         String id1, id2;
@@ -165,7 +165,7 @@ public class ListContainersCmdIT extends CmdIT {
     }
 
     @Test
-    public void testIdsFilter() throws Exception {
+    public void testIdsFilter() {
         String id1, id2;
         id1 = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
                 .withLabels(testLabel)
@@ -188,7 +188,7 @@ public class ListContainersCmdIT extends CmdIT {
     }
 
     @Test
-    public void testStatusFilter() throws Exception {
+    public void testStatusFilter() {
         String id1, id2;
         id1 = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
                 .withCmd("sh", "-c", "sleep 99999")
@@ -247,7 +247,7 @@ public class ListContainersCmdIT extends CmdIT {
     }
 
     @Test
-    public void testVolumeFilter() throws Exception {
+    public void testVolumeFilter() {
         String id;
         dockerRule.getClient().createVolumeCmd()
                 .withName("TestFilterVolume")
@@ -276,7 +276,7 @@ public class ListContainersCmdIT extends CmdIT {
     }
 
     @Test
-    public void testNetworkFilter() throws Exception {
+    public void testNetworkFilter() {
         String id;
         dockerRule.getClient().createNetworkCmd()
                 .withName("TestFilterNetwork")
@@ -337,7 +337,7 @@ public class ListContainersCmdIT extends CmdIT {
     }
 
     @Test
-    public void testExitedFilter() throws Exception {
+    public void testExitedFilter() {
         dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
                 .withLabels(testLabel)
                 .exec();

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/LogContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/LogContainerCmdIT.java
@@ -66,7 +66,7 @@ public class LogContainerCmdIT extends CmdIT {
 
         assertTrue(loggingCallback.toString().contains("hello"));
 
-        assertEquals(loggingCallback.getCollectedFrames().get(0).getStreamType(), StreamType.RAW);
+        assertEquals(StreamType.RAW, loggingCallback.getCollectedFrames().get(0).getStreamType());
     }
 
     @Test

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/PushImageCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/PushImageCmdIT.java
@@ -36,7 +36,7 @@ public class PushImageCmdIT extends CmdIT {
     private AuthConfig authConfig;
 
     @Before
-    public void beforeTest() throws Exception {
+    public void beforeTest() {
         authConfig = REGISTRY.getAuthConfig();
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/RemoveContainerCmdImplIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/RemoveContainerCmdImplIT.java
@@ -23,7 +23,7 @@ public class RemoveContainerCmdImplIT extends CmdIT {
     
 
     @Test
-    public void removeContainer() throws Exception {
+    public void removeContainer() {
 
         CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox").withCmd("true").exec();
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/RemoveImageCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/RemoveImageCmdIT.java
@@ -24,7 +24,7 @@ public class RemoveImageCmdIT extends CmdIT {
     public static final Logger LOG = LoggerFactory.getLogger(RemoveImageCmdIT.class);
     
     @Test
-    public void removeImage() throws DockerException, InterruptedException {
+    public void removeImage() throws DockerException {
 
         CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox").withCmd("sleep", "9999").exec();
         LOG.info("Created container: {}", container.toString());
@@ -47,7 +47,7 @@ public class RemoveImageCmdIT extends CmdIT {
     }
 
     @Test(expected = NotFoundException.class)
-    public void removeNonExistingImage() throws DockerException, InterruptedException {
+    public void removeNonExistingImage() throws DockerException {
 
         dockerRule.getClient().removeImageCmd("non-existing").exec();
     }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/RenameContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/RenameContainerCmdIT.java
@@ -45,7 +45,7 @@ public class RenameContainerCmdIT extends CmdIT {
     }
 
     @Test(expected = NotFoundException.class)
-    public void renameExistingContainer() throws DockerException, InterruptedException {
+    public void renameExistingContainer() throws DockerException {
         dockerRule.getClient().renameContainerCmd("non-existing")
                 .withName("renameExistingContainer")
                 .exec();

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/RestartContainerCmdImplIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/RestartContainerCmdImplIT.java
@@ -45,7 +45,7 @@ public class RestartContainerCmdImplIT extends CmdIT {
     }
 
     @Test(expected = NotFoundException.class)
-    public void restartNonExistingContainer() throws DockerException, InterruptedException {
+    public void restartNonExistingContainer() throws DockerException {
 
         dockerRule.getClient().restartContainerCmd("non-existing").exec();
     }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/StartContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/StartContainerCmdIT.java
@@ -44,7 +44,7 @@ public class StartContainerCmdIT extends CmdIT {
     public static final Logger LOG = LoggerFactory.getLogger(StartContainerCmdIT.class);
 
     @Test
-    public void startContainerWithVolumes() throws Exception {
+    public void startContainerWithVolumes() {
 
         // see http://docs.docker.io/use/working_with_volumes/
         Volume volume1 = new Volume("/opt/webapp1");

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/TagImageCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/TagImageCmdIT.java
@@ -11,7 +11,7 @@ public class TagImageCmdIT extends CmdIT {
     public static final Logger LOG = LoggerFactory.getLogger(TagImageCmdIT.class);
 
     @Test
-    public void tagImage() throws Exception {
+    public void tagImage() {
         String tag = "" + RandomUtils.nextInt(0, Integer.MAX_VALUE);
 
         dockerRule.getClient().tagImageCmd("busybox:latest", "docker-java/busybox", tag).exec();
@@ -20,7 +20,7 @@ public class TagImageCmdIT extends CmdIT {
     }
 
     @Test(expected = NotFoundException.class)
-    public void tagNonExistingImage() throws Exception {
+    public void tagNonExistingImage() {
 
         String tag = "" + RandomUtils.nextInt(0, Integer.MAX_VALUE);
         dockerRule.getClient().tagImageCmd("non-existing", "docker-java/busybox", tag).exec();

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/UpdateContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/UpdateContainerCmdIT.java
@@ -31,7 +31,7 @@ public class UpdateContainerCmdIT extends CmdIT {
 
 
     @Test
-    public void updateContainer() throws DockerException, IOException {
+    public void updateContainer() throws DockerException {
         assumeThat("API version should be >= 1.22", dockerRule, isGreaterOrEqual(VERSION_1_22));
 
         CreateContainerResponse response = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/VersionCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/VersionCmdIT.java
@@ -22,7 +22,7 @@ public class VersionCmdIT extends CmdIT {
         assertTrue(version.getGoVersion().length() > 0);
         assertTrue(version.getVersion().length() > 0);
 
-        assertEquals(StringUtils.split(version.getVersion(), ".").length, 3);
+        assertEquals(3, StringUtils.split(version.getVersion(), ".").length);
 
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/WaitContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/WaitContainerCmdIT.java
@@ -84,7 +84,7 @@ public class WaitContainerCmdIT extends CmdIT {
     }
 
     @Test
-    public void testWaitContainerTimeout() throws Exception {
+    public void testWaitContainerTimeout() {
 
         CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox").withCmd("sleep", "10").exec();
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/CreateSecretCmdExecIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/CreateSecretCmdExecIT.java
@@ -21,7 +21,7 @@ public class CreateSecretCmdExecIT extends SwarmCmdIT {
     public static final Logger LOG = LoggerFactory.getLogger(CreateSecretCmdExecIT.class);
 
     @Test
-    public void testCreateSecret() throws Exception {
+    public void testCreateSecret() {
         DockerClient dockerClient = startSwarm();
         int length = 10;
         boolean useLetters = true;

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/CreateServiceCmdExecIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/CreateServiceCmdExecIT.java
@@ -53,7 +53,7 @@ public class CreateServiceCmdExecIT extends SwarmCmdIT {
     private DockerClient dockerClient;
 
     @Before
-    public final void setUpCreateServiceCmdExecIT() throws Exception {
+    public final void setUpCreateServiceCmdExecIT() {
         authConfig = REGISTRY.getAuthConfig();
         dockerClient = startSwarm();
     }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/InspectConfigCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/InspectConfigCmdIT.java
@@ -9,8 +9,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 
 public class InspectConfigCmdIT extends SwarmCmdIT {

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/JoinSwarmCmdExecIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/JoinSwarmCmdExecIT.java
@@ -43,7 +43,7 @@ public class JoinSwarmCmdExecIT extends SwarmCmdIT {
     }
 
     @Test
-    public void joinSwarmAsWorker() throws Exception {
+    public void joinSwarmAsWorker() {
         SwarmJoinTokens tokens = initSwarmOnDocker(docker1);
 
         docker2.joinSwarmCmd()
@@ -58,7 +58,7 @@ public class JoinSwarmCmdExecIT extends SwarmCmdIT {
     }
 
     @Test
-    public void joinSwarmAsManager() throws DockerException, InterruptedException {
+    public void joinSwarmAsManager() throws DockerException {
         SwarmJoinTokens tokens = initSwarmOnDocker(docker1);
 
         docker2.joinSwarmCmd()
@@ -73,7 +73,7 @@ public class JoinSwarmCmdExecIT extends SwarmCmdIT {
     }
 
     @Test(expected = DockerException.class)
-    public void joinSwarmIfAlreadyInSwarm() throws Exception {
+    public void joinSwarmIfAlreadyInSwarm() {
         SwarmJoinTokens tokens = initSwarmOnDocker(docker1);
 
         initSwarmOnDocker(docker2);

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/ListServicesCmdExecIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/ListServicesCmdExecIT.java
@@ -27,7 +27,7 @@ public class ListServicesCmdExecIT extends SwarmCmdIT {
     private static final String LABEL_VALUE = "test";
 
     @Test
-    public void testListServices() throws Exception {
+    public void testListServices() {
         DockerClient dockerClient = startSwarm();
         Map<String, String> serviceLabels = Collections.singletonMap(LABEL_KEY, LABEL_VALUE);
         CreateServiceResponse response = dockerClient.createServiceCmd(new ServiceSpec()

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/ListSwarmNodesCmdExecIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/ListSwarmNodesCmdExecIT.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.is;
 
 public class ListSwarmNodesCmdExecIT extends SwarmCmdIT {
     @Test
-    public void testListSwarmNodes() throws Exception {
+    public void testListSwarmNodes() {
         DockerClient dockerClient = startSwarm();
 
         List<SwarmNode> nodes = dockerClient.listSwarmNodesCmd().exec();
@@ -20,7 +20,7 @@ public class ListSwarmNodesCmdExecIT extends SwarmCmdIT {
     }
 
     @Test
-    public void testListSwarmNodesWithIdFilter() throws Exception {
+    public void testListSwarmNodesWithIdFilter() {
         DockerClient dockerClient = startSwarm();
 
         List<SwarmNode> nodes = dockerClient.listSwarmNodesCmd().exec();
@@ -39,7 +39,7 @@ public class ListSwarmNodesCmdExecIT extends SwarmCmdIT {
     }
 
     @Test
-    public void testListSwarmNodesWithNameFilter() throws Exception {
+    public void testListSwarmNodesWithNameFilter() {
         DockerClient dockerClient = startSwarm();
 
         List<SwarmNode> nodes = dockerClient.listSwarmNodesCmd().exec();
@@ -58,7 +58,7 @@ public class ListSwarmNodesCmdExecIT extends SwarmCmdIT {
     }
 
     @Test
-    public void testListSwarmNodesWithMembershipFilter() throws Exception {
+    public void testListSwarmNodesWithMembershipFilter() {
         DockerClient dockerClient = startSwarm();
 
         List<SwarmNode> nodesWithAcceptedMembership = dockerClient.listSwarmNodesCmd()
@@ -73,7 +73,7 @@ public class ListSwarmNodesCmdExecIT extends SwarmCmdIT {
     }
 
     @Test
-    public void testListSwarmNodesWithRoleFilter() throws Exception {
+    public void testListSwarmNodesWithRoleFilter() {
         DockerClient dockerClient = startSwarm();
 
         List<SwarmNode> nodesWithManagerRole = dockerClient.listSwarmNodesCmd()

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/SwarmCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/SwarmCmdIT.java
@@ -47,7 +47,7 @@ public abstract class SwarmCmdIT extends CmdIT {
     private final Set<String> startedContainerIds = new HashSet<>();
 
     @Before
-    public final void setUpMultiNodeSwarmCmdIT() throws Exception {
+    public final void setUpMultiNodeSwarmCmdIT() {
         assumeThat(dockerRule, isGreaterOrEqual(VERSION_1_24));
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/UpdateSwarmNodeIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/UpdateSwarmNodeIT.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 
 public class UpdateSwarmNodeIT extends SwarmCmdIT {
     @Test
-    public void testUpdateSwarmNode() throws Exception {
+    public void testUpdateSwarmNode() {
         DockerClient dockerClient = startSwarm();
         List<SwarmNode> nodes = dockerClient.listSwarmNodesCmd().exec();
         assertThat(1, is(nodes.size()));

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/UpdateSwarmServiceIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/UpdateSwarmServiceIT.java
@@ -21,7 +21,7 @@ import static org.hamcrest.Matchers.is;
 
 public class UpdateSwarmServiceIT extends SwarmCmdIT {
     @Test
-    public void testUpdateServiceReplicate() throws Exception {
+    public void testUpdateServiceReplicate() {
         DockerClient dockerClient = startSwarm();
         //create network
         String networkId = dockerClient.createNetworkCmd().withName("networkname").withDriver("overlay")

--- a/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
@@ -79,7 +79,7 @@ public class DefaultDockerClientConfigTest {
         // when you build a config
         DefaultDockerClientConfig config = buildConfig(env, systemProperties);
 
-        assertEquals(config.getDockerHost(), URI.create("tcp://baz:8768"));
+        assertEquals(URI.create("tcp://baz:8768"), config.getDockerHost());
     }
 
     @Test
@@ -164,11 +164,11 @@ public class DefaultDockerClientConfigTest {
         DefaultDockerClientConfig config = buildConfig(Collections.<String, String> emptyMap(), systemProperties);
 
         // then the cert path is as expected
-        assertEquals(config.getDockerHost(), URI.create("unix:///var/run/docker.sock"));
-        assertEquals(config.getRegistryUsername(), "someUserName");
-        assertEquals(config.getRegistryUrl(), AuthConfig.DEFAULT_SERVER_ADDRESS);
-        assertEquals(config.getApiVersion(), RemoteApiVersion.unknown());
-        assertEquals(config.getDockerConfigPath(), homeDir() + "/.docker");
+        assertEquals(URI.create("unix:///var/run/docker.sock"), config.getDockerHost());
+        assertEquals("someUserName", config.getRegistryUsername());
+        assertEquals(AuthConfig.DEFAULT_SERVER_ADDRESS, config.getRegistryUrl());
+        assertEquals(RemoteApiVersion.unknown(), config.getApiVersion());
+        assertEquals(homeDir() + "/.docker", config.getDockerConfigPath());
         assertNull(config.getSSLConfig());
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DefaultDockerClientConfigTest.java
@@ -58,12 +58,12 @@ public class DefaultDockerClientConfigTest {
     }
 
     @Test
-    public void equals() throws Exception {
+    public void equals() {
         assertEquals(EXAMPLE_CONFIG, newExampleConfig());
     }
 
     @Test
-    public void environmentDockerHost() throws Exception {
+    public void environmentDockerHost() {
 
         // given docker host in env
         Map<String, String> env = new HashMap<>();
@@ -83,7 +83,7 @@ public class DefaultDockerClientConfigTest {
     }
 
     @Test
-    public void dockerContextFromConfig() throws Exception {
+    public void dockerContextFromConfig() {
         // given home directory with docker contexts configured
         Properties systemProperties = new Properties();
         systemProperties.setProperty("user.home", "target/test-classes/dockerContextHomeDir");
@@ -98,7 +98,7 @@ public class DefaultDockerClientConfigTest {
     }
 
     @Test
-    public void dockerContextFromEnvironmentVariable() throws Exception {
+    public void dockerContextFromEnvironmentVariable() {
         // given home directory with docker contexts
         Properties systemProperties = new Properties();
         systemProperties.setProperty("user.home", "target/test-classes/dockerContextHomeDir");
@@ -114,7 +114,7 @@ public class DefaultDockerClientConfigTest {
     }
 
     @Test
-    public void environment() throws Exception {
+    public void environment() {
 
         // given a default config in env properties
         Map<String, String> env = new HashMap<>();
@@ -153,7 +153,7 @@ public class DefaultDockerClientConfigTest {
     }
 
     @Test
-    public void defaults() throws Exception {
+    public void defaults() {
 
         // given default cert path
         Properties systemProperties = new Properties();
@@ -173,7 +173,7 @@ public class DefaultDockerClientConfigTest {
     }
 
     @Test
-    public void systemProperties() throws Exception {
+    public void systemProperties() {
 
         // given system properties based on the example
         Properties systemProperties = new Properties();
@@ -204,7 +204,7 @@ public class DefaultDockerClientConfigTest {
     }
 
     @Test()
-    public void testSslContextEmpty() throws Exception {
+    public void testSslContextEmpty() {
         new DefaultDockerClientConfig(URI.create("tcp://foo"), new DockerConfigFile(), "dockerConfig", "apiVersion", "registryUrl", "registryUsername", "registryPassword", "registryEmail",
                 null);
     }
@@ -212,13 +212,13 @@ public class DefaultDockerClientConfigTest {
 
 
     @Test()
-    public void testTlsVerifyAndCertPath() throws Exception {
+    public void testTlsVerifyAndCertPath() {
         new DefaultDockerClientConfig(URI.create("tcp://foo"), new DockerConfigFile(), "dockerConfig", "apiVersion", "registryUrl", "registryUsername", "registryPassword", "registryEmail",
                 new LocalDirectorySSLConfig(dockerCertPath()));
     }
 
     @Test()
-    public void testAnyHostScheme() throws Exception {
+    public void testAnyHostScheme() {
         URI dockerHost = URI.create("a" + UUID.randomUUID().toString().replace("-", "") + "://foo");
         new DefaultDockerClientConfig(dockerHost, new DockerConfigFile(), "dockerConfig", "apiVersion", "registryUrl", "registryUsername", "registryPassword", "registryEmail",
             null);

--- a/docker-java/src/test/java/com/github/dockerjava/core/DockerClientBuilderTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DockerClientBuilderTest.java
@@ -1,12 +1,7 @@
 package com.github.dockerjava.core;
 
 
-import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.DockerCmdExecFactory;
-import com.github.dockerjava.api.model.PushResponseItem;
-import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
-import com.github.dockerjava.transport.DockerHttpClient;
-import java.time.Duration;
 import org.junit.Test;
 
 import java.util.ArrayList;

--- a/docker-java/src/test/java/com/github/dockerjava/core/DockerClientBuilderTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DockerClientBuilderTest.java
@@ -39,7 +39,7 @@ public class DockerClientBuilderTest {
 
         parallel(AMOUNT, runnable);
         // set contains all required unique instances
-        assertEquals(instances.size(), AMOUNT);
+        assertEquals(AMOUNT, instances.size());
     }
 
     public static void parallel(int threads, final Runnable task) throws Exception {

--- a/docker-java/src/test/java/com/github/dockerjava/core/DockerClientImplTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DockerClientImplTest.java
@@ -22,7 +22,7 @@ public class DockerClientImplTest {
             throw new AssertionError();
         } catch (NullPointerException e) {
             // then we get a NPE with expected message
-            assertEquals(e.getMessage(), "Configured serverAddress is null.");
+            assertEquals("Configured serverAddress is null.", e.getMessage());
         }
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/core/DockerClientImplTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DockerClientImplTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertEquals;
 public class DockerClientImplTest {
 
     @Test
-    public void configuredInstanceAuthConfig() throws Exception {
+    public void configuredInstanceAuthConfig() {
         // given a config with null serverAddress
         DefaultDockerClientConfig dockerClientConfig = new DefaultDockerClientConfig(URI.create("tcp://foo"),
             new DockerConfigFile(), null, null, null, "", "", "", null);
@@ -27,7 +27,7 @@ public class DockerClientImplTest {
     }
 
     @Test
-    public void defaultInstanceAuthConfig() throws Exception {
+    public void defaultInstanceAuthConfig() {
 
         System.setProperty("user.home", "target/test-classes/someHomeDir");
 

--- a/docker-java/src/test/java/com/github/dockerjava/core/GoLangFileMatchTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/GoLangFileMatchTest.java
@@ -85,7 +85,7 @@ public class GoLangFileMatchTest {
     public MatchTestCase testCase;
 
     @Test
-    public void testMatch() throws IOException {
+    public void testMatch() {
         String pattern = testCase.pattern;
         String s = testCase.s;
         if (GoLangFileMatch.IS_WINDOWS) {

--- a/docker-java/src/test/java/com/github/dockerjava/core/NameParserTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/NameParserTest.java
@@ -80,31 +80,31 @@ public class NameParserTest {
     @Test
     public void testResolveSimpleRepositoryName() throws Exception {
         HostnameReposName resolved = NameParser.resolveRepositoryName("repository");
-        assertEquals(resolved, new HostnameReposName(AuthConfig.DEFAULT_SERVER_ADDRESS, "repository"));
+        assertEquals(new HostnameReposName(AuthConfig.DEFAULT_SERVER_ADDRESS, "repository"), resolved);
     }
 
     @Test
     public void testResolveRepositoryNameWithNamespace() throws Exception {
         HostnameReposName resolved = NameParser.resolveRepositoryName("namespace/repository");
-        assertEquals(resolved, new HostnameReposName(AuthConfig.DEFAULT_SERVER_ADDRESS, "namespace/repository"));
+        assertEquals(new HostnameReposName(AuthConfig.DEFAULT_SERVER_ADDRESS, "namespace/repository"), resolved);
     }
 
     @Test
     public void testResolveRepositoryNameWithNamespaceAndSHA256() throws Exception {
         HostnameReposName resolved = NameParser.resolveRepositoryName("namespace/repository@sha256:sha256");
-        assertEquals(resolved, new HostnameReposName(AuthConfig.DEFAULT_SERVER_ADDRESS, "namespace/repository@sha256:sha256"));
+        assertEquals(new HostnameReposName(AuthConfig.DEFAULT_SERVER_ADDRESS, "namespace/repository@sha256:sha256"), resolved);
     }
 
     @Test
     public void testResolveRepositoryNameWithNamespaceAndHostname() throws Exception {
         HostnameReposName resolved = NameParser.resolveRepositoryName("localhost:5000/namespace/repository");
-        assertEquals(resolved, new HostnameReposName("localhost:5000", "namespace/repository"));
+        assertEquals(new HostnameReposName("localhost:5000", "namespace/repository"), resolved);
     }
 
     @Test
     public void testResolveRepositoryNameWithNamespaceAndHostnameAndSHA256() throws Exception {
         HostnameReposName resolved = NameParser.resolveRepositoryName("localhost:5000/namespace/repository@sha256:sha256");
-        assertEquals(resolved, new HostnameReposName("localhost:5000", "namespace/repository"));
+        assertEquals(new HostnameReposName("localhost:5000", "namespace/repository"), resolved);
     }
 
     @Test(expected = InvalidRepositoryNameException.class)
@@ -115,36 +115,36 @@ public class NameParserTest {
     @Test
     public void testResolveReposTagWithoutTagSimple() throws Exception {
         ReposTag resolved = NameParser.parseRepositoryTag("repository");
-        assertEquals(resolved, new ReposTag("repository", ""));
+        assertEquals(new ReposTag("repository", ""), resolved);
 
         resolved = NameParser.parseRepositoryTag("namespace/repository");
-        assertEquals(resolved, new ReposTag("namespace/repository", ""));
+        assertEquals(new ReposTag("namespace/repository", ""), resolved);
 
         resolved = NameParser.parseRepositoryTag("localhost:5000/namespace/repository");
-        assertEquals(resolved, new ReposTag("localhost:5000/namespace/repository", ""));
+        assertEquals(new ReposTag("localhost:5000/namespace/repository", ""), resolved);
     }
 
     @Test
     public void testResolveReposTagWithTag() throws Exception {
         ReposTag resolved = NameParser.parseRepositoryTag("repository:tag");
-        assertEquals(resolved, new ReposTag("repository", "tag"));
+        assertEquals(new ReposTag("repository", "tag"), resolved);
 
         resolved = NameParser.parseRepositoryTag("namespace/repository:tag");
-        assertEquals(resolved, new ReposTag("namespace/repository", "tag"));
+        assertEquals(new ReposTag("namespace/repository", "tag"), resolved);
 
         resolved = NameParser.parseRepositoryTag("localhost:5000/namespace/repository:tag");
-        assertEquals(resolved, new ReposTag("localhost:5000/namespace/repository", "tag"));
+        assertEquals(new ReposTag("localhost:5000/namespace/repository", "tag"), resolved);
     }
 
     @Test
     public void testResolveReposTagWithSHA256() throws Exception {
         ReposTag resolved = NameParser.parseRepositoryTag("repository@sha256:sha256");
-        assertEquals(resolved, new ReposTag("repository@sha256:sha256", ""));
+        assertEquals(new ReposTag("repository@sha256:sha256", ""), resolved);
 
         resolved = NameParser.parseRepositoryTag("namespace/repository@sha256:sha256");
-        assertEquals(resolved, new ReposTag("namespace/repository@sha256:sha256", ""));
+        assertEquals(new ReposTag("namespace/repository@sha256:sha256", ""), resolved);
 
         resolved = NameParser.parseRepositoryTag("localhost:5000/namespace/repository@sha256:sha256");
-        assertEquals(resolved, new ReposTag("localhost:5000/namespace/repository@sha256:sha256", ""));
+        assertEquals(new ReposTag("localhost:5000/namespace/repository@sha256:sha256", ""), resolved);
     }
 }

--- a/docker-java/src/test/java/com/github/dockerjava/core/NameParserTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/NameParserTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertEquals;
 public class NameParserTest {
 
     @Test
-    public void testValidateRepoName() throws Exception {
+    public void testValidateRepoName() {
         NameParser.validateRepoName("repository");
         NameParser.validateRepoName("namespace/repository");
         NameParser.validateRepoName("namespace-with-dashes/repository");
@@ -33,87 +33,87 @@ public class NameParserTest {
     }
 
     @Test(expected = InvalidRepositoryNameException.class)
-    public void testValidateRepoNameEmpty() throws Exception {
+    public void testValidateRepoNameEmpty() {
         NameParser.validateRepoName("");
     }
 
     @Test(expected = InvalidRepositoryNameException.class)
-    public void testValidateRepoNameExceedsMaxLength() throws Exception {
+    public void testValidateRepoNameExceedsMaxLength() {
         NameParser.validateRepoName(StringUtils.repeat("repository", 255));
     }
 
     @Test(expected = InvalidRepositoryNameException.class)
-    public void testValidateRepoNameEndWithDash() throws Exception {
+    public void testValidateRepoNameEndWithDash() {
         NameParser.validateRepoName("repository-");
     }
 
     @Test(expected = InvalidRepositoryNameException.class)
-    public void testValidateRepoNameStartWithDash() throws Exception {
+    public void testValidateRepoNameStartWithDash() {
         NameParser.validateRepoName("-repository");
     }
 
     @Test(expected = InvalidRepositoryNameException.class)
-    public void testValidateRepoNameEndWithDot() throws Exception {
+    public void testValidateRepoNameEndWithDot() {
         NameParser.validateRepoName("repository.");
     }
 
     @Test(expected = InvalidRepositoryNameException.class)
-    public void testValidateRepoNameStartWithDot() throws Exception {
+    public void testValidateRepoNameStartWithDot() {
         NameParser.validateRepoName(".repository");
     }
 
     @Test(expected = InvalidRepositoryNameException.class)
-    public void testValidateRepoNameEndWithUnderscore() throws Exception {
+    public void testValidateRepoNameEndWithUnderscore() {
         NameParser.validateRepoName("repository_");
     }
 
     @Test(expected = InvalidRepositoryNameException.class)
-    public void testValidateRepoNameStartWithUnderscore() throws Exception {
+    public void testValidateRepoNameStartWithUnderscore() {
         NameParser.validateRepoName("_repository");
     }
 
     @Test(expected = InvalidRepositoryNameException.class)
-    public void testValidateRepoNameWithColon() throws Exception {
+    public void testValidateRepoNameWithColon() {
         NameParser.validateRepoName("repository:with:colon");
     }
 
     @Test
-    public void testResolveSimpleRepositoryName() throws Exception {
+    public void testResolveSimpleRepositoryName() {
         HostnameReposName resolved = NameParser.resolveRepositoryName("repository");
         assertEquals(new HostnameReposName(AuthConfig.DEFAULT_SERVER_ADDRESS, "repository"), resolved);
     }
 
     @Test
-    public void testResolveRepositoryNameWithNamespace() throws Exception {
+    public void testResolveRepositoryNameWithNamespace() {
         HostnameReposName resolved = NameParser.resolveRepositoryName("namespace/repository");
         assertEquals(new HostnameReposName(AuthConfig.DEFAULT_SERVER_ADDRESS, "namespace/repository"), resolved);
     }
 
     @Test
-    public void testResolveRepositoryNameWithNamespaceAndSHA256() throws Exception {
+    public void testResolveRepositoryNameWithNamespaceAndSHA256() {
         HostnameReposName resolved = NameParser.resolveRepositoryName("namespace/repository@sha256:sha256");
         assertEquals(new HostnameReposName(AuthConfig.DEFAULT_SERVER_ADDRESS, "namespace/repository@sha256:sha256"), resolved);
     }
 
     @Test
-    public void testResolveRepositoryNameWithNamespaceAndHostname() throws Exception {
+    public void testResolveRepositoryNameWithNamespaceAndHostname() {
         HostnameReposName resolved = NameParser.resolveRepositoryName("localhost:5000/namespace/repository");
         assertEquals(new HostnameReposName("localhost:5000", "namespace/repository"), resolved);
     }
 
     @Test
-    public void testResolveRepositoryNameWithNamespaceAndHostnameAndSHA256() throws Exception {
+    public void testResolveRepositoryNameWithNamespaceAndHostnameAndSHA256() {
         HostnameReposName resolved = NameParser.resolveRepositoryName("localhost:5000/namespace/repository@sha256:sha256");
         assertEquals(new HostnameReposName("localhost:5000", "namespace/repository"), resolved);
     }
 
     @Test(expected = InvalidRepositoryNameException.class)
-    public void testResolveRepositoryNameWithIndex() throws Exception {
+    public void testResolveRepositoryNameWithIndex() {
         NameParser.resolveRepositoryName("index.docker.io/repository");
     }
 
     @Test
-    public void testResolveReposTagWithoutTagSimple() throws Exception {
+    public void testResolveReposTagWithoutTagSimple() {
         ReposTag resolved = NameParser.parseRepositoryTag("repository");
         assertEquals(new ReposTag("repository", ""), resolved);
 
@@ -125,7 +125,7 @@ public class NameParserTest {
     }
 
     @Test
-    public void testResolveReposTagWithTag() throws Exception {
+    public void testResolveReposTagWithTag() {
         ReposTag resolved = NameParser.parseRepositoryTag("repository:tag");
         assertEquals(new ReposTag("repository", "tag"), resolved);
 
@@ -137,7 +137,7 @@ public class NameParserTest {
     }
 
     @Test
-    public void testResolveReposTagWithSHA256() throws Exception {
+    public void testResolveReposTagWithSHA256() {
         ReposTag resolved = NameParser.parseRepositoryTag("repository@sha256:sha256");
         assertEquals(new ReposTag("repository@sha256:sha256", ""), resolved);
 

--- a/docker-java/src/test/java/com/github/dockerjava/core/command/FrameReaderTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/command/FrameReaderTest.java
@@ -34,7 +34,7 @@ public class FrameReaderTest {
 
     @Test
     public void stdInBytesFrameReturnsFrame() throws Exception {
-        assertEquals(nextFrame(0, 0, 0, 0, 0, 0, 0, 0), new Frame(StreamType.STDIN, new byte[0]));
+        assertEquals(new Frame(StreamType.STDIN, new byte[0]), nextFrame(0, 0, 0, 0, 0, 0, 0, 0));
     }
 
     private Frame nextFrame(int... bytes) throws IOException {
@@ -44,12 +44,12 @@ public class FrameReaderTest {
 
     @Test
     public void stdOutBytesFrameReturnsFrame() throws Exception {
-        assertEquals(nextFrame(1, 0, 0, 0, 0, 0, 0, 0), new Frame(StreamType.STDOUT, new byte[0]));
+        assertEquals(new Frame(StreamType.STDOUT, new byte[0]), nextFrame(1, 0, 0, 0, 0, 0, 0, 0));
     }
 
     @Test
     public void stdErrBytesFrameReturnsFrame() throws Exception {
-        assertEquals(nextFrame(2, 0, 0, 0, 0, 0, 0, 0), new Frame(StreamType.STDERR, new byte[0]));
+        assertEquals(new Frame(StreamType.STDERR, new byte[0]), nextFrame(2, 0, 0, 0, 0, 0, 0, 0));
     }
 
     private void setBytes(int... bytes) {

--- a/docker-java/src/test/java/com/github/dockerjava/core/util/CompressArchiveUtilTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/util/CompressArchiveUtilTest.java
@@ -241,7 +241,7 @@ public class CompressArchiveUtilTest {
         TarArchiveEntry tarArchiveEntry = getTarArchiveEntry(archive, fileName);
         assertNotNull(tarArchiveEntry);
         assertTrue(tarArchiveEntry.isFile());
-        assertEquals("should be executable", (tarArchiveEntry.getMode() & 0755), 0755);
+        assertEquals("should be executable", 0755, (tarArchiveEntry.getMode() & 0755));
     }
 
     private static void assertTarArchiveEntryIsSymlink(File archive, String fileName, String expectedTarget) throws IOException {

--- a/docker-java/src/test/java/com/github/dockerjava/netty/NettyDockerCmdExecFactoryConfigTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/netty/NettyDockerCmdExecFactoryConfigTest.java
@@ -56,8 +56,8 @@ public class NettyDockerCmdExecFactoryConfigTest {
 
             List<HttpRequest> requests = server.getRequests();
 
-            assertEquals(requests.size(), 1);
-            assertEquals(requests.get(0).uri(), "/v1.23/version");
+            assertEquals(1, requests.size());
+            assertEquals("/v1.23/version", requests.get(0).uri());
         } finally {
             server.stop();
         }
@@ -83,8 +83,8 @@ public class NettyDockerCmdExecFactoryConfigTest {
 
             List<HttpRequest> requests = server.getRequests();
 
-            assertEquals(requests.size(), 1);
-            assertEquals(requests.get(0).uri(), "/version");
+            assertEquals(1, requests.size());
+            assertEquals("/version", requests.get(0).uri());
         } finally {
             server.stop();
         }

--- a/docker-java/src/test/java/com/github/dockerjava/netty/NettyWebTargetTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/netty/NettyWebTargetTest.java
@@ -31,12 +31,12 @@ public class NettyWebTargetTest {
         NettyWebTarget anotherWebTarget = emptyWebTarget.path("/containers/{id}/attach")
                 .resolveTemplate("id", "2cfada4e3c07").queryParam("stdin", "true");
 
-        assertEquals(new NettyWebTarget(JSONTestHelper.getMapper(), channelProvider, "DUMMY"), emptyWebTarget);
+        assertEquals(emptyWebTarget, new NettyWebTarget(JSONTestHelper.getMapper(), channelProvider, "DUMMY"));
 
-        assertEquals(new NettyWebTarget(JSONTestHelper.getMapper(), channelProvider, "DUMMY").path("/containers/d03da378b592/attach")
-                .queryParam("logs", "true"), initWebTarget);
+        assertEquals(initWebTarget, new NettyWebTarget(JSONTestHelper.getMapper(), channelProvider, "DUMMY").path("/containers/d03da378b592/attach")
+                .queryParam("logs", "true"));
 
-        assertEquals(new NettyWebTarget(JSONTestHelper.getMapper(), channelProvider, "DUMMY").path("/containers/2cfada4e3c07/attach")
-                .queryParam("stdin", "true"), anotherWebTarget);
+        assertEquals(anotherWebTarget, new NettyWebTarget(JSONTestHelper.getMapper(), channelProvider, "DUMMY").path("/containers/2cfada4e3c07/attach")
+                .queryParam("stdin", "true"));
     }
 }

--- a/docker-java/src/test/java/com/github/dockerjava/netty/NettyWebTargetTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/netty/NettyWebTargetTest.java
@@ -17,12 +17,12 @@ public class NettyWebTargetTest {
     private ChannelProvider channelProvider;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         MockitoAnnotations.initMocks(this);
     }
 
     @Test
-    public void verifyImmutability() throws Exception {
+    public void verifyImmutability() {
         NettyWebTarget emptyWebTarget = new NettyWebTarget(JSONTestHelper.getMapper(), channelProvider, "DUMMY");
 
         NettyWebTarget initWebTarget = emptyWebTarget.path("/containers/{id}/attach").resolveTemplate("id", "d03da378b592")

--- a/docker-java/src/test/java/com/github/dockerjava/netty/handler/FramedResponseStreamHandlerTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/netty/handler/FramedResponseStreamHandlerTest.java
@@ -87,7 +87,7 @@ public class FramedResponseStreamHandlerTest {
     objectUnderTest.channelRead0(Mockito.mock(ChannelHandlerContext.class), Unpooled.wrappedBuffer(msg));
 
     // Assert result
-    assertEquals(responseHandler.frames.get(0).toString(), "RAW: ");
+    assertEquals("RAW: ", responseHandler.frames.get(0).toString());
   }
 
   @Test
@@ -117,7 +117,7 @@ public class FramedResponseStreamHandlerTest {
     objectUnderTest.channelRead0(Mockito.mock(ChannelHandlerContext.class), Unpooled.wrappedBuffer(msg));
 
     // Assert result
-    assertEquals(responseHandler.frames.get(0).toString(), "STDIN: ");
+    assertEquals("STDIN: ", responseHandler.frames.get(0).toString());
   }
 
   @Test
@@ -132,7 +132,7 @@ public class FramedResponseStreamHandlerTest {
     objectUnderTest.channelRead0(Mockito.mock(ChannelHandlerContext.class), Unpooled.wrappedBuffer(msg));
 
     // Assert result
-    assertEquals(responseHandler.frames.get(0).toString(), "STDOUT: ");
+    assertEquals("STDOUT: ", responseHandler.frames.get(0).toString());
   }
 
   @Test
@@ -147,7 +147,7 @@ public class FramedResponseStreamHandlerTest {
     objectUnderTest.channelRead0(Mockito.mock(ChannelHandlerContext.class), Unpooled.wrappedBuffer(msg));
 
     // Assert result
-    assertEquals(responseHandler.frames.get(0).toString(), "STDERR: ");
+    assertEquals("STDERR: ", responseHandler.frames.get(0).toString());
   }
 
   @Test
@@ -162,7 +162,7 @@ public class FramedResponseStreamHandlerTest {
     objectUnderTest.channelRead0(Mockito.mock(ChannelHandlerContext.class), Unpooled.wrappedBuffer(msg));
 
     // Assert result
-    assertEquals(responseHandler.frames.get(0).toString(), "STDOUT: ");
+    assertEquals("STDOUT: ", responseHandler.frames.get(0).toString());
   }
 
   @Test
@@ -179,6 +179,6 @@ public class FramedResponseStreamHandlerTest {
     objectUnderTest.exceptionCaught(Mockito.mock(ChannelHandlerContext.class), throwable);
 
     // Assert result
-    assertEquals(responseHandler.exceptions.get(0).getCause(), exception);
+    assertEquals(exception, responseHandler.exceptions.get(0).getCause());
   }
 }

--- a/docker-java/src/test/java/com/github/dockerjava/netty/handler/HttpResponseStreamHandlerTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/netty/handler/HttpResponseStreamHandlerTest.java
@@ -32,10 +32,10 @@ public class HttpResponseStreamHandlerTest {
         ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
         ByteBuf buffer = generateByteBuf();
         ByteBuf readBuffer = buffer.copy();
-        assertEquals(buffer.refCnt(), 1);
+        assertEquals(1, buffer.refCnt());
         streamHandler.channelRead(ctx, buffer);
         streamHandler.channelInactive(ctx);
-        assertEquals(buffer.refCnt(), 0);
+        assertEquals(0, buffer.refCnt());
         try (InputStream inputStream = callback.getInputStream()) {
             assertTrue(IOUtils.contentEquals(inputStream, new ByteBufInputStream(readBuffer)));
         }
@@ -49,10 +49,10 @@ public class HttpResponseStreamHandlerTest {
         ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
         ByteBuf buffer = generateByteBuf();
         ByteBuf readBuffer = buffer.copy();
-        assertEquals(buffer.refCnt(), 1);
+        assertEquals(1, buffer.refCnt());
         streamHandler.channelRead(ctx, buffer);
         streamHandler.channelInactive(ctx);
-        assertEquals(buffer.refCnt(), 0);
+        assertEquals(0, buffer.refCnt());
         try (InputStream inputStream = callback.getInputStream()) {
             for (int i = 0; i < readBuffer.readableBytes(); i++) {
                 int b = inputStream.read();


### PR DESCRIPTION
Fixes #1923

### Parameter order

Docker-Java used to implement its tests with [TestNG](https://testng.org/doc/) until #909.
In TestNG, `assertEquals` has a different parameter order (_actual_, _expected_) compared to JUnit (_expected_, _actual_).

Some old tests still use the old parameter ordering, some tests follow the JUnit semantics.
There are even test classes which mix both forms.

While this does not affect the validity of the tests, it confuses the reader and therefore should be cleaned up.

### Housekeeping

Being at it, I did some basic housekeeping on the tests: I removed some unused imports and unneccessary throws declarations.