### PR TITLE
Annotations option added to hostconfig

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/HostConfig.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/HostConfig.java
@@ -73,6 +73,9 @@ public class HostConfig extends DockerObject implements Serializable {
     @JsonProperty("NanoCpus")
     private Long nanoCPUs;
 
+    @JsonProperty("Annotations")
+    private Map<String, String> annotations;
+
     @JsonProperty("CapAdd")
     private Capability[] capAdd;
 
@@ -302,6 +305,11 @@ public class HostConfig extends DockerObject implements Serializable {
 
     public Integer getBlkioWeight() {
         return blkioWeight;
+    }
+
+    @CheckForNull
+    public Map<String, String> getAnnotations() {
+        return annotations;
     }
 
     public Capability[] getCapAdd() {
@@ -633,6 +641,11 @@ public class HostConfig extends DockerObject implements Serializable {
      */
     public HostConfig withBlkioWeightDevice(List<BlkioWeightDevice> blkioWeightDevice) {
         this.blkioWeightDevice = blkioWeightDevice;
+        return this;
+    }
+
+    public HostConfig withAnnotations(Map<String, String> annotations) {
+        this.annotations = annotations;
         return this;
     }
 


### PR DESCRIPTION
Annotations opptions added to Hostconfig. 
When users choose crun rather than runc and would like to deploy wasm containers, they need to provide annotations on hostconfig.