### PR TITLE
Upgrade Jackson to 2.18.4

### DIFF
--- a/docker-java/pom.xml
+++ b/docker-java/pom.xml
@@ -125,16 +125,16 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<!-- Force the version to 2.18.3 to ensure the compatibility with old projects -->
-			<version>2.18.3</version>
+			<!-- Force the version to 2.18.4 to ensure the compatibility with old projects -->
+			<version>2.18.4</version>
 			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<!-- Force the version to 2.18.3 to ensure the compatibility with old projects -->
-			<version>2.18.3</version>
+			<!-- Force the version to 2.18.4 to ensure the compatibility with old projects -->
+			<version>2.18.4</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
 		<jdk.target>1.8</jdk.target>
 
 		<jersey.version>2.30.1</jersey.version>
-		<jackson.version>2.18.3</jackson.version>
-		<jackson-jaxrs.version>2.18.3</jackson-jaxrs.version>
+		<jackson.version>2.18.4</jackson.version>
+		<jackson-jaxrs.version>2.18.4</jackson-jaxrs.version>
 		<httpclient.version>4.5.12</httpclient.version><!-- 4.5.1-4.5.2 broken -->
 		<commons-compress.version>1.27.1</commons-compress.version>
 		<commons-io.version>2.18.0</commons-io.version>


### PR DESCRIPTION
Initially, I tried to upgrade to 2.19.0, but there [are some test failures that I am not familiar with](https://github.com/docker-java/docker-java/actions/runs/15138384051/job/42555624100?pr=2434)/the errors are not very helpful

2.18.4 is a safe, intermediate upgrade, we can use to get the vulnerability relief we need. We can upgrade to 2.19 as a follow up 

Additional Context: https://github.com/testcontainers/testcontainers-java/pull/10258