### PR TITLE
Fix RestartPolicy.noRestart() so it can disable restart on existing containers

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/model/RestartPolicy.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/model/RestartPolicy.java
@@ -51,7 +51,7 @@ public class RestartPolicy extends DockerObject implements Serializable {
      * Do not restart the container if it dies. (default)
      */
     public static RestartPolicy noRestart() {
-        return new RestartPolicy();
+        return new RestartPolicy(0, "no");
     }
 
     /**

--- a/docker-java/src/test/java/com/github/dockerjava/api/model/RestartPolicySerializingTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/api/model/RestartPolicySerializingTest.java
@@ -15,7 +15,7 @@ public class RestartPolicySerializingTest {
     // --restart no
     public void noRestart() throws Exception {
         String json = JSONTestHelper.getMapper().writeValueAsString(RestartPolicy.noRestart());
-        assertEquals("{\"MaximumRetryCount\":0,\"Name\":\"\"}", json);
+        assertEquals("{\"MaximumRetryCount\":0,\"Name\":\"no\"}", json);
     }
 
     @Test


### PR DESCRIPTION

noRestart() returned a policy with an empty Name (""), which the Docker Engine update endpoint ignores: it only applies RestartPolicy when Name != "". As a result an existing container could not be switched from always/on-failure back to no-restart via updateContainerCmd.

Return Name "no" instead - a valid "none" policy (RestartPolicy.IsNone() is true for both "" and "no") that the daemon actually applies. Update RestartPolicySerializingTest to match; this also matches what modern Docker sends for `docker run --restart no`.