### PR TITLE
Use long rather than int for sizeRw and sizeRootFs

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
@@ -61,10 +61,10 @@ public class InspectContainerResponse extends DockerObject {
     private String id;
 
     @JsonProperty("SizeRootFs")
-    private Integer sizeRootFs;
+    private Long sizeRootFs;
 
     @JsonProperty("SizeRw")
-    private Integer sizeRw;
+    private Long sizeRw;
 
     @JsonProperty("Image")
     private String imageId;
@@ -124,11 +124,11 @@ public class InspectContainerResponse extends DockerObject {
         return id;
     }
 
-    public Integer getSizeRootFs() {
+    public Long getSizeRootFs() {
         return sizeRootFs;
     }
 
-    public Integer getSizeRw() {
+    public Long getSizeRw() {
         return sizeRw;
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/InspectContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/InspectContainerCmdIT.java
@@ -100,9 +100,9 @@ public class InspectContainerCmdIT extends CmdIT {
         // TODO check swarm
         if (isNotSwarm(dockerRule.getClient())) {
             assertNotNull(containerInfo.getSizeRootFs());
-            assertTrue(containerInfo.getSizeRootFs().intValue() > 0);
+            assertTrue(containerInfo.getSizeRootFs().longValue() > 0L);
             assertNotNull(containerInfo.getSizeRw());
-            assertTrue(containerInfo.getSizeRw().intValue() == 0);
+            assertTrue(containerInfo.getSizeRw().longValue() == 0L);
         }
     }
 


### PR DESCRIPTION
Currently docker-java uses an integer to represent SizeRw and SizeRootFs. This value however represents the an amount of bytes, meaning the integer could easily overflow.

This MR changes these two fields to longs.

Note that Container.java also implements a SizeRw and SizeRootFs fields. Here, the fields are represented as longs rather than integers, so it would make sense that the inspect container command also returns longs.