### PR TITLE
Copy symbolic links to directories as symlinks instead of cloning the directories

### DIFF
--- a/docker-java-core/src/main/java/com/github/dockerjava/core/dockerfile/Dockerfile.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/dockerfile/Dockerfile.java
@@ -1,6 +1,8 @@
 package com.github.dockerjava.core.dockerfile;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -203,7 +205,7 @@ public class Dockerfile {
 
             if (files.length != 0) {
                 for (File f : files) {
-                    if (f.isDirectory()) {
+                    if (f.isDirectory() && !Files.isSymbolicLink(Paths.get(f.getAbsolutePath()))) {
                         addFilesInDirectory(f);
                     } else if (effectiveMatchingIgnorePattern(f) == null) {
                         filesToAdd.add(f);


### PR DESCRIPTION
This fixes issue [2193](https://github.com/docker-java/docker-java/issues/2193).

### Testing

I ran a build using `mvn clean install -DskipITs`. It would be good if someone could trigger a build including integration tests.