### PR TITLE
Allow SaveImagesCmd to omit image tags

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/SaveImagesCmd.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/SaveImagesCmd.java
@@ -2,6 +2,7 @@ package com.github.dockerjava.api.command;
 
 import com.github.dockerjava.api.exception.NotFoundException;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.InputStream;
 import java.util.List;
@@ -22,10 +23,10 @@ public interface SaveImagesCmd extends SyncDockerCmd<InputStream> {
     /**
      * Adds an image to the list of images to download.
      * @param name image name (not null)
-     * @param tag tag
+     * @param tag tag (optional; when {@code null}, only the image name is used)
      * @return this
      */
-    SaveImagesCmd withImage(@Nonnull String name, @Nonnull String tag);
+    SaveImagesCmd withImage(@Nonnull String name, @CheckForNull String tag);
 
 
     /**

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/SaveImagesCmdImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/SaveImagesCmdImpl.java
@@ -4,6 +4,7 @@ import com.github.dockerjava.api.command.SaveImagesCmd;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.google.common.collect.ImmutableList;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.InputStream;
 import java.util.List;
@@ -17,11 +18,14 @@ public class SaveImagesCmdImpl extends AbstrDockerCmd<SaveImagesCmd, InputStream
 
         private TaggedImageImpl(String name, String tag) {
             this.name = Objects.requireNonNull(name, "image name was not specified");
-            this.tag = Objects.requireNonNull(tag, "image tag was not specified");
+            this.tag = tag;
         }
 
         @Override
         public String asString() {
+            if (tag == null) {
+                return name;
+            }
             return name + ":" + tag;
         }
 
@@ -38,7 +42,7 @@ public class SaveImagesCmdImpl extends AbstrDockerCmd<SaveImagesCmd, InputStream
     }
 
     @Override
-    public SaveImagesCmd withImage(@Nonnull final String name, @Nonnull final String tag) {
+    public SaveImagesCmd withImage(@Nonnull final String name, @CheckForNull final String tag) {
         taggedImages.add(new TaggedImageImpl(name, tag));
         return this;
     }

--- a/docker-java/src/test/java/com/github/dockerjava/core/command/SaveImagesCmdImplTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/command/SaveImagesCmdImplTest.java
@@ -1,0 +1,37 @@
+package com.github.dockerjava.core.command;
+
+import com.github.dockerjava.api.command.SaveImagesCmd;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SaveImagesCmdImplTest {
+
+    private static final SaveImagesCmd.Exec NOOP_EXEC = new SaveImagesCmd.Exec() {
+        @Override
+        public InputStream exec(SaveImagesCmd command) {
+            return null;
+        }
+    };
+
+    @Test
+    public void withImageNullTagProducesNameOnly() {
+        SaveImagesCmd cmd = new SaveImagesCmdImpl(NOOP_EXEC).withImage("busybox", null);
+
+        List<SaveImagesCmd.TaggedImage> images = cmd.getImages();
+        assertEquals(1, images.size());
+        assertEquals("busybox", images.get(0).asString());
+    }
+
+    @Test
+    public void withImageTaggedFormRemainsNameColonTag() {
+        SaveImagesCmd cmd = new SaveImagesCmdImpl(NOOP_EXEC).withImage("busybox", "latest");
+
+        List<SaveImagesCmd.TaggedImage> images = cmd.getImages();
+        assertEquals(1, images.size());
+        assertEquals("busybox:latest", images.get(0).asString());
+    }
+}


### PR DESCRIPTION
Fixes #1872

## What was wrong

`SaveImagesCmd` documents that an image can be saved without an explicit tag, but `withImage(name, tag)` rejected a null tag and always formatted images as `name:tag`. That made the documented name-only form unusable.

## What changed

The tag argument is now nullable. `TaggedImage.asString()` returns the image name alone when no tag is supplied and keeps the existing `name:tag` form for tagged images. A small unit test covers both forms without requiring a Docker daemon.

## Testing

- `mvn -pl docker-java -Dtest=SaveImagesCmdImplTest test`
- `mvn -pl docker-java -Dtest='!OkHttpClientTests' test` — 366 tests, 0 failures, 2 skipped
- `mvn -pl docker-java -am checkstyle:check`
- `git diff --check`

The full reactor test command reaches Docker-dependent transport tests, but no Docker daemon is available in this environment, so that part could not run.
