### PR TITLE
Bump Apache commons-* dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,9 +61,9 @@
 		<jackson.version>2.10.3</jackson.version>
 		<jackson-jaxrs.version>2.10.3</jackson-jaxrs.version>
 		<httpclient.version>4.5.12</httpclient.version><!-- 4.5.1-4.5.2 broken -->
-		<commons-compress.version>1.21</commons-compress.version>
-		<commons-io.version>2.13.0</commons-io.version>
-		<commons-lang3.version>3.12.0</commons-lang3.version>
+		<commons-compress.version>1.27.1</commons-compress.version>
+		<commons-io.version>2.18.0</commons-io.version>
+		<commons-lang3.version>3.16.0</commons-lang3.version>
 		<slf4j-api.version>1.7.30</slf4j-api.version>
 
 		<bouncycastle.version>1.76</bouncycastle.version>


### PR DESCRIPTION
We're using docker-java and it would be good to bump this set of dependency versions to solve some security alerts and avoid conflicts due to dependencies that `docker-java:3.4.0` is  pulling transitively.