### PR TITLE
Enable japicmp in docker-java-api module

### DIFF
--- a/docker-java-api/pom.xml
+++ b/docker-java-api/pom.xml
@@ -81,6 +81,10 @@
 					</instructions>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.github.siom79.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/InspectContainerResponse.java
@@ -61,10 +61,10 @@ public class InspectContainerResponse extends DockerObject {
     private String id;
 
     @JsonProperty("SizeRootFs")
-    private Long sizeRootFs;
+    private Integer sizeRootFs;
 
     @JsonProperty("SizeRw")
-    private Long sizeRw;
+    private Integer sizeRw;
 
     @JsonProperty("Image")
     private String imageId;
@@ -124,11 +124,11 @@ public class InspectContainerResponse extends DockerObject {
         return id;
     }
 
-    public Long getSizeRootFs() {
+    public Integer getSizeRootFs() {
         return sizeRootFs;
     }
 
-    public Long getSizeRw() {
+    public Integer getSizeRw() {
         return sizeRw;
     }
 

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/InspectContainerCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/InspectContainerCmdIT.java
@@ -100,9 +100,9 @@ public class InspectContainerCmdIT extends CmdIT {
         // TODO check swarm
         if (isNotSwarm(dockerRule.getClient())) {
             assertNotNull(containerInfo.getSizeRootFs());
-            assertTrue(containerInfo.getSizeRootFs().longValue() > 0L);
+            assertTrue(containerInfo.getSizeRootFs().intValue() > 0);
             assertNotNull(containerInfo.getSizeRw());
-            assertTrue(containerInfo.getSizeRw().longValue() == 0L);
+            assertTrue(containerInfo.getSizeRw().intValue() == 0);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -243,13 +243,13 @@
 					<!-- use with "mvn -DskipTests clean verify" -->
 					<groupId>com.github.siom79.japicmp</groupId>
 					<artifactId>japicmp-maven-plugin</artifactId>
-					<version>0.18.2</version>
+					<version>0.18.3</version>
 					<configuration>
 						<oldVersion>
 							<dependency>
 								<groupId>com.github.docker-java</groupId>
 								<artifactId>${project.artifactId}</artifactId>
-								<version>3.2.0</version>
+								<version>3.3.4</version>
 								<type>jar</type>
 							</dependency>
 						</oldVersion>


### PR DESCRIPTION
- Enable japicmp in docker-java-api
- Revert "Use long rather than int for sizeRw and sizeRootFs (#2230)"
