### PR TITLE
Implemented the `SizeRw` field in the `InspectContainerResponse` class.

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
@@ -63,6 +63,9 @@ public class InspectContainerResponse extends DockerObject {
     @JsonProperty("SizeRootFs")
     private Integer sizeRootFs;
 
+    @JsonPropertY("SizeRw")
+    private Integer sizeRw;
+
     @JsonProperty("Image")
     private String imageId;
 
@@ -123,6 +126,10 @@ public class InspectContainerResponse extends DockerObject {
 
     public Integer getSizeRootFs() {
         return sizeRootFs;
+    }
+
+    public Inte ger getSizeRw() {
+        return sizeRw;
     }
 
     public String getCreated() {

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/InspectContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/InspectContainerCmdIT.java
@@ -101,6 +101,8 @@ public class InspectContainerCmdIT extends CmdIT {
         if (isNotSwarm(dockerRule.getClient())) {
             assertNotNull(containerInfo.getSizeRootFs());
             assertTrue(containerInfo.getSizeRootFs().intValue() > 0);
+            assertNotNull(containerInfo.getSizeRw());
+            assertTrue(containerInfo.getSizeRw().intValue() == 0);
         }
     }
 

--- a/docker-java/src/test/resources/com/github/dockerjava/api/command/inspectContainerResponse_full_1_26a.json
+++ b/docker-java/src/test/resources/com/github/dockerjava/api/command/inspectContainerResponse_full_1_26a.json
@@ -6,6 +6,7 @@
       "postgres"
     ],
     "SizeRootFs" : null,
+    "SizeRw" : null,
     "HostConfig" : {
       "KernelMemory" : 0,
       "MemorySwappiness" : -1,

--- a/docker-java/src/test/resources/samples/1.22/containers/json/filter1.json
+++ b/docker-java/src/test/resources/samples/1.22/containers/json/filter1.json
@@ -10,6 +10,7 @@
     "Created": 1455662451,
     "Ports": [],
     "SizeRootFs": 1113554,
+    "SizeRw": 0,
     "Labels": {},
     "Status": "Up Less than a second",
     "HostConfig": {


### PR DESCRIPTION
This PR implements the `SizeRw` field that is missing from the docker inspect response. This field is present in the response of docker list, but is not present in docker inspect.

One other concern I had while writing this PR is that my SizeRw deliberately mirrors SizeRootFs, but SizeRootFs is implemented as an integer in the inspect command. I suspect they should be longs instead to avoid overflows. Within the list command, they are implemented as longs.