### PR TITLE
Ignore LogSwarmObjectIT#testLogsCmd

### DIFF
--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/LogSwarmObjectIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/LogSwarmObjectIT.java
@@ -12,6 +12,7 @@ import com.github.dockerjava.api.model.Task;
 import com.github.dockerjava.api.model.TaskSpec;
 import com.github.dockerjava.api.model.TaskState;
 import com.github.dockerjava.utils.LogContainerTestCallback;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -25,6 +26,8 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 
 public class LogSwarmObjectIT extends SwarmCmdIT {
+
+    @Ignore
     @Test
     public void testLogsCmd() throws InterruptedException, IOException {
         DockerClient dockerClient = startSwarm();


### PR DESCRIPTION
It was working on `20.10.25+azure-2`, `23.0.6+azure-2` and started failing with `24.0.5`