### PR TITLE
Add StartInterval to health check since it will be supported by the 1.44 docker API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Ignore all build/dist directories
 target
+dependency-reduced-pom.xml
 
 # Ignore InteliJ Idea project files
 .idea/

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/HealthCheck.java
@@ -55,6 +55,12 @@ public class HealthCheck extends DockerObject implements Serializable {
     @JsonProperty("StartPeriod")
     private Long startPeriod;
 
+    /**
+     * @since 1.44
+     */
+    @JsonProperty("StartInterval")
+    private Long startInterval;
+
     public Long getInterval() {
         return interval;
     }
@@ -109,6 +115,19 @@ public class HealthCheck extends DockerObject implements Serializable {
      */
     public HealthCheck withStartPeriod(Long startPeriod) {
         this.startPeriod = startPeriod;
+        return this;
+    }
+
+    public Long getStartInterval() {
+        return startInterval;
+    }
+
+    /**
+     * Set startInterval in nanoseconds
+     * @return this {@link HealthCheck} instance
+     */
+    public HealthCheck withStartInterval(Long startInterval) {
+        this.startInterval = startInterval;
         return this;
     }
 }

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/RemoteApiVersion.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/RemoteApiVersion.java
@@ -93,6 +93,8 @@ public class RemoteApiVersion implements Serializable {
     public static final RemoteApiVersion VERSION_1_40 = RemoteApiVersion.create(1, 40);
     public static final RemoteApiVersion VERSION_1_41 = RemoteApiVersion.create(1, 41);
     public static final RemoteApiVersion VERSION_1_42 = RemoteApiVersion.create(1, 42);
+    public static final RemoteApiVersion VERSION_1_43 = RemoteApiVersion.create(1, 43);
+    public static final RemoteApiVersion VERSION_1_44 = RemoteApiVersion.create(1, 44);
 
 
     /**

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/HealthCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/HealthCmdIT.java
@@ -1,0 +1,86 @@
+package com.github.dockerjava.cmd;
+
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.command.HealthState;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.exception.DockerException;
+import com.github.dockerjava.api.model.HealthCheck;
+import com.github.dockerjava.core.RemoteApiVersion;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static com.github.dockerjava.junit.DockerMatchers.isGreaterOrEqual;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assume.assumeThat;
+
+public class HealthCmdIT extends CmdIT {
+    private final Logger LOG = LoggerFactory.getLogger(HealthCmdIT.class);
+
+    @Test
+    public void healthiness() throws DockerException, Exception {
+        CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox")
+            .withCmd("nc", "-l",  "-p", "8080")
+            .withHealthcheck(new HealthCheck()
+                .withTest(Arrays.asList("sh", "-c", "netstat -ltn | grep 8080"))
+                .withInterval(TimeUnit.SECONDS.toNanos(1))
+                .withTimeout(TimeUnit.MINUTES.toNanos(1))
+                .withStartPeriod(TimeUnit.SECONDS.toNanos(30))
+                .withRetries(10))
+            .exec();
+
+        LOG.info("Created container: {}", container.toString());
+        assertThat(container.getId(), not(is(emptyString())));
+        dockerRule.getClient().startContainerCmd(container.getId()).exec();
+
+        HealthState healthState = await().atMost(60L, TimeUnit.SECONDS).until(
+            () -> {
+                InspectContainerResponse inspectContainerResponse = dockerRule.getClient().inspectContainerCmd(container.getId()).exec();
+                return inspectContainerResponse.getState().getHealth();
+            },
+            Objects::nonNull
+        );
+
+        assertThat(healthState.getStatus(), is(equalTo("healthy")));
+    }
+
+    @Test
+    public void healthiness_startInterval() throws Exception {
+        assumeThat("API version should be >= 1.44", dockerRule, isGreaterOrEqual(RemoteApiVersion.VERSION_1_44));
+
+        CreateContainerResponse container = dockerRule.getClient().createContainerCmd("busybox")
+            .withCmd("nc", "-l",  "-p", "8080")
+            .withHealthcheck(new HealthCheck()
+                .withTest(Arrays.asList("sh", "-c", "netstat -ltn | grep 8080"))
+                .withInterval(TimeUnit.SECONDS.toNanos(1))
+                .withTimeout(TimeUnit.MINUTES.toNanos(1))
+                .withStartPeriod(TimeUnit.SECONDS.toNanos(30))
+                .withStartInterval(TimeUnit.SECONDS.toNanos(5))
+                .withRetries(10))
+            .exec();
+
+        LOG.info("Created container: {}", container.toString());
+        assertThat(container.getId(), not(is(emptyString())));
+        dockerRule.getClient().startContainerCmd(container.getId()).exec();
+
+        HealthState healthState = await().atMost(60L, TimeUnit.SECONDS).until(
+            () -> {
+                InspectContainerResponse inspectContainerResponse = dockerRule.getClient().inspectContainerCmd(container.getId()).exec();
+                return inspectContainerResponse.getState().getHealth();
+            },
+            Objects::nonNull
+        );
+
+        assertThat(healthState.getStatus(), is(equalTo("healthy")));
+    }
+
+}


### PR DESCRIPTION
See [here](https://github.com/moby/moby/commit/2216d3ca8d65c5b0c85e297a3eb351a05db3a4d2) for the change on the docker side.