### PR TITLE
Add units (nanoseconds) to HealthCheck.

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
@@ -63,7 +63,7 @@ public class HealthCheck extends DockerObject implements Serializable {
         return timeout;
     }
 
-    /***
+    /**
      * Set interval in nanoseconds
      * @return this
      */

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
@@ -53,7 +53,7 @@ public class HealthCheck extends DockerObject implements Serializable {
      * @since 1.26
      */
     @JsonProperty("StartPeriod")
-    private Long startPeriod; // in nanoseconds
+    private Long startPeriod;
 
     public Long getInterval() {
         return interval;

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
@@ -72,7 +72,7 @@ public class HealthCheck extends DockerObject implements Serializable {
         return this;
     }
 
-    /***
+    /**
      * Set timeout in nanoseconds
      * @return this
      */

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
@@ -103,7 +103,7 @@ public class HealthCheck extends DockerObject implements Serializable {
         return startPeriod;
     }
 
-    /***
+    /**
      * Set startPeriod in nanoseconds
      * @return this
      */

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
@@ -65,7 +65,7 @@ public class HealthCheck extends DockerObject implements Serializable {
 
     /**
      * Set interval in nanoseconds
-     * @return this
+     * @return this {@link HealthCheck} instance
      */
     public HealthCheck withInterval(Long interval) {
         this.interval = interval;

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
@@ -32,10 +32,10 @@ public class HealthCheck extends DockerObject implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @JsonProperty("Interval")
-    private Long interval;
+    private Long interval; // in nanoseconds
 
     @JsonProperty("Timeout")
-    private Long timeout;
+    private Long timeout; // in nanoseconds
 
     /**
      * @since 1.26
@@ -53,7 +53,7 @@ public class HealthCheck extends DockerObject implements Serializable {
      * @since 1.26
      */
     @JsonProperty("StartPeriod")
-    private Long startPeriod;
+    private Long startPeriod; // in nanoseconds
 
     public Long getInterval() {
         return interval;
@@ -63,11 +63,19 @@ public class HealthCheck extends DockerObject implements Serializable {
         return timeout;
     }
 
+    /***
+     * Set interval in nanoseconds
+     * @return this
+     */
     public HealthCheck withInterval(Long interval) {
         this.interval = interval;
         return this;
     }
 
+    /***
+     * Set timeout in nanoseconds
+     * @return this
+     */
     public HealthCheck withTimeout(Long timeout) {
         this.timeout = timeout;
         return this;
@@ -95,6 +103,10 @@ public class HealthCheck extends DockerObject implements Serializable {
         return startPeriod;
     }
 
+    /***
+     * Set startPeriod in nanoseconds
+     * @return this
+     */
     public HealthCheck withStartPeriod(Long startPeriod) {
         this.startPeriod = startPeriod;
         return this;

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
@@ -74,7 +74,7 @@ public class HealthCheck extends DockerObject implements Serializable {
 
     /**
      * Set timeout in nanoseconds
-     * @return this
+     * @return this {@link HealthCheck} instance
      */
     public HealthCheck withTimeout(Long timeout) {
         this.timeout = timeout;

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
@@ -105,7 +105,7 @@ public class HealthCheck extends DockerObject implements Serializable {
 
     /**
      * Set startPeriod in nanoseconds
-     * @return this
+     * @return this {@link HealthCheck} instance
      */
     public HealthCheck withStartPeriod(Long startPeriod) {
         this.startPeriod = startPeriod;

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
@@ -35,7 +35,7 @@ public class HealthCheck extends DockerObject implements Serializable {
     private Long interval;
 
     @JsonProperty("Timeout")
-    private Long timeout; // in nanoseconds
+    private Long timeout;
 
     /**
      * @since 1.26

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
@@ -32,7 +32,7 @@ public class HealthCheck extends DockerObject implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @JsonProperty("Interval")
-    private Long interval; // in nanoseconds
+    private Long interval;
 
     @JsonProperty("Timeout")
     private Long timeout; // in nanoseconds


### PR DESCRIPTION
I need to add a manual healtcheck in code. I found the com.github.dockerjava.api.model.HealthCheck:

```
return new HealthCheck()
                .withTest(Arrays.asList("CMD", "curl", "-f", url))
                .withStartPeriod(SECONDS.toNanos(60))
                .withInterval(SECONDS.toNanos(30))
                .withTimeout(SECONDS.toNanos(30))
                .withRetries(50);
```

However, I've no idea what the correct unit should be.
I've tried seconds (too small), millis (too small value too), micro (seems to work, but still timing out) and nanos (seems to be the correct one).