### PR TITLE
Support propagation modes rslave, rshared and rprivate in Bind.parse

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Bind.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Bind.java
@@ -118,10 +118,16 @@ public class Bind extends DockerObject implements Serializable {
                         nocopy = true;
                     } else if (PropagationMode.SHARED.toString().equals(p)) {
                         propagationMode = PropagationMode.SHARED;
+                    } else if (PropagationMode.RSHARED.toString().equals(p)) {
+                        propagationMode = PropagationMode.RSHARED;
                     } else if (PropagationMode.SLAVE.toString().equals(p)) {
                         propagationMode = PropagationMode.SLAVE;
+                    } else if (PropagationMode.RSLAVE.toString().equals(p)) {
+                        propagationMode = PropagationMode.RSLAVE;
                     } else if (PropagationMode.PRIVATE.toString().equals(p)) {
                         propagationMode = PropagationMode.PRIVATE;
+                    } else if (PropagationMode.RPRIVATE.toString().equals(p)) {
+                        propagationMode = PropagationMode.RPRIVATE;
                     } else {
                         seMode = SELContext.fromString(p);
                     }

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/BindTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/BindTest.java
@@ -167,6 +167,17 @@ public class BindTest {
     }
 
     @Test
+    public void parseReadWriteRshared() {
+        Bind bind = Bind.parse("/host:/container:rw,rshared");
+        assertThat(bind.getPath(), is("/host"));
+        assertThat(bind.getVolume().getPath(), is("/container"));
+        assertThat(bind.getAccessMode(), is(rw));
+        assertThat(bind.getSecMode(), is(SELContext.none));
+        assertThat(bind.getNoCopy(), nullValue());
+        assertThat(bind.getPropagationMode(), is(PropagationMode.RSHARED));
+    }
+
+    @Test
     public void parseReadWriteSlave() {
         Bind bind = Bind.parse("/host:/container:rw,slave");
         assertThat(bind.getPath(), is("/host"));
@@ -178,6 +189,17 @@ public class BindTest {
     }
 
     @Test
+    public void parseReadWriteRslave() {
+        Bind bind = Bind.parse("/host:/container:rw,rslave");
+        assertThat(bind.getPath(), is("/host"));
+        assertThat(bind.getVolume().getPath(), is("/container"));
+        assertThat(bind.getAccessMode(), is(rw));
+        assertThat(bind.getSecMode(), is(SELContext.none));
+        assertThat(bind.getNoCopy(), nullValue());
+        assertThat(bind.getPropagationMode(), is(PropagationMode.RSLAVE));
+    }
+
+    @Test
     public void parseReadWritePrivate() {
         Bind bind = Bind.parse("/host:/container:rw,private");
         assertThat(bind.getPath(), is("/host"));
@@ -186,6 +208,17 @@ public class BindTest {
         assertThat(bind.getSecMode(), is(SELContext.none));
         assertThat(bind.getNoCopy(), nullValue());
         assertThat(bind.getPropagationMode(), is(PropagationMode.PRIVATE));
+    }
+
+    @Test
+    public void parseReadWriteRprivate() {
+        Bind bind = Bind.parse("/host:/container:rw,rprivate");
+        assertThat(bind.getPath(), is("/host"));
+        assertThat(bind.getVolume().getPath(), is("/container"));
+        assertThat(bind.getAccessMode(), is(rw));
+        assertThat(bind.getSecMode(), is(SELContext.none));
+        assertThat(bind.getNoCopy(), nullValue());
+        assertThat(bind.getPropagationMode(), is(PropagationMode.RPRIVATE));
     }
 
     @Test
@@ -285,13 +318,28 @@ public class BindTest {
     }
 
     @Test
+    public void toStringReadWriteRshared() {
+        assertThat(Bind.parse("/host:/container:rw,rshared").toString(), is("/host:/container:rw,rshared"));
+    }
+
+    @Test
     public void toStringReadWriteSlave() {
         assertThat(Bind.parse("/host:/container:rw,slave").toString(), is("/host:/container:rw,slave"));
     }
 
     @Test
+    public void toStringReadWriteRslave() {
+        assertThat(Bind.parse("/host:/container:rw,rslave").toString(), is("/host:/container:rw,rslave"));
+    }
+
+    @Test
     public void toStringReadWritePrivate() {
         assertThat(Bind.parse("/host:/container:rw,private").toString(), is("/host:/container:rw,private"));
+    }
+
+    @Test
+    public void toStringReadWriteRprivate() {
+        assertThat(Bind.parse("/host:/container:rw,rprivate").toString(), is("/host:/container:rw,rprivate"));
     }
 
     @Test


### PR DESCRIPTION
I added support for propagation modes rslave, rshared and rprivate in Bind.parse

See also this old issue: https://github.com/docker-java/docker-java/issues/2271