### PR TITLE
Add setters for security options and runtimes

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Info.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Info.java
@@ -1108,8 +1108,19 @@ public class Info extends DockerObject implements Serializable {
         return this;
     }
 
+    /**
+     * @see #securityOptions
+     */
     public List<String> getSecurityOptions() {
         return securityOptions;
+    }
+
+    /**
+     * @see #securityOptions
+     */
+    public Info withSecurityOptions(List<String> securityOptions) {
+        this.securityOptions = securityOptions;
+        return this;
     }
 
     /**
@@ -1117,5 +1128,13 @@ public class Info extends DockerObject implements Serializable {
      */
     public Map<String, RuntimeInfo> getRuntimes() {
         return runtimes;
+    }
+
+    /**
+     * @see #runtimes
+     */
+    public Info withRuntimes(Map<String, RuntimeInfo> runtimes) {
+        this.runtimes = runtimes;
+        return this;
     }
 }


### PR DESCRIPTION
We wanted to mock the info API endpoint for one of our tests, but we couldn't because we need to mock the runtimes field, which didn't have a setter.

There are two fields within this object that don't have a setter. This PR adds setters for the two fields, and moves the code from https://github.com/docker-java/docker-java/pull/2360 around such that it is now consistent across the file (every getter is directly followed by its setter).