### PR TITLE
Fix Bind.parse for Windows drive paths written with forward slashes

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/Bind.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/Bind.java
@@ -99,8 +99,9 @@ public class Bind extends DockerObject implements Serializable {
      */
     public static Bind parse(String serialized) {
         try {
-            // Split by ':' but not ':\' (Windows-style path)
-            String[] parts = serialized.split(":(?!\\\\)");
+            // Split by ':' but not the ':' that follows a Windows drive letter,
+            // whether written with a backslash (C:\host) or a forward slash (C:/host).
+            String[] parts = serialized.split(":(?!\\\\)(?<!^[A-Za-z]:)");
             switch (parts.length) {
             case 2: {
                 return new Bind(parts[0], new Volume(parts[1]));

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/BindTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/BindTest.java
@@ -38,6 +38,39 @@ public class BindTest {
     }
 
     @Test
+    public void parseUsingDefaultAccessModeForwardSlashWindows() {
+        Bind bind = Bind.parse("C:/host:/container");
+        assertThat(bind.getPath(), is("C:/host"));
+        assertThat(bind.getVolume().getPath(), is("/container"));
+        assertThat(bind.getAccessMode(), is(AccessMode.DEFAULT));
+        assertThat(bind.getSecMode(), is(SELContext.none));
+        assertThat(bind.getNoCopy(), nullValue());
+        assertThat(bind.getPropagationMode(), is(PropagationMode.DEFAULT_MODE));
+    }
+
+    @Test
+    public void parseReadWriteForwardSlashWindows() {
+        Bind bind = Bind.parse("C:/host:/container:rw");
+        assertThat(bind.getPath(), is("C:/host"));
+        assertThat(bind.getVolume().getPath(), is("/container"));
+        assertThat(bind.getAccessMode(), is(rw));
+        assertThat(bind.getSecMode(), is(SELContext.none));
+        assertThat(bind.getNoCopy(), nullValue());
+        assertThat(bind.getPropagationMode(), is(PropagationMode.DEFAULT_MODE));
+    }
+
+    @Test
+    public void parseReadOnlySELForwardSlashWindows() {
+        Bind bind = Bind.parse("c:/host:/container:ro,z");
+        assertThat(bind.getPath(), is("c:/host"));
+        assertThat(bind.getVolume().getPath(), is("/container"));
+        assertThat(bind.getAccessMode(), is(ro));
+        assertThat(bind.getSecMode(), is(SELContext.shared));
+        assertThat(bind.getNoCopy(), nullValue());
+        assertThat(bind.getPropagationMode(), is(PropagationMode.DEFAULT_MODE));
+    }
+
+    @Test
     public void parseReadWriteNoCopyWindows() {
         Bind bind = Bind.parse("C:\\host:/container:rw,nocopy");
         assertThat(bind.getPath(), is("C:\\host"));


### PR DESCRIPTION
### Problem

`Bind.parse` splits the spec on `:` unless the colon is followed by a backslash, which handles Windows paths written as `C:\host:/container`. But a Windows drive path written with **forward slashes** (`C:/host:/container`) has a drive-letter colon that isn't followed by a backslash, so it gets treated as a separator:

```
Bind.parse("C:/host:/container:rw")
  split ":(?!\\)"  ->  ["C", "/host", "/container", "rw"]   // 4 parts -> IllegalArgumentException
```

Docker itself accepts drive paths with either slash direction, so `C:/...` binds should parse the same as `C:\...`.

### Fix

Add a negative lookbehind so a leading `<letter>:` is not treated as a separator:

```
":(?!\\)"  ->  ":(?!\\)(?<!^[A-Za-z]:)"
```

```
Bind.parse("C:/host:/container:rw")  ->  ["C:/host", "/container", "rw"]   // path=C:/host, volume=/container, rw
```

Existing backslash paths are unaffected (their drive colon is still skipped by the `(?!\\)` lookahead).

### Tests

Added three cases to `BindTest` for forward-slash drive paths (default / `rw` / `ro,z`). Full `BindTest` (41 tests) passes and the reactor build is green.

### Note

One intentional behavior change: a bare `a:b` (single-letter relative host path) now parses as a drive prefix and is rejected, matching how Docker treats a leading `<letter>:`. Happy to adjust the scope if you'd prefer it narrower.

---
This was written with AI assistance (Claude); I've reviewed the change and tested it locally.
