### PR TITLE
Add missing states in ServiceUpdateState

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/ServiceUpdateState.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/ServiceUpdateState.java
@@ -6,6 +6,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @since {@link RemoteApiVersion#VERSION_1_24}
  */
 public enum ServiceUpdateState {
+    @JsonProperty("unknown")
+    UNKNOWN,
+
     @JsonProperty("updating")
     UPDATING,
 
@@ -14,6 +17,12 @@ public enum ServiceUpdateState {
 
     @JsonProperty("completed")
     COMPLETED,
+
+    @JsonProperty("rollback_started")
+    ROLLBACK_STARTED,
+
+    @JsonProperty("rollback_paused")
+    ROLLBACK_PAUSED,
 
     @JsonProperty("rollback_completed")
     ROLLBACK_COMPLETED


### PR DESCRIPTION
See the full list of states here:

https://github.com/moby/swarmkit/blob/7eb504690c36ab1d9b299e7e01893fbc830729b1/api/types.proto#L458
```

	enum UpdateState {
		UNKNOWN = 0;
		UPDATING = 1;
		PAUSED = 2;
		COMPLETED = 3;
		ROLLBACK_STARTED = 4;
		ROLLBACK_PAUSED = 5; // if a rollback fails
		ROLLBACK_COMPLETED = 6;
	}
```