### PR TITLE
Updated Vulnerable Jackson Dependency to Latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
 		<jdk.target>1.8</jdk.target>
 
 		<jersey.version>2.30.1</jersey.version>
-		<jackson.version>2.10.3</jackson.version>
-		<jackson-jaxrs.version>2.10.3</jackson-jaxrs.version>
+		<jackson.version>2.17.1</jackson.version>
+		<jackson-jaxrs.version>2.17.1</jackson-jaxrs.version>
 		<httpclient.version>4.5.12</httpclient.version><!-- 4.5.1-4.5.2 broken -->
 		<commons-compress.version>1.21</commons-compress.version>
 		<commons-io.version>2.13.0</commons-io.version>


### PR DESCRIPTION
Updated Jackson dependency to latest, this should resolve critical CVE issues mentioned in #1974