### PR TITLE
Parse prefixed Capability values

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Capability.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Capability.java
@@ -303,9 +303,9 @@ public enum Capability {
      */
     WAKE_ALARM;
 
-    @JsonCreator()
+    @JsonCreator
     public static Capability fromValue(String cap) {
-        String result = !cap.startsWith("CAP_") ? cap : cap.substring(4);
+        String result = !cap.startsWith("CAP_") ? cap : cap.split("_", 2)[1];
         return Capability.valueOf(result);
     }
 }

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Capability.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Capability.java
@@ -1,5 +1,7 @@
 package com.github.dockerjava.api.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 /**
  * The Linux capabilities supported by Docker. The list of capabilities is defined in Docker's types.go, {@link #ALL} was added manually.
  *
@@ -299,5 +301,11 @@ public enum Capability {
     /**
      * Trigger something that will wake up the system (set CLOCK_REALTIME_ALARM and CLOCK_BOOTTIME_ALARM timers).
      */
-    WAKE_ALARM
+    WAKE_ALARM;
+
+    @JsonCreator()
+    public static Capability fromValue(String cap) {
+        String result = !cap.startsWith("CAP_") ? cap : cap.substring(4);
+        return Capability.valueOf(result);
+    }
 }

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/CapabilityTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/CapabilityTest.java
@@ -18,12 +18,9 @@ public class CapabilityTest {
     public void deserializeCapability() throws Exception {
         Capability capability = JSONTestHelper.getMapper().readValue("\"ALL\"", Capability.class);
         assertEquals(Capability.ALL, capability);
-    }
 
-    @Test
-    public void parseCapPrefix() throws Exception {
-        Capability capability = JSONTestHelper.getMapper().readValue("\"CAP_ALL\"", Capability.class);
-        assertEquals(Capability.ALL, capability);
+        Capability compatibleCapability = JSONTestHelper.getMapper().readValue("\"CAP_ALL\"", Capability.class);
+        assertEquals(Capability.ALL, compatibleCapability);
     }
 
     @Test(expected = JsonMappingException.class)

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/CapabilityTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/CapabilityTest.java
@@ -20,6 +20,12 @@ public class CapabilityTest {
         assertEquals(Capability.ALL, capability);
     }
 
+    @Test
+    public void parseCapPrefix() throws Exception {
+        Capability capability = JSONTestHelper.getMapper().readValue("\"CAP_ALL\"", Capability.class);
+        assertEquals(Capability.ALL, capability);
+    }
+
     @Test(expected = JsonMappingException.class)
     public void deserializeInvalidCapability() throws Exception {
         JSONTestHelper.getMapper().readValue("\"nonsense\"", Capability.class);


### PR DESCRIPTION
Parse "CAP_" prefixed capability values. The most recent docker version has the normalized values for CapAdd/CapDrop prefixed. This results in the inspection response json failing to parse.

https://github.com/docker-java/docker-java/issues/1980
https://github.com/docker-java/docker-java/issues/2365
