### PR TITLE
Modify logging in callbacks

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/async/ResultCallbackTemplate.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/async/ResultCallbackTemplate.java
@@ -48,14 +48,12 @@ public abstract class ResultCallbackTemplate<RC_T extends ResultCallback<A_RES_T
             this.firstError = throwable;
         }
 
+        LOGGER.debug("Error during callback", throwable);
+
         try {
-            LOGGER.error("Error during callback", throwable);
-        } finally {
-            try {
-                close();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+            close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/BuildImageResultCallback.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/BuildImageResultCallback.java
@@ -31,7 +31,7 @@ public class BuildImageResultCallback extends ResultCallbackTemplate<BuildImageR
         } else if (item.isErrorIndicated()) {
             this.error = item.getError();
         }
-        LOGGER.debug(item.toString());
+        LOGGER.debug("{}", item);
     }
 
     /**

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/LoadImageCallback.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/LoadImageCallback.java
@@ -22,7 +22,7 @@ public class LoadImageCallback extends ResultCallbackTemplate<LoadImageCallback,
             this.error = item.getError();
         }
 
-        LOGGER.debug(item.toString());
+        LOGGER.debug("{}", item);
     }
 
     public String awaitMessage() {

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/PullImageResultCallback.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/PullImageResultCallback.java
@@ -41,7 +41,7 @@ public class PullImageResultCallback extends ResultCallback.Adapter<PullResponse
             handleDockerClientResponse(item);
         }
 
-        LOGGER.debug(item.toString());
+        LOGGER.debug("{}", item);
     }
 
     private void checkForDockerSwarmResponse(PullResponseItem item) {

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/WaitContainerResultCallback.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/WaitContainerResultCallback.java
@@ -27,7 +27,7 @@ public class WaitContainerResultCallback extends ResultCallbackTemplate<WaitCont
     @Override
     public void onNext(WaitResponse waitResponse) {
         this.waitResponse = waitResponse;
-        LOGGER.debug(waitResponse.toString());
+        LOGGER.debug("{}", waitResponse);
     }
 
     /**


### PR DESCRIPTION
We are feeling some pain from this log message.  In our application, we allow the underlying docker engine to be patched/restarted without stopping the entire application.  Therefore, when docker interactions throw Exceptions, they are caught, and a WARN message is emitted.  However, in this one case, the `docker-java` library is logging an ERROR and it triggers our health/status alarms.

The docker library should not be logging error messages - all issues should be communicated via normal Exception handling.

Also, the logger is named `ResultCallbackTemplate`, which is an inherited class, so we had no idea, at a cursory view, which parent class was having the issue since the errors we see are typically generic "cannot connect to docker" type messages.

```
LOGGER.error("Error during callback", throwable);
```

Also, just for cleanup:

```
LOGGER.debug(item.toString());
// can be re-written as LOGGER.debug("{}", item);
```

This will change things so that the object is materialized into a String, only when DEBUG is enabled.  Currently, the object is always serialized, and then the resulting string is tossed away if the logger is higher than DEBUG.


