### PR TITLE
Add registry authentication to service updates

### DIFF
--- a/docker-java-api/src/main/java/com/github/dockerjava/api/command/UpdateServiceCmd.java
+++ b/docker-java-api/src/main/java/com/github/dockerjava/api/command/UpdateServiceCmd.java
@@ -1,5 +1,6 @@
 package com.github.dockerjava.api.command;
 
+import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.ServiceSpec;
 
 import javax.annotation.CheckForNull;
@@ -18,6 +19,12 @@ public interface UpdateServiceCmd extends SyncDockerCmd<Void> {
     ServiceSpec getServiceSpec();
 
     UpdateServiceCmd withServiceSpec(ServiceSpec serviceSpec);
+
+    @CheckForNull
+    AuthConfig getAuthConfig();
+
+    @Nonnull
+    UpdateServiceCmd withAuthConfig(@Nonnull AuthConfig authConfig);
 
     @CheckForNull
     Long getVersion();

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/command/UpdateServiceCmdImpl.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/command/UpdateServiceCmdImpl.java
@@ -2,6 +2,7 @@ package com.github.dockerjava.core.command;
 
 import com.github.dockerjava.api.command.UpdateServiceCmd;
 import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.ServiceSpec;
 import com.github.dockerjava.core.RemoteApiVersion;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -11,6 +12,7 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import java.util.Objects;
 
 /**
  * @since {@link RemoteApiVersion#VERSION_1_24}
@@ -27,6 +29,13 @@ public class UpdateServiceCmdImpl extends AbstrDockerCmd<UpdateServiceCmd, Void>
      * @since 1.24
      */
     private ServiceSpec serviceSpec;
+
+    /**
+     * Registry authentication sent with the service update request.
+     *
+     * @since {@link RemoteApiVersion#VERSION_1_24}
+     */
+    private AuthConfig authConfig;
 
     /**
      * @since 1.24
@@ -68,6 +77,25 @@ public class UpdateServiceCmdImpl extends AbstrDockerCmd<UpdateServiceCmd, Void>
      */
     public UpdateServiceCmd withServiceSpec(ServiceSpec serviceSpec) {
         this.serviceSpec = serviceSpec;
+        return this;
+    }
+
+    /**
+     * @see #authConfig
+     */
+    @Override
+    @CheckForNull
+    public AuthConfig getAuthConfig() {
+        return authConfig;
+    }
+
+    /**
+     * @see #authConfig
+     */
+    @Override
+    @Nonnull
+    public UpdateServiceCmd withAuthConfig(@Nonnull AuthConfig authConfig) {
+        this.authConfig = Objects.requireNonNull(authConfig, "authConfig was not specified");
         return this;
     }
 

--- a/docker-java-core/src/main/java/com/github/dockerjava/core/exec/UpdateServiceCmdExec.java
+++ b/docker-java-core/src/main/java/com/github/dockerjava/core/exec/UpdateServiceCmdExec.java
@@ -2,6 +2,7 @@ package com.github.dockerjava.core.exec;
 
 import com.github.dockerjava.api.command.UpdateServiceCmd;
 import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.core.InvocationBuilder;
 import com.github.dockerjava.core.MediaType;
 import com.github.dockerjava.core.WebTarget;
 import org.slf4j.Logger;
@@ -27,8 +28,10 @@ public class UpdateServiceCmdExec extends AbstrSyncDockerCmdExec<UpdateServiceCm
                 .queryParam("version", command.getVersion());
 
         LOGGER.trace("POST: {}", webResource);
+        InvocationBuilder builder = resourceWithOptionalAuthConfig(command.getAuthConfig(), webResource.request())
+                .accept(MediaType.APPLICATION_JSON);
         try {
-            webResource.request().accept(MediaType.APPLICATION_JSON).post(command.getServiceSpec()).close();
+            builder.post(command.getServiceSpec()).close();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/UpdateSwarmServiceIT.java
+++ b/docker-java/src/test/java/com/github/dockerjava/cmd/swarm/UpdateSwarmServiceIT.java
@@ -8,16 +8,23 @@ import com.github.dockerjava.api.model.Service;
 import com.github.dockerjava.api.model.ServiceModeConfig;
 import com.github.dockerjava.api.model.ServiceReplicatedModeOptions;
 import com.github.dockerjava.api.model.ServiceSpec;
+import com.github.dockerjava.api.model.Task;
 import com.github.dockerjava.api.model.TaskSpec;
+import com.github.dockerjava.api.model.TaskState;
+import com.github.dockerjava.junit.PrivateRegistryRule;
 import com.google.common.collect.Lists;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import static com.github.dockerjava.core.DockerRule.DEFAULT_IMAGE;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 
 public class UpdateSwarmServiceIT extends SwarmCmdIT {
     @Test
@@ -45,5 +52,46 @@ public class UpdateSwarmServiceIT extends SwarmCmdIT {
             Service updateService = dockerClient.listServicesCmd().withIdFilter(Arrays.asList(serviceId)).exec().get(0);
             assertThat(updateService.getSpec().getMode().getReplicated().getReplicas(), is(2L));
         });
+    }
+
+    @Test
+    public void testUpdateServiceWithRegistryAuth() throws InterruptedException {
+        DockerClient dockerClient = startSwarm();
+        ServiceSpec serviceSpec = new ServiceSpec()
+                .withName("authenticated-worker")
+                .withMode(new ServiceModeConfig().withReplicated(new ServiceReplicatedModeOptions().withReplicas(1)))
+                .withTaskTemplate(new TaskSpec().withContainerSpec(
+                        new ContainerSpec().withImage(DEFAULT_IMAGE).withArgs(Arrays.asList("sleep", "3600"))));
+        String serviceId = dockerClient.createServiceCmd(serviceSpec).exec().getId();
+
+        await().atMost(60, TimeUnit.SECONDS).untilAsserted(() -> {
+            List<Task> tasks = dockerClient.listTasksCmd()
+                    .withServiceFilter(serviceId)
+                    .withStateFilter(TaskState.RUNNING)
+                    .exec();
+            assertThat(tasks, hasSize(1));
+        });
+
+        try (PrivateRegistryRule registry = new PrivateRegistryRule(dockerClient)) {
+            registry.start();
+            String privateImage = registry.createPrivateImage("update-service");
+            Service service = dockerClient.inspectServiceCmd(serviceId).exec();
+            ServiceSpec updatedServiceSpec = service.getSpec();
+            updatedServiceSpec.getTaskTemplate().getContainerSpec().withImage(privateImage);
+
+            dockerClient.updateServiceCmd(serviceId, updatedServiceSpec)
+                    .withVersion(service.getVersion().getIndex())
+                    .withAuthConfig(registry.getAuthConfig())
+                    .exec();
+
+            await().atMost(60, TimeUnit.SECONDS).untilAsserted(() -> {
+                List<Task> tasks = dockerClient.listTasksCmd()
+                        .withServiceFilter(serviceId)
+                        .withStateFilter(TaskState.RUNNING)
+                        .exec();
+                assertThat(tasks, hasSize(1));
+                assertThat(tasks.get(0).getSpec().getContainerSpec().getImage(), startsWith(privateImage));
+            });
+        }
     }
 }

--- a/docker-java/src/test/java/com/github/dockerjava/core/exec/UpdateServiceCmdExecTest.java
+++ b/docker-java/src/test/java/com/github/dockerjava/core/exec/UpdateServiceCmdExecTest.java
@@ -1,0 +1,105 @@
+package com.github.dockerjava.core.exec;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.AuthConfig;
+import com.github.dockerjava.api.model.ServiceSpec;
+import com.github.dockerjava.core.DefaultDockerClientConfig;
+import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.core.DockerClientImpl;
+import com.github.dockerjava.transport.DockerHttpClient;
+import com.google.common.io.BaseEncoding;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class UpdateServiceCmdExecTest {
+
+    private static final String REGISTRY_AUTH_HEADER = "X-Registry-Auth";
+
+    @Test
+    public void sendsRegistryAuthHeader() throws Exception {
+        AtomicReference<DockerHttpClient.Request> request = new AtomicReference<>();
+        DockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder().build();
+        DockerClient dockerClient = DockerClientImpl.getInstance(config, new CapturingDockerHttpClient(request));
+        AuthConfig authConfig = new AuthConfig()
+                .withUsername("user")
+                .withPassword("password")
+                .withRegistryAddress("registry.example.com");
+
+        dockerClient.updateServiceCmd("service-id", new ServiceSpec())
+                .withVersion(1L)
+                .withAuthConfig(authConfig)
+                .exec();
+
+        String encodedAuth = request.get().headers().get(REGISTRY_AUTH_HEADER);
+        assertThat(encodedAuth, notNullValue());
+        byte[] decodedAuth = BaseEncoding.base64Url().decode(encodedAuth);
+        AuthConfig sentAuth = config.getObjectMapper().readValue(decodedAuth, AuthConfig.class);
+        assertThat(sentAuth, is(authConfig));
+    }
+
+    @Test
+    public void omitsRegistryAuthHeaderWhenNotConfigured() {
+        AtomicReference<DockerHttpClient.Request> request = new AtomicReference<>();
+        DockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder().build();
+        DockerClient dockerClient = DockerClientImpl.getInstance(config, new CapturingDockerHttpClient(request));
+
+        dockerClient.updateServiceCmd("service-id", new ServiceSpec())
+                .withVersion(1L)
+                .exec();
+
+        assertThat(request.get().headers().get(REGISTRY_AUTH_HEADER), nullValue());
+    }
+
+    private static class CapturingDockerHttpClient implements DockerHttpClient {
+
+        private final AtomicReference<Request> request;
+
+        CapturingDockerHttpClient(AtomicReference<Request> request) {
+            this.request = request;
+        }
+
+        @Override
+        public Response execute(Request request) {
+            this.request.set(request);
+            return new EmptyResponse();
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+    }
+
+    private static class EmptyResponse implements DockerHttpClient.Response {
+
+        @Override
+        public int getStatusCode() {
+            return 200;
+        }
+
+        @Override
+        public Map<String, List<String>> getHeaders() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public InputStream getBody() {
+            return new ByteArrayInputStream(new byte[0]);
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/docker-java/src/test/java/com/github/dockerjava/junit/PrivateRegistryRule.java
+++ b/docker-java/src/test/java/com/github/dockerjava/junit/PrivateRegistryRule.java
@@ -12,6 +12,7 @@ import com.github.dockerjava.core.DockerRule;
 import org.junit.rules.ExternalResource;
 
 import java.io.File;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import static com.github.dockerjava.api.model.HostConfig.newHostConfig;
@@ -20,7 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
-public class PrivateRegistryRule extends ExternalResource {
+public class PrivateRegistryRule extends ExternalResource implements AutoCloseable {
 
     private final DockerClient dockerClient;
 
@@ -29,7 +30,11 @@ public class PrivateRegistryRule extends ExternalResource {
     private String containerId;
 
     public PrivateRegistryRule() {
-        this.dockerClient = CmdIT.createDockerClient(DockerRule.config(null));
+        this(CmdIT.createDockerClient(DockerRule.config(null)));
+    }
+
+    public PrivateRegistryRule(DockerClient dockerClient) {
+        this.dockerClient = Objects.requireNonNull(dockerClient);
     }
 
     public AuthConfig getAuthConfig() {
@@ -59,12 +64,20 @@ public class PrivateRegistryRule extends ExternalResource {
         return imgName + ":" + tagName;
     }
 
+    public void start() throws InterruptedException {
+        startRegistry();
+    }
+
     /**
      * Starts a local test registry when it is not already started and returns the auth configuration for it
      * This method is synchronized so that only the first invocation starts the registry
      */
     @Override
-    protected void before() throws Throwable {
+    protected void before() throws InterruptedException {
+        startRegistry();
+    }
+
+    private void startRegistry() throws InterruptedException {
 
         int port = 5050;
 
@@ -115,5 +128,10 @@ public class PrivateRegistryRule extends ExternalResource {
                     .withRemoveVolumes(true)
                     .exec();
         }
+    }
+
+    @Override
+    public void close() {
+        after();
     }
 }


### PR DESCRIPTION
## Summary

Adds registry authentication support to UpdateServiceCmd, bringing service updates in line with the authentication support already available when creating services.

## Problem

A service update can change its container image. When the new image is hosted in a private registry, Docker requires registry credentials in the X-Registry-Auth request header. UpdateServiceCmd did not expose an AuthConfig option, so callers could not provide those credentials and Swarm could not pull the private image during an update.

## Implementation

- add optional AuthConfig accessors to UpdateServiceCmd
- store the authentication configuration in UpdateServiceCmdImpl with the project null-safety annotations and builder conventions
- apply the existing resourceWithOptionalAuthConfig helper before executing the service-update request
- extend PrivateRegistryRule so an integration test can run the registry in the same Docker daemon as the Swarm worker

Running the registry in the Swarm Docker-in-Docker daemon is important because localhost:5050 must resolve to the registry from the worker performing the image pull.

## Compatibility

- existing callers do not need to provide authentication
- no X-Registry-Auth header is sent when AuthConfig is absent
- the existing service-update request body, version parameter, and response handling remain unchanged
- the feature uses the existing AuthConfig model and the existing authentication-header serialization path

## Verification

- mvn -pl docker-java -am -Dtest=UpdateServiceCmdExecTest -Dsurefire.failIfNoSpecifiedTests=false test — 2 tests passed
- mvn -pl docker-java -am -DskipTests test-compile — Java 8 test compilation and checkstyle passed
- mvn -f docker-java/pom.xml -Dit.test=UpdateSwarmServiceIT#testUpdateServiceWithRegistryAuth org.apache.maven.plugins:maven-failsafe-plugin:3.0.0-M4:integration-test — 1 test passed
- git diff --check — passed

The executor tests verify both the serialized authentication header and its omission when authentication is not configured.

The integration test starts a service with a public image, pushes that image to an authenticated local registry, removes the local private-image tag, and then updates the service with AuthConfig. It waits until the replacement Swarm task is running the private image, ensuring the update really authenticated and pulled from the registry.
