### PR TITLE
Add setter to auths if it's null to avoid NPE when getting auths

### DIFF
--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DockerConfigFile.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DockerConfigFile.java
@@ -1,6 +1,7 @@
 package com.github.dockerjava.core;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.model.AuthConfig;
@@ -28,7 +29,7 @@ public class DockerConfigFile {
     };
 
     @JsonProperty
-    private final Map<String, AuthConfig> auths;
+    private Map<String, AuthConfig> auths;
 
     @JsonProperty
     private String currentContext;
@@ -44,6 +45,11 @@ public class DockerConfigFile {
     @Nonnull
     public Map<String, AuthConfig> getAuths() {
         return auths;
+    }
+
+    @JsonSetter
+    public void setAuths(Map<String, AuthConfig> authConfigMap) {
+        auths = (authConfigMap == null || authConfigMap.size() == 0) ? new HashMap<>() : authConfigMap;
     }
 
     void addAuthConfig(AuthConfig config) {

--- a/docker-java/src/test/java/com/github/dockerjava/core/DockerConfigFileTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/DockerConfigFileTest.java
@@ -164,6 +164,12 @@ public class DockerConfigFileTest {
         assertThat(runTest("idontexist"), is(expected));
     }
 
+    @Test
+    public void validJsonAuthsNull() throws IOException {
+        DockerConfigFile expected = new DockerConfigFile();
+        assertThat(runTest("validJsonAuthsNull"), is(expected));
+    }
+
     private DockerConfigFile runTest(String testFileName) throws IOException {
         return DockerConfigFile.loadConfig(JSONTestHelper.getMapper(), new File(FILESROOT, testFileName).getAbsolutePath());
     }

--- a/docker-java/src/test/resources/testAuthConfigFile/validJsonAuthsNull/config.json
+++ b/docker-java/src/test/resources/testAuthConfigFile/validJsonAuthsNull/config.json
@@ -1,0 +1,9 @@
+{
+    "auths": null,
+    "credsStore": "desktop",
+    "plugins": {
+        "-x-cli-hints": {
+            "enabled": "true"
+        }
+    }
+}


### PR DESCRIPTION
This is to resolve #2138 where `NullPointerException` is thrown if `auths` is `null` from `config.json`.