### PR TITLE
Update ExposedPort to allow for port ranges

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/ExposedPort.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/ExposedPort.java
@@ -12,7 +12,8 @@ import com.github.dockerjava.api.model.Ports.Binding;
 import lombok.EqualsAndHashCode;
 
 /**
- * Represents a container port that Docker exposes to external clients. The port is defined by its {@link #getPort() port number} and an
+ * Represents a container port that Docker exposes to external clients. The port is defined by its {@link #getPortRangeFrom() port number}
+ * or given a range {@link #getPortRangeFrom() port number from} - {@link #getPortRangeTo() port number to} and an
  * {@link InternetProtocol}. It can be published by Docker by {@link Ports#bind(ExposedPort, Binding) binding} it to a host port,
  * represented by a {@link Binding}.
  */
@@ -22,30 +23,62 @@ public class ExposedPort implements Serializable {
 
     private final InternetProtocol protocol;
 
-    private final int port;
+    private final int portRangeFrom;
+
+    private final int portRangeTo;
 
     /**
      * Creates an {@link ExposedPort} for the given parameters.
      *
      * @param port
-     *            the {@link #getPort() port number}
+     *            the {@link #getPortRangeFrom() port number}
      * @param protocol
      *            the {@link InternetProtocol}
      */
     public ExposedPort(int port, InternetProtocol protocol) {
-        this.port = port;
+        this.portRangeTo = port;
+        this.portRangeFrom = port;
         this.protocol = protocol;
     }
 
     /**
-     * Creates an {@link ExposedPort} for the given {@link #getPort() port number} and {@link InternetProtocol#DEFAULT}.
+     * Creates an {@link ExposedPort} for the given parameters.
+     *
+     * @param portRangeFrom
+     *            the {@link #getPortRangeFrom() port number}
+     * @param portRangeTo
+     *            the {@link #getPortRangeTo() port number}
+     * @param protocol
+     *            the {@link InternetProtocol}
+     */
+    public ExposedPort(int portRangeFrom, int portRangeTo, InternetProtocol protocol) {
+        this.portRangeTo = portRangeTo;
+        this.portRangeFrom = portRangeFrom;
+        this.protocol = protocol;
+    }
+
+    /**
+     * Creates an {@link ExposedPort} for the given {@link #getPortRangeFrom() port number} and {@link InternetProtocol#DEFAULT}.
      *
      * @param port
-     *            the {@link #getPort() port number}
+     *            the {@link #getPortRangeFrom() port number}
      */
     public ExposedPort(int port) {
         this(port, InternetProtocol.DEFAULT);
     }
+
+    /**
+     * Creates an {@link ExposedPort} for the given {@link #getPortRangeFrom() port number} and {@link InternetProtocol#DEFAULT}.
+     *
+     * @param portRangeFrom
+     *            the {@link #getPortRangeFrom() port number}
+     * @param portRangeTo
+     *            the {@link #getPortRangeTo() port number}
+     */
+    public ExposedPort(int portRangeFrom, int portRangeTo) {
+        this(portRangeFrom, portRangeTo, InternetProtocol.DEFAULT);
+    }
+
 
     /**
      * Creates an {@link ExposedPort} for the given parameters.
@@ -53,7 +86,7 @@ public class ExposedPort implements Serializable {
      * @param scheme
      *            the {@link #getScheme() scheme}, <code>tcp</code>, <code>udp</code> or <code>sctp</code>
      * @param port
-     *            the {@link #getPort() port number}
+     *            the {@link #getPortRangeFrom() port number}
      * @deprecated use {@link #ExposedPort(int, InternetProtocol)}
      */
     @Deprecated
@@ -62,7 +95,7 @@ public class ExposedPort implements Serializable {
     }
 
     /**
-     * @return the {@link InternetProtocol} of the {@link #getPort() port} that the container exposes
+     * @return the {@link InternetProtocol} of the {@link #getPortRangeFrom() port} that the container exposes
      */
     public InternetProtocol getProtocol() {
         return protocol;
@@ -77,9 +110,22 @@ public class ExposedPort implements Serializable {
         return protocol.toString();
     }
 
-    /** @return the port number that the container exposes */
+    /** @return the port number that the container exposes, if a range is exposed the port number from is returned.
+     *  @deprecated use {@link #getPortRangeFrom()} and {@link #getPortRangeTo()}!
+     */
+    @Deprecated
     public int getPort() {
-        return port;
+        return portRangeFrom;
+    }
+
+    /** @return the port number from that the container exposes */
+    public int getPortRangeFrom() {
+        return portRangeFrom;
+    }
+
+    /** @return the port number from that the container exposes */
+    public int getPortRangeTo() {
+        return portRangeTo;
     }
 
     /**
@@ -120,10 +166,32 @@ public class ExposedPort implements Serializable {
         try {
             String[] parts = serialized.split("/");
             switch (parts.length) {
-                case 1:
-                    return new ExposedPort(Integer.parseInt(parts[0]));
-                case 2:
-                    return new ExposedPort(Integer.parseInt(parts[0]), InternetProtocol.parse(parts[1]));
+                case 1: {
+                    String[] ports = parts[0].split("-");
+                    switch (ports.length) {
+                        case 1:
+                            return new ExposedPort(Integer.parseInt(ports[0]));
+                        case 2:
+                            return new ExposedPort(Integer.parseInt(ports[0]), Integer.parseInt(ports[1]));
+                        default:
+                            throw new IllegalArgumentException();
+                    }
+                }
+                case 2: {
+                    String[] ports = parts[0].split("-");
+                    switch (ports.length) {
+                        case 1:
+                            return new ExposedPort(Integer.parseInt(ports[0]), InternetProtocol.parse(parts[1]));
+                        case 2:
+                            return new ExposedPort(
+                                Integer.parseInt(ports[0]),
+                                Integer.parseInt(ports[1]),
+                                InternetProtocol.parse(parts[1])
+                            );
+                        default:
+                            throw new IllegalArgumentException();
+                    }
+                }
                 default:
                     throw new IllegalArgumentException();
             }
@@ -141,6 +209,10 @@ public class ExposedPort implements Serializable {
     @Override
     @JsonValue
     public String toString() {
-        return port + "/" + protocol.toString();
+        if (portRangeFrom == portRangeTo) {
+            return portRangeFrom + "/" + protocol.toString();
+        } else {
+            return portRangeFrom + "-" + portRangeTo + "/" + protocol.toString();
+        }
     }
 }

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/PortBindingTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/PortBindingTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.assertEquals;
 public class PortBindingTest {
 
     private static final ExposedPort TCP_8080 = ExposedPort.tcp(8080);
+    private static final ExposedPort TCP_8080_8081 = new ExposedPort(8080, 8081, InternetProtocol.TCP);
 
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
@@ -19,6 +20,12 @@ public class PortBindingTest {
     public void fullDefinition() {
         assertEquals(PortBinding.parse("127.0.0.1:80:8080/tcp"),
                 new PortBinding(Binding.bindIpAndPort("127.0.0.1", 80), TCP_8080));
+    }
+
+    @Test
+    public void portRange() {
+        assertEquals(PortBinding.parse("127.0.0.1:80-81:8080-8081/tcp"),
+            new PortBinding(Binding.bindIpAndPortRange("127.0.0.1", 80, 81), TCP_8080_8081));
     }
 
     @Test


### PR DESCRIPTION
The following Dockerfile is currently not mappable by ExposedPort:
```
FROM busybox

EXPOSE 8000-8080

CMD ["/bin/sh", "-c", "while true; do sleep 1; done"]
```
as the ranges can not be represented. Port ranges can only be continuous, therefore _portRangeFrom_ and _portRangeTo_ parameters were introduced to express such ranges.
Single exposed ports are represented by _portRangeFrom_ = _portRangeTo_.

To be backwards compatibale the old _getPort()_ getter returns the first port of the range.
This should in all old use cases always return the same port as before. The getter was set to deprecated as user should use the new _getPortRangeFrom()_ and _getPortRangeTo()_.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/docker-java/docker-java/2618)
<!-- Reviewable:end -->
