### PR TITLE
build HttpClient with useSystemProperties()

### DIFF
--- a/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/ApacheDockerHttpClientImpl.java
+++ b/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/ApacheDockerHttpClientImpl.java
@@ -120,9 +120,9 @@ class ApacheDockerHttpClientImpl implements DockerHttpClient {
         }
 
         httpClient = HttpClients.custom()
-            .useSystemProperties()
             .setRequestExecutor(new HijackingHttpRequestExecutor(null))
             .setConnectionManager(connectionManager)
+            .useSystemProperties()
             .setDefaultRequestConfig(defaultRequest.build())
             .disableConnectionState()
             .build();

--- a/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/ApacheDockerHttpClientImpl.java
+++ b/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/ApacheDockerHttpClientImpl.java
@@ -124,6 +124,7 @@ class ApacheDockerHttpClientImpl implements DockerHttpClient {
             .setConnectionManager(connectionManager)
             .setDefaultRequestConfig(defaultRequest.build())
             .disableConnectionState()
+            .useSystemProperties()
             .build();
     }
 

--- a/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/ApacheDockerHttpClientImpl.java
+++ b/docker-java-transport-httpclient5/src/main/java/com/github/dockerjava/httpclient5/ApacheDockerHttpClientImpl.java
@@ -120,11 +120,11 @@ class ApacheDockerHttpClientImpl implements DockerHttpClient {
         }
 
         httpClient = HttpClients.custom()
+            .useSystemProperties()
             .setRequestExecutor(new HijackingHttpRequestExecutor(null))
             .setConnectionManager(connectionManager)
             .setDefaultRequestConfig(defaultRequest.build())
             .disableConnectionState()
-            .useSystemProperties()
             .build();
     }
 


### PR DESCRIPTION
related to #2158 

building the HttpClient with useSystemProperties() should allow users to specify proxy (and other settings) with java system properties according to https://hc.apache.org/httpcomponents-client-5.2.x/current/httpclient5/apidocs/
