### PR TITLE
Add `Runtimes` to `Info` response

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Info.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Info.java
@@ -235,6 +235,9 @@ public class Info extends DockerObject implements Serializable {
     @JsonProperty("SecurityOptions")
     private List<String> securityOptions;
 
+    @JsonProperty("Runtimes")
+    private Map<String, RuntimeInfo> runtimes;
+
     /**
      * @see #architecture
      */
@@ -1069,5 +1072,12 @@ public class Info extends DockerObject implements Serializable {
 
     public List<String> getSecurityOptions() {
         return securityOptions;
+    }
+
+    /**
+     * @see #runtimes
+     */
+    public Map<String, RuntimeInfo> getRuntimes() {
+        return runtimes;
     }
 }

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/RuntimeInfo.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/RuntimeInfo.java
@@ -1,0 +1,23 @@
+package com.github.dockerjava.api.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+import java.io.Serializable;
+
+@EqualsAndHashCode
+@ToString
+public class RuntimeInfo extends DockerObject implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String path;
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+}

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/InfoCmdIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/InfoCmdIT.java
@@ -48,6 +48,7 @@ public class InfoCmdIT extends CmdIT {
         assertThat(dockerInfo.getImages(), notNullValue());
         assertThat(dockerInfo.getImages(), greaterThan(0));
         assertThat(dockerInfo.getDebug(), notNullValue());
+        assertThat(dockerInfo.getRuntimes(), notNullValue());
 
         if (isNotSwarm(dockerClient)) {
             assertThat(dockerInfo.getNFd(), greaterThan(0));


### PR DESCRIPTION
`Runtimes` definition can be found [here](https://docs.docker.com/engine/api/v1.44/#tag/System/operation/SystemInfo)