### PR TITLE
Bump jersey to 2.34

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<jdk.source>1.8</jdk.source>
 		<jdk.target>1.8</jdk.target>
 
-		<jersey.version>2.30.1</jersey.version>
+		<jersey.version>2.34</jersey.version>
 		<jackson.version>2.19.2</jackson.version>
 		<httpclient.version>4.5.12</httpclient.version><!-- 4.5.1-4.5.2 broken -->
 		<commons-compress.version>1.27.1</commons-compress.version>


### PR DESCRIPTION
This is to remediate https://nvd.nist.gov/vuln/detail/CVE-2021-28168

I hope you could review and release a new version with it promptly. Thanks!