### PR TITLE
Fixing flaky test `ListContainersCmdIT.testStatusFilter`

### DIFF
--- a/docker-java/src/test/java/com/github/dockerjava/cmd/ListContainersCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/ListContainersCmdIT.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static ch.lambdaj.Lambda.filter;
 import static com.github.dockerjava.api.model.HostConfig.newHostConfig;
@@ -243,14 +244,15 @@ public class ListContainersCmdIT extends CmdIT {
     }
 
     @Test
-    public void shouldFilterByExitedStatus() {
+    public void shouldFilterByExitedStatus() throws InterruptedException {
         String containerId = dockerRule.getClient().createContainerCmd(DEFAULT_IMAGE)
                 .withCmd("sh", "-c", "sleep 99999")
                 .withLabels(testLabel)
                 .exec()
                 .getId();
         dockerRule.getClient().startContainerCmd(containerId).exec();
-        dockerRule.getClient().killContainerCmd(containerId).exec();
+        dockerRule.getClient().stopContainerCmd(containerId).exec();
+        dockerRule.getClient().waitContainerCmd(containerId).start().awaitCompletion(15, TimeUnit.SECONDS);
 
         List<Container> filteredContainers = dockerRule.getClient().listContainersCmd()
                 .withShowAll(true)


### PR DESCRIPTION
**Changes**

- Decouple the big test (`testStatusFilter `) into 4 smaller tests for checking each status independently (created, running, paused, exited)
- Add `waitContainer` - the same way as it is done in https://github.com/docker-java/docker-java/pull/2189