### PR TITLE
If BuildImage fails but logs something about success, don't succeed

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/BuildImageResultCallback.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/BuildImageResultCallback.java
@@ -67,14 +67,14 @@ public class BuildImageResultCallback extends ResultCallbackTemplate<BuildImageR
     }
 
     private String getImageId() {
+        if (error != null) {
+            throw new DockerClientException("Could not build image: " + error);
+        }
+
         if (imageId != null) {
             return imageId;
         }
 
-        if (error == null) {
-            throw new DockerClientException("Could not build image");
-        }
-
-        throw new DockerClientException("Could not build image: " + error);
+        throw new DockerClientException("Could not build image");
     }
 }


### PR DESCRIPTION
This patch ensures that if the docker build commands result in logging the string "Successfully built", the callback from that build will still fail if there was an error in building.

Fixes #2184