### PR TITLE
Align Jackson dependencies using the Jackson BOM

### DIFF
--- a/docker-java-transport-jersey/pom.xml
+++ b/docker-java-transport-jersey/pom.xml
@@ -29,7 +29,6 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.jaxrs</groupId>
 			<artifactId>jackson-jaxrs-json-provider</artifactId>
-			<version>${jackson-jaxrs.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.connectors</groupId>

--- a/docker-java/pom.xml
+++ b/docker-java/pom.xml
@@ -125,16 +125,12 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<!-- Force the version to 2.18.3 to ensure the compatibility with old projects -->
-			<version>2.18.3</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<!-- Force the version to 2.18.3 to ensure the compatibility with old projects -->
-			<version>2.18.3</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,7 @@
 		<jdk.target>1.8</jdk.target>
 
 		<jersey.version>2.30.1</jersey.version>
-		<jackson.version>2.18.3</jackson.version>
-		<jackson-jaxrs.version>2.18.3</jackson-jaxrs.version>
+		<jackson.version>2.18.3</jackson.version> <!-- Force the version to 2.18.3 to ensure the compatibility with old projects -->
 		<httpclient.version>4.5.12</httpclient.version><!-- 4.5.1-4.5.2 broken -->
 		<commons-compress.version>1.27.1</commons-compress.version>
 		<commons-io.version>2.18.0</commons-io.version>
@@ -103,6 +102,18 @@
 		<module>docker-java-transport-zerodep</module>
 		<module>docker-java</module>
 	</modules>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.fasterxml.jackson</groupId>
+				<artifactId>jackson-bom</artifactId>
+				<version>${jackson.version}</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<build>
 		<pluginManagement>


### PR DESCRIPTION
Instead of specifying version explicitly for every Jackson component, as part of dependency definition, one can use a BOM to get a full, complete set of consistent versions to use.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/2446)
<!-- Reviewable:end -->
