### PR TITLE
Bump netty version and update to support Arm architecture 

### DIFF
--- a/docker-java-transport-netty/pom.xml
+++ b/docker-java-transport-netty/pom.xml
@@ -17,7 +17,46 @@
 
 	<properties>
 		<automatic.module.name>com.github.dockerjava.transport.netty</automatic.module.name>
+		<osmaven.version>1.7.1</osmaven.version>
 	</properties>
+
+	<profiles>
+		<profile>
+			<id>mac</id>
+			<activation>
+				<os>
+					<!-- Automatically active on mac with native extensions -->
+					<family>mac</family>
+				</os>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>io.netty</groupId>
+					<artifactId>netty-transport-native-kqueue</artifactId>
+					<version>${netty.version}</version>
+					<classifier>${os.detected.classifier}</classifier>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>linux</id>
+			<activation>
+				<os>
+					<!-- Automatically active on linux with native extensions -->
+					<family>unix</family>
+					<name>linux</name>
+				</os>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>io.netty</groupId>
+					<artifactId>netty-transport-native-epoll</artifactId>
+					<version>${netty.version}</version>
+					<classifier>${os.detected.classifier}</classifier>
+				</dependency>
+			</dependencies>
+		</profile>
+	</profiles>
 
 	<dependencies>
 		<dependency>
@@ -25,37 +64,32 @@
 			<artifactId>docker-java-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler-proxy</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-epoll</artifactId>
-            <version>${netty.version}</version>
-            <classifier>linux-x86_64</classifier>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-kqueue</artifactId>
-            <version>${netty.version}</version>
-            <classifier>osx-x86_64</classifier>
-        </dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-codec-http</artifactId>
+			<version>${netty.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-handler</artifactId>
+			<version>${netty.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-handler-proxy</artifactId>
+			<version>${netty.version}</version>
+		</dependency>
 	</dependencies>
 
 	<build>
+		<extensions>
+			<!-- Use os-maven-plugin extension similar to netty-all to support native dependencies classifier -->
+			<extension>
+				<groupId>kr.motd.maven</groupId>
+				<artifactId>os-maven-plugin</artifactId>
+				<version>${osmaven.version}</version>
+			</extension>
+		</extensions>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.felix</groupId>

--- a/docker-java-transport-netty/pom.xml
+++ b/docker-java-transport-netty/pom.xml
@@ -79,6 +79,17 @@
 			<artifactId>netty-handler-proxy</artifactId>
 			<version>${netty.version}</version>
 		</dependency>
+		<!-- The native dependencies with the classifier are added by the native-dependencies profile. -->
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-transport-classes-epoll</artifactId>
+			<version>${netty.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-transport-classes-kqueue</artifactId>
+			<version>${netty.version}</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 
 		<!-- test dependencies -->
 		<logback.version>1.2.3</logback.version>
-		<netty.version>4.1.46.Final</netty.version>
+		<netty.version>4.1.84.Final</netty.version>
 		<hamcrest.library.version>2.2</hamcrest.library.version>
 		<hamcrest.jpa-matchers>1.8</hamcrest.jpa-matchers>
 		<lambdaj.version>2.3.3</lambdaj.version>


### PR DESCRIPTION
* Running the library on a Mac based M1/2 Arm CPU with a more recent `netty` version throws the error 
```
Caused by: java.lang.UnsatisfiedLinkError: failed to load the required native library
	at io.netty.channel.kqueue.KQueue.ensureAvailability(KQueue.java:71)
	at io.netty.channel.kqueue.KQueueEventLoop.<clinit>(KQueueEventLoop.java:54)
	at io.netty.channel.kqueue.KQueueEventLoopGroup.newChild(KQueueEventLoopGroup.java:184)
	at io.netty.channel.kqueue.KQueueEventLoopGroup.newChild(KQueueEventLoopGroup.java:33)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:84)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:60)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:49)
	at io.netty.channel.MultithreadEventLoopGroup.<init>(MultithreadEventLoopGroup.java:59)
	at io.netty.channel.kqueue.KQueueEventLoopGroup.<init>(KQueueEventLoopGroup.java:111)
	at io.netty.channel.kqueue.KQueueEventLoopGroup.<init>(KQueueEventLoopGroup.java:98)
	at io.netty.channel.kqueue.KQueueEventLoopGroup.<init>(KQueueEventLoopGroup.java:74)
	at com.github.dockerjava.netty.NettyDockerCmdExecFactory$UnixDomainSocketInitializer.kqueueGroup(NettyDockerCmdExecFactory.java:167)
	at com.github.dockerjava.netty.NettyDockerCmdExecFactory$UnixDomainSocketInitializer.init(NettyDockerCmdExecFactory.java:146)
	at com.github.dockerjava.netty.NettyDockerCmdExecFactory.init(NettyDockerCmdExecFactory.java:115)
	at com.github.dockerjava.core.DockerClientImpl.withDockerCmdExecFactory(DockerClientImpl.java:252)
	...
Caused by: java.lang.UnsatisfiedLinkError: could not load a native library: netty_transport_native_kqueue_aarch_64
	at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:224)
	at io.netty.channel.kqueue.Native.loadNativeLibrary(Native.java:155)
	at io.netty.channel.kqueue.Native.<clinit>(Native.java:76)
	at io.netty.channel.kqueue.KQueue.<clinit>(KQueue.java:38)
````
* Updating pom similar to netty's [all/pom.xml](https://github.com/netty/netty/blob/13e143c2aeec7cc38fa54095189ed4bd762a2975/all/pom.xml#L130-L141C1) to inspect OS type and include the correct native dependencies

* Output of `mvn dependency:tree` 
```
[INFO] ---------< com.github.docker-java:docker-java-transport-netty >---------
[INFO] Building docker-java-transport-netty 0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ docker-java-transport-netty ---
[INFO] com.github.docker-java:docker-java-transport-netty:jar:0-SNAPSHOT
[INFO] +- com.github.docker-java:docker-java-core:jar:0-SNAPSHOT:compile
[INFO] |  +- com.github.docker-java:docker-java-api:jar:0-SNAPSHOT:compile
[INFO] |  |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.10.3:compile
[INFO] |  +- com.github.docker-java:docker-java-transport:jar:0-SNAPSHOT:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.30:compile
[INFO] |  +- commons-io:commons-io:jar:2.6:compile
[INFO] |  +- org.apache.commons:commons-compress:jar:1.21:compile
[INFO] |  +- org.apache.commons:commons-lang3:jar:3.12.0:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.10.3:compile
[INFO] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.10.3:compile
[INFO] |  +- com.google.guava:guava:jar:19.0:compile
[INFO] |  \- org.bouncycastle:bcpkix-jdk15on:jar:1.64:compile
[INFO] |     \- org.bouncycastle:bcprov-jdk15on:jar:1.64:compile
[INFO] +- io.netty:netty-codec-http:jar:4.1.84.Final:compile
[INFO] |  +- io.netty:netty-common:jar:4.1.84.Final:compile
[INFO] |  +- io.netty:netty-buffer:jar:4.1.84.Final:compile
[INFO] |  +- io.netty:netty-transport:jar:4.1.84.Final:compile
[INFO] |  \- io.netty:netty-codec:jar:4.1.84.Final:compile
[INFO] +- io.netty:netty-handler:jar:4.1.84.Final:compile
[INFO] |  +- io.netty:netty-resolver:jar:4.1.84.Final:compile
[INFO] |  \- io.netty:netty-transport-native-unix-common:jar:4.1.84.Final:compile
[INFO] +- io.netty:netty-handler-proxy:jar:4.1.84.Final:compile
[INFO] |  \- io.netty:netty-codec-socks:jar:4.1.84.Final:compile
[INFO] +- io.netty:netty-transport-classes-epoll:jar:4.1.84.Final:compile
[INFO] +- io.netty:netty-transport-classes-kqueue:jar:4.1.84.Final:compile
[INFO] \- io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.84.Final:compile
```