### PR TITLE
Expose inspectSwarmNodeCmd through DockerClient

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/DockerClient.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/DockerClient.java
@@ -31,6 +31,7 @@ import com.github.dockerjava.api.command.ImageHistoryCmd;
 import com.github.dockerjava.api.command.InspectNetworkCmd;
 import com.github.dockerjava.api.command.InspectServiceCmd;
 import com.github.dockerjava.api.command.InspectSwarmCmd;
+import com.github.dockerjava.api.command.InspectSwarmNodeCmd;
 import com.github.dockerjava.api.command.InspectVolumeCmd;
 import com.github.dockerjava.api.command.JoinSwarmCmd;
 import com.github.dockerjava.api.command.KillContainerCmd;
@@ -358,6 +359,15 @@ public interface DockerClient extends Closeable {
      * @since 1.24
      */
     UpdateSwarmNodeCmd updateSwarmNodeCmd();
+
+    /**
+     * Inspect the swarm node
+     *
+     * @param swarmNodeId swarmNodeId
+     * @return the command
+     * @since 1.24
+     */
+    InspectSwarmNodeCmd inspectSwarmNodeCmd(String swarmNodeId);
 
     /**
      * Remove the swarm node

--- a/docker-java-api/src/main/java/com/github/dockerjava/api/DockerClientDelegate.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/DockerClientDelegate.java
@@ -31,6 +31,7 @@ import com.github.dockerjava.api.command.ImageHistoryCmd;
 import com.github.dockerjava.api.command.InspectNetworkCmd;
 import com.github.dockerjava.api.command.InspectServiceCmd;
 import com.github.dockerjava.api.command.InspectSwarmCmd;
+import com.github.dockerjava.api.command.InspectSwarmNodeCmd;
 import com.github.dockerjava.api.command.InspectVolumeCmd;
 import com.github.dockerjava.api.command.JoinSwarmCmd;
 import com.github.dockerjava.api.command.KillContainerCmd;
@@ -440,6 +441,11 @@ public class DockerClientDelegate implements DockerClient {
     @Override
     public UpdateSwarmNodeCmd updateSwarmNodeCmd() {
         return getDockerClient().updateSwarmNodeCmd();
+    }
+
+    @Override
+    public InspectSwarmNodeCmd inspectSwarmNodeCmd(String swarmNodeId) {
+        return getDockerClient().inspectSwarmNodeCmd(swarmNodeId);
     }
 
     @Override

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/DockerClientImpl.java
@@ -33,6 +33,7 @@ import com.github.dockerjava.api.command.ImageHistoryCmd;
 import com.github.dockerjava.api.command.InspectNetworkCmd;
 import com.github.dockerjava.api.command.InspectServiceCmd;
 import com.github.dockerjava.api.command.InspectSwarmCmd;
+import com.github.dockerjava.api.command.InspectSwarmNodeCmd;
 import com.github.dockerjava.api.command.InspectVolumeCmd;
 import com.github.dockerjava.api.command.JoinSwarmCmd;
 import com.github.dockerjava.api.command.KillContainerCmd;
@@ -119,6 +120,7 @@ import com.github.dockerjava.core.command.InspectImageCmdImpl;
 import com.github.dockerjava.core.command.ImageHistoryCmdImpl;
 import com.github.dockerjava.core.command.InspectServiceCmdImpl;
 import com.github.dockerjava.core.command.InspectSwarmCmdImpl;
+import com.github.dockerjava.core.command.InspectSwarmNodeCmdImpl;
 import com.github.dockerjava.core.command.InspectVolumeCmdImpl;
 import com.github.dockerjava.core.command.JoinSwarmCmdImpl;
 import com.github.dockerjava.core.command.KillContainerCmdImpl;
@@ -635,6 +637,11 @@ public class DockerClientImpl implements Closeable, DockerClient {
     @Override
     public UpdateSwarmNodeCmd updateSwarmNodeCmd() {
         return new UpdateSwarmNodeCmdImpl(getDockerCmdExecFactory().updateSwarmNodeCmdExec());
+    }
+
+    @Override
+    public InspectSwarmNodeCmd inspectSwarmNodeCmd(String swarmNodeId) {
+        return new InspectSwarmNodeCmdImpl(getDockerCmdExecFactory().inspectSwarmNodeCmdExec(), swarmNodeId);
     }
 
     @Override

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/InspectSwarmNodeCmdExecIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/InspectSwarmNodeCmdExecIT.java
@@ -1,0 +1,26 @@
+package com.github.dockerjava.cmd.swarm;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.SwarmNode;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class InspectSwarmNodeCmdExecIT extends SwarmCmdIT {
+
+    @Test
+    public void testInspectSwarmNode() {
+        DockerClient dockerClient = startSwarm();
+
+        List<SwarmNode> nodes = dockerClient.listSwarmNodesCmd().exec();
+        assertThat(nodes.size(), is(1));
+
+        String nodeId = nodes.get(0).getId();
+        SwarmNode node = dockerClient.inspectSwarmNodeCmd(nodeId).exec();
+
+        assertThat(node.getId(), is(nodeId));
+    }
+}


### PR DESCRIPTION
## Summary

- expose the existing `InspectSwarmNodeCmd` through `DockerClient`
- delegate the new client method and wire it to the existing command implementation and executor
- add swarm integration coverage that inspects a node by ID

## Root cause

The command interface, implementation, and executor already existed, but `DockerClient` and `DockerClientDelegate` did not expose a factory method. Consumers therefore could not invoke the command through the public client API.

## Impact

Consumers can now call `dockerClient.inspectSwarmNodeCmd(nodeId).exec()` consistently with the existing list, update, and remove swarm-node commands.

## Verification

- `mvn -pl docker-java-api,docker-java-core -am test -DskipITs -Dmaven.javadoc.skip=true`
- `mvn -pl docker-java -am test-compile -DskipITs -Dmaven.javadoc.skip=true`
- `git diff --check`
- Full `mvn clean install -DskipITs` passed through the API, core, transport TCK, Netty, and Jersey modules; it stopped in the existing OkHttp Docker-dependent TCK because no local Docker daemon was available.

Fixes #2373
